### PR TITLE
user index now returns :created_at

### DIFF
--- a/app/serializers/user_index_serializer.rb
+++ b/app/serializers/user_index_serializer.rb
@@ -1,5 +1,5 @@
 class UserIndexSerializer < ActiveModel::Serializer
-  attributes :id, :email, :context, :confirmed
+  attributes :id, :email, :context, :confirmed, :created_at
 
   def confirmed
     object.confirmed?

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -26,11 +26,12 @@ describe UsersController, type: :controller do
 
         user_raw = body.first
         expect(user_raw).to be_an_instance_of Hash
-        expect(user_raw.size).to eq 4
+        expect(user_raw.size).to eq 5
         expect(user_raw.key?(:id)).to be true
         expect(user_raw.key?(:email)).to be true
         expect(user_raw.key?(:context)).to be true
         expect(user_raw.key?(:confirmed)).to be true
+        expect(user_raw.key?(:created_at)).to be true
       end
     end
 


### PR DESCRIPTION
Ajout de :created_at au retour de user/index, sur une demande de @mazalaigue 