### PR TITLE
Trailblazer 2.1.rc13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'jwt', '~> 2.0'
 gem 'active_model_serializers', '~> 0.10.0'
 
 gem 'trailblazer', '~> 2.1.0.rc13'
-#gem 'trailblazer-rails'
 gem 'reform-rails'
 gem 'dry-validation', '~> 0.11.1'
 

--- a/Gemfile
+++ b/Gemfile
@@ -29,8 +29,8 @@ gem 'jwtf', '~> 0.1'
 gem 'jwt', '~> 2.0'
 gem 'active_model_serializers', '~> 0.10.0'
 
-gem 'trailblazer', '~> 2.1.0.rc1'
-gem 'trailblazer-rails'
+gem 'trailblazer', '~> 2.1.0.rc13'
+#gem 'trailblazer-rails'
 gem 'reform-rails'
 gem 'dry-validation', '~> 0.11.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,6 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    hirb (0.7.3)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     inflecto (0.0.2)
@@ -290,26 +289,22 @@ GEM
       sprockets (>= 3.0.0)
     thor (0.20.3)
     thread_safe (0.3.6)
-    trailblazer (2.1.0.rc1)
-      declarative
-      trailblazer-macro (>= 2.1.0.rc1, < 2.2.0)
-      trailblazer-macro-contract (= 2.1.0.rc1)
+    trailblazer (2.1.0.rc13)
+      trailblazer-macro (>= 2.1.0.rc12, < 2.2.0)
+      trailblazer-macro-contract (>= 2.1.0.rc12, < 2.2.0)
       trailblazer-operation
-    trailblazer-activity (0.7.1)
-      hirb
-      trailblazer-context
-    trailblazer-context (0.1.2)
-    trailblazer-loader (0.1.2)
-    trailblazer-macro (2.1.0.rc1)
-    trailblazer-macro-contract (2.1.0.rc1)
+    trailblazer-activity (0.8.3)
+      trailblazer-context (>= 0.1.4)
+    trailblazer-activity-dsl-linear (0.1.7)
+      trailblazer-activity (>= 0.8.3, < 1.0.0)
+    trailblazer-context (0.1.4)
+    trailblazer-macro (2.1.0.rc13)
+      trailblazer-activity-dsl-linear (>= 0.1.6, < 0.2.0)
+      trailblazer-operation (>= 0.5.2)
+    trailblazer-macro-contract (2.1.0.rc13)
       reform (>= 2.2.0, < 3.0.0)
-    trailblazer-operation (0.4.1)
-      trailblazer-activity (>= 0.7.1, < 0.8.0)
-      trailblazer-context (>= 0.1.1, < 0.3.0)
-    trailblazer-rails (2.1.6)
-      railties (>= 4.0.0)
-      trailblazer (>= 2.1.0.beta1, < 2.2.0)
-      trailblazer-loader (>= 0.1.0)
+    trailblazer-operation (0.5.2)
+      trailblazer-activity-dsl-linear (>= 0.1.6, < 1.0.0)
     tty-color (0.4.3)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -355,8 +350,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
-  trailblazer (~> 2.1.0.rc1)
-  trailblazer-rails
+  trailblazer (~> 2.1.0.rc13)
   tzinfo-data
   unindent
 

--- a/app/concepts/incident/operation/create.rb
+++ b/app/concepts/incident/operation/create.rb
@@ -1,7 +1,7 @@
 class Incident
   module Operation
     class Create < Trailblazer::Operation
-      step Nested(Incident::Operation::Save)
+      step Subprocess(Incident::Operation::Save)
     end
   end
 end

--- a/app/concepts/incident/operation/save.rb
+++ b/app/concepts/incident/operation/save.rb
@@ -1,10 +1,8 @@
-class Incident
-  module Operation
-    class Save < Trailblazer::Operation
-      success ->(options, model: nil, **) { options[:model] = Incident.new if model.nil? }
-      step self::Contract::Build(constant: Incident::Contract::Save)
-      step self::Contract::Validate()
-      step self::Contract::Persist()
-    end
+module Incident::Operation
+  class Save < Trailblazer::Operation
+    pass ->(options, model: nil, **) { options[:model] = Incident.new if model.nil? }
+    step self::Contract::Build(constant: Incident::Contract::Save)
+    step self::Contract::Validate()
+    step self::Contract::Persist()
   end
 end

--- a/app/concepts/incident/operation/update.rb
+++ b/app/concepts/incident/operation/update.rb
@@ -3,7 +3,7 @@ class Incident
     class Update < Trailblazer::Operation
       step Model(Incident, :find_by)
       fail ->(options, params:, **) { options[:errors] = "Incident with id `#{params[:id]}` does not exist." }
-      step Nested(Incident::Operation::Save)
+      step Subprocess(Incident::Operation::Save)
     end
   end
 end

--- a/app/concepts/jwt_api_entreprise/operation/admin_create.rb
+++ b/app/concepts/jwt_api_entreprise/operation/admin_create.rb
@@ -1,8 +1,8 @@
-class JwtApiEntreprise
+module JwtApiEntreprise::Operation
   class AdminCreate < Trailblazer::Operation
     step self::Contract::Validate(constant: JwtApiEntreprise::Contract::AdminCreate)
     step :verify_user
-    failure :error_message
+    fail :error_message
     step :create_token
     step ->(options, created_token:, **) { UserMailer.token_creation_notice(created_token).deliver_now }
 

--- a/app/concepts/jwt_api_entreprise/operation/user_create.rb
+++ b/app/concepts/jwt_api_entreprise/operation/user_create.rb
@@ -1,13 +1,13 @@
-class JwtApiEntreprise
+module JwtApiEntreprise::Operation
   # TODO create an operation or activity for JWT creation to be called from admin or user request
   # ie remove token creation duplication
   class UserCreate < Trailblazer::Operation
     step self::Contract::Validate(constant: JwtApiEntreprise::Contract::UserCreate)
     step ->(options, params:, **) { options[:user] = User.find_by(id: params[:user_id]) }
-    failure ->(options, params:, **) { options[:errors] = "user does not exist (UID : '#{params[:user_id]}')" }, fail_fast: true
+    fail ->(options, params:, **) { options[:errors] = "user does not exist (UID : '#{params[:user_id]}')" }, fail_fast: true
 
     step :filter_authorized_roles
-    failure ->(options, params:, **) { options[:errors] = 'No authorized roles given' }
+    fail ->(options, params:, **) { options[:errors] = 'No authorized roles given' }
 
     step :create_contact
     step :create_token

--- a/app/concepts/role/operation/create.rb
+++ b/app/concepts/role/operation/create.rb
@@ -1,4 +1,4 @@
-class Role
+module Role::Operation
   class Create < Trailblazer::Operation
     step Model(Role, :new)
     step self::Contract::Validate(constant: Role::Contract::Create)

--- a/app/concepts/role/operation/db_seed.rb
+++ b/app/concepts/role/operation/db_seed.rb
@@ -1,30 +1,8 @@
 module Role::Operation
   class DBSeed < Trailblazer::Operation
-    extend ClassDependencies
-
-    self[:roles_seed] = [
-      { name: 'Attestation AGEFIPH',    code: 'attestations_agefiph' },
-      { name: 'Attestation Fiscale',    code: 'attestations_fiscales' },
-      { name: 'Attestation Sociale',    code: 'attestations_sociales' },
-      { name: 'Certificat CNETP',       code: 'certificat_cnetp' },
-      { name: 'Association',            code: 'associations' },
-      { name: 'Certificat OPQIBI',      code: 'certificat_opqibi' },
-      { name: 'Document association',   code: 'documents_association' },
-      { name: 'INSEE Etablissement',    code: 'etablissements' },
-      { name: 'INSEE Entreprise',       code: 'entreprises' },
-      { name: 'Extrait INPI',           code: 'extrait_court_inpi' },
-      { name: 'Extrait RCS',            code: 'extraits_rcs' },
-      { name: 'Exercice',               code: 'exercices' },
-      { name: 'Liasse fiscale',         code: 'liasse_fiscale' },
-      { name: 'Carte Pro FNTP',         code: 'fntp_carte_pro' },
-      { name: 'Certificat Qualibat',    code: 'qualibat' },
-      { name: 'Certificat PROBTP',      code: 'probtp' },
-      { name: 'Cotisation MSA',         code: 'msa_cotisations' },
-      { name: 'Bilans Entreprises BDF', code: 'bilans_entreprise_bdf' }
-    ]
-
+    step :init_roles_seed
     step ->(options, **) { options[:log] = [] }
-    success :seed!
+    step :seed!
 
     def seed!(options, roles_seed:, log:, **)
       roles_seed.each do |role|
@@ -35,6 +13,33 @@ module Role::Operation
           log << "Warning role already exists : name \"#{role[:name]}\", code \"#{role[:code]}\""
         end
       end
+    end
+
+    def init_roles_seed(ctx, roles_seed: nil, **)
+      if roles_seed.nil?
+        ctx[:roles_seed] = [
+          { name: 'Attestation AGEFIPH',    code: 'attestations_agefiph' },
+          { name: 'Attestation Fiscale',    code: 'attestations_fiscales' },
+          { name: 'Attestation Sociale',    code: 'attestations_sociales' },
+          { name: 'Certificat CNETP',       code: 'certificat_cnetp' },
+          { name: 'Certificat RGE (ADEME)', code: 'certificat_rge_ademe' },
+          { name: 'Association',            code: 'associations' },
+          { name: 'Certificat OPQIBI',      code: 'certificat_opqibi' },
+          { name: 'Document association',   code: 'documents_association' },
+          { name: 'INSEE Etablissement',    code: 'etablissements' },
+          { name: 'INSEE Entreprise',       code: 'entreprises' },
+          { name: 'Extrait INPI',           code: 'extrait_court_inpi' },
+          { name: 'Extrait RCS',            code: 'extraits_rcs' },
+          { name: 'Exercice',               code: 'exercices' },
+          { name: 'Liasse fiscale',         code: 'liasse_fiscale' },
+          { name: 'Carte Pro FNTP',         code: 'fntp_carte_pro' },
+          { name: 'Certificat Qualibat',    code: 'qualibat' },
+          { name: 'Certificat PROBTP',      code: 'probtp' },
+          { name: 'Cotisation MSA',         code: 'msa_cotisations' },
+          { name: 'Bilans Entreprises BDF', code: 'bilans_entreprise_bdf' }
+        ]
+      end
+      ctx[:roles_seed]
     end
   end
 end

--- a/app/concepts/role/operation/db_seed.rb
+++ b/app/concepts/role/operation/db_seed.rb
@@ -1,4 +1,4 @@
-class Role
+module Role::Operation
   class DBSeed < Trailblazer::Operation
     extend ClassDependencies
 
@@ -28,7 +28,7 @@ class Role
 
     def seed!(options, roles_seed:, log:, **)
       roles_seed.each do |role|
-        result = Role::Create.call(params: role)
+        result = Role::Operation::Create.call(params: role)
         if result.success?
           log << "Role created : name \"#{role[:name]}\", code \"#{role[:code]}\""
         else

--- a/app/concepts/user/operation/add_roles.rb
+++ b/app/concepts/user/operation/add_roles.rb
@@ -1,8 +1,8 @@
-class User
+module User::Operation
   class AddRoles < Trailblazer::Operation
     step self::Contract::Validate(constant: User::Contract::AddRoles)
     step ->(options, params:, **) { options[:model] = User.find_by(id: params[:id]) }
-    failure ->(options, **) { options['errors'] = 'user does not exist' }
+    fail ->(options, **) { options['errors'] = 'user does not exist' }
 
     step ->(options, model:, params:, **) { model.roles << Role.where(id: params[:roles]) }
   end

--- a/app/concepts/user/operation/confirm.rb
+++ b/app/concepts/user/operation/confirm.rb
@@ -1,11 +1,11 @@
-class User
+module User::Operation
   class Confirm < Trailblazer::Operation
     step self::Contract::Validate(constant: User::Contract::Confirm)
     step :retrieve_user_from_token
-    failure :invalid_token, fail_fast: true
+    fail :invalid_token, fail_fast: true
     step ->(options, model:, **) { model.cgu_agreement_date = Time.now }
     step ->(options, model:, **) { model.confirm }
-    failure :user_already_confirmed
+    fail :user_already_confirmed
     step :set_user_password
     step :dispose_session_token
 

--- a/app/concepts/user/operation/create.rb
+++ b/app/concepts/user/operation/create.rb
@@ -1,4 +1,4 @@
-class User
+module User::Operation
   class Create < Trailblazer::Operation
     step Model(User, :new)
     step self::Contract::Build(constant: User::Contract::Create)

--- a/app/concepts/user/operation/login.rb
+++ b/app/concepts/user/operation/login.rb
@@ -1,4 +1,4 @@
-class User
+module User::Operation
   class Login < Trailblazer::Operation
     step :retrieve_user_from_email
     step ->(options, model:, **) { model.confirmed? }

--- a/app/controllers/jwt_api_entreprise_controller.rb
+++ b/app/controllers/jwt_api_entreprise_controller.rb
@@ -1,7 +1,7 @@
 class JwtApiEntrepriseController < ApplicationController
   def admin_create
     authorize :admin, :admin?
-    result = JwtApiEntreprise::AdminCreate.call(params: params)
+    result = JwtApiEntreprise::Operation::AdminCreate.call(params: params)
 
     if result.success?
       render json: { new_token: result[:created_token].rehash }, status: 201
@@ -17,7 +17,7 @@ class JwtApiEntrepriseController < ApplicationController
     authorize JwtApiEntreprise
 
     # permit!.to_h is needed here because dry-validation needs params[:contact] to be a hash
-    result = JwtApiEntreprise::UserCreate.call(params: params.permit!.to_h)
+    result = JwtApiEntreprise::Operation::UserCreate.call(params: params.permit!.to_h)
 
     if result.success?
       render json: { new_token: result[:created_token].rehash }, status: 201

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -8,7 +8,7 @@ class RolesController < ApplicationController
 
   def create
     authorize :admin, :admin?
-    result = Role::Create.call(params: params)
+    result = Role::Operation::Create.call(params: params)
 
     if result.success?
       render json: result[:model], status: 201

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -50,7 +50,7 @@ class UsersController < ApplicationController
   end
 
   def confirm
-    result = User::Confirm.call(params: params)
+    result = User::Operation::Confirm.call(params: params)
 
     if result.success?
       render json: { access_token: result['access_token'] }, status: 200
@@ -64,7 +64,7 @@ class UsersController < ApplicationController
 
   def add_roles
     authorize :admin, :admin?
-    result = User::AddRoles.call(params: params)
+    result = User::Operation::AddRoles.call(params: params)
 
     if result.success?
       render json: {}, status: 200

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,7 @@ class UsersController < ApplicationController
 
   def create
     authorize :admin, :admin?
-    result = User::Create.call(params: params)
+    result = User::Operation::Create.call(params: params)
 
     if result.success?
       render json: result['model'], status: 201

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,8 +45,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.trailblazer.enable_loader = false
-
   config.account_confirmation_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/account/confirm'
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/admin/users/%s/tokens/'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -80,6 +80,4 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
-
-  config.trailblazer.enable_loader = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.trailblazer.enable_loader = false
+  #config.trailblazer.enable_loader = false
 
   config.account_confirmation_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/account/confirm'
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/admin/users/%s/tokens/'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,8 +40,6 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  #config.trailblazer.enable_loader = false
-
   config.account_confirmation_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/account/confirm'
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/admin/users/%s/tokens/'
 end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -11,7 +11,7 @@ Doorkeeper.configure do
   end
 
   resource_owner_from_credentials do |routes|
-    authentication = User::Login.call(params: params)
+    authentication = User::Operation::Login.call(params: params)
     authentication[:model] unless authentication.failure?
   end
 

--- a/spec/concepts/jwt_api_entreprise/operation/admin_create_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/admin_create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JwtApiEntreprise::AdminCreate do
+describe JwtApiEntreprise::Operation::AdminCreate do
   let(:user) { create(:user) }
   let(:roles) { create_list(:role, 7) }
   let(:token_params) do

--- a/spec/concepts/jwt_api_entreprise/operation/user_create_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/user_create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JwtApiEntreprise::UserCreate do
+describe JwtApiEntreprise::Operation::UserCreate do
   let(:user) { create(:user_with_roles) }
   let(:roles) { user.roles }
   let(:token_params) do

--- a/spec/concepts/role/operation/create_spec.rb
+++ b/spec/concepts/role/operation/create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Role::Create do
+describe Role::Operation::Create do
   let(:role_params) do
     { name: 'Role test', code: 'rol1' }
   end

--- a/spec/concepts/role/operation/db_seed_spec.rb
+++ b/spec/concepts/role/operation/db_seed_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Role::DBSeed do
+describe Role::Operation::DBSeed do
   describe 'with custom roles seed' do
     subject { described_class.call roles_seed: roles_seed }
 

--- a/spec/concepts/role/operation/db_seed_spec.rb
+++ b/spec/concepts/role/operation/db_seed_spec.rb
@@ -44,7 +44,7 @@ describe Role::Operation::DBSeed do
     subject { described_class.call }
 
     it 'saves all roles in the database' do
-      expect { subject }.to change(Role, :count).by(18)
+      expect { subject }.to change(Role, :count).by(19)
     end
   end
 end

--- a/spec/concepts/user/operation/add_roles_spec.rb
+++ b/spec/concepts/user/operation/add_roles_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User::AddRoles do
+describe User::Operation::AddRoles do
   let(:result) { described_class.call(params: op_params) }
   let(:user) { create(:user) }
   let(:roles) { create_list(:role, 3) }

--- a/spec/concepts/user/operation/confirm_spec.rb
+++ b/spec/concepts/user/operation/confirm_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User::Confirm do
+describe User::Operation::Confirm do
   let(:result) { described_class.call(params: confirmation_params) }
   let(:inactive_user) { UsersFactory.inactive_user }
   let(:confirmation_params) do

--- a/spec/concepts/user/operation/create_spec.rb
+++ b/spec/concepts/user/operation/create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User::Create do
+describe User::Operation::Create do
   let(:result) { described_class.call(params: user_params) }
   let(:user_email) { 'new@record.gg' }
   let(:user_params) do

--- a/spec/concepts/user/operation/login_spec.rb
+++ b/spec/concepts/user/operation/login_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User::Login do
+describe User::Operation::Login do
   let(:result) { described_class.call(params: login_params) }
 
   context 'when user email is unknown' do

--- a/spec/helpers/factories/users.rb
+++ b/spec/helpers/factories/users.rb
@@ -3,7 +3,7 @@ require 'rake'
 module UsersFactory
   def self.inactive_user
     params = { email: 'in@ctive.user', context: 'testing confirmation' }
-    operation_result = User::Create.call(params: params)
+    operation_result = User::Operation::Create.call(params: params)
     operation_result[:model]
   end
 
@@ -14,7 +14,7 @@ module UsersFactory
                password: 'couCOU123',
                password_confirmation: 'couCOU123'
     }
-    operation_result = User::Confirm.call(params: params)
+    operation_result = User::Operation::Confirm.call(params: params)
     operation_result[:model]
   end
 


### PR DESCRIPTION
### Contenu de la PR 
Monté de version de Trailblazer vers la *release candidate* 2.1.0.rc13 : 
* supression au passage de trailblazer-loader et donc renommage des constantes en accord avec les conventions Rails
* Injection de dépendances via *ClassDependencies* n'est plus supportée
* Déprécation annoncée de la macro *Nested* en faveur de *Subprocess*

### Comment faire la review 
Commits par commit