### PR TITLE
Amélioration des alertes d'expiration des jetons

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ service:
   - postgresql
 addons:
   postgresql: '9.6'
+before_install:
+  - export TZ=Europe/Paris
 before_script:
   - bundle exec rake dev:init
   - psql -U postgres -f postgresql_setup.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ service:
   - postgresql
 addons:
   postgresql: '9.6'
-before_install:
-  - export TZ=Europe/Paris
 before_script:
   - bundle exec rake dev:init
   - psql -U postgres -f postgresql_setup.txt

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: 'tech@entreprise.api.gouv.fr'
+  default from: Rails.configuration.emails_from_address
   layout 'mailer'
 end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: Rails.configuration.emails_from_address
+  default from: Rails.configuration.emails_sender_address
   layout 'mailer'
 end

--- a/app/mailers/jwt_api_entreprise_mailer.rb
+++ b/app/mailers/jwt_api_entreprise_mailer.rb
@@ -3,8 +3,21 @@ class JwtApiEntrepriseMailer < ApplicationMailer
     @jwt = jwt
     @nb_days = nb_days
 
+    recipients = exp_notice_recipients
     subject = "API Entreprise - Votre jeton expire dans #{@nb_days} jours !"
 
-    mail(to: jwt.user.email, subject: subject)
+    mail(to: recipients, subject: subject)
+  end
+
+  private
+
+  def exp_notice_recipients
+    # TODO This could be better and clearer here, be patient it will be refactor soon
+    main_account_email = @jwt.user.email
+    business_addresses = @jwt.user.contacts.where(contact_type: 'admin').pluck(:email)
+    tech_addresses = @jwt.user.contacts.where(contact_type: 'tech').pluck(:email)
+
+    recipients = [main_account_email, business_addresses, tech_addresses]
+    recipients.flatten.uniq
   end
 end

--- a/app/models/jwt_api_entreprise.rb
+++ b/app/models/jwt_api_entreprise.rb
@@ -11,6 +11,10 @@ class JwtApiEntreprise < ApplicationRecord
     self.roles.pluck(:code)
   end
 
+  def user_friendly_exp_date
+    "#{Time.at(exp).strftime('%d/%m/%Y à %Hh%M')} (heure de Paris)"
+  end
+
   private
 
   def token_payload

--- a/app/views/jwt_api_entreprise_mailer/expiration_notice.html.erb
+++ b/app/views/jwt_api_entreprise_mailer/expiration_notice.html.erb
@@ -12,7 +12,7 @@
 
     <p><strong>Passée la date du <%= @jwt.user_friendly_exp_date %> les appels à API Entreprise avec ce jeton seront rejetés.</strong></p>
 
-    <p>Merci de contacter le support à l'adresse <%= mail_to 'tech@entreprise.api.gouv.fr' %> afin de procéder au renouvellement.</p>
+    <p>Merci de contacter le support à l'adresse <%= mail_to(Rails.configuration.emails_from_address) %> afin de procéder au renouvellement.</p>
 
 
     <p>Cordialement,</p>

--- a/app/views/jwt_api_entreprise_mailer/expiration_notice.html.erb
+++ b/app/views/jwt_api_entreprise_mailer/expiration_notice.html.erb
@@ -12,7 +12,7 @@
 
     <p><strong>Passée la date du <%= @jwt.user_friendly_exp_date %> les appels à API Entreprise avec ce jeton seront rejetés.</strong></p>
 
-    <p>Merci de contacter le support à l'adresse <%= mail_to(Rails.configuration.emails_from_address) %> afin de procéder au renouvellement.</p>
+    <p>Merci de contacter le support à l'adresse <%= mail_to(Rails.configuration.emails_sender_address) %> afin de procéder au renouvellement.</p>
 
 
     <p>Cordialement,</p>

--- a/app/views/jwt_api_entreprise_mailer/expiration_notice.html.erb
+++ b/app/views/jwt_api_entreprise_mailer/expiration_notice.html.erb
@@ -8,9 +8,9 @@
 
     <p>Un de vos jetons d'accès à API Entreprise expire dans moins de <%= @nb_days %> jours.</p>
 
-    <p>En effet, le jeton utilisé dans le cadre "<%= @jwt.subject %>" (id : <%= @jwt.id %>) ne sera bientôt plus valide !
+    <p>En effet, le jeton attribué dans le cadre d'utilisation "<%= @jwt.subject %>" (id : <%= @jwt.id %>) ne sera bientôt plus valide !
 
-    <p>Passée la date du <%= Time.at(@jwt.exp).to_datetime %> les appels à API Entreprise seront rejetés.</p>
+    <p><strong>Passée la date du <%= @jwt.user_friendly_exp_date %> les appels à API Entreprise avec ce jeton seront rejetés.</strong></p>
 
     <p>Merci de contacter le support à l'adresse <%= mail_to 'tech@entreprise.api.gouv.fr' %> afin de procéder au renouvellement.</p>
 

--- a/app/views/jwt_api_entreprise_mailer/expiration_notice.text.erb
+++ b/app/views/jwt_api_entreprise_mailer/expiration_notice.text.erb
@@ -6,7 +6,7 @@ En effet, le jeton attribué dans le cadre d'utilisation "<%= @jwt.subject %>" (
 
 Passée la date du <%= @jwt.user_friendly_exp_date %> les appels à API Entreprise avec ce jeton seront rejetés.
 
-Merci de contacter le support à l'adresse <%= mail_to(Rails.configuration.emails_from_address) %> afin de procéder au renouvellement.
+Merci de contacter le support à l'adresse <%= mail_to(Rails.configuration.emails_sender_address) %> afin de procéder au renouvellement.
 
 Cordialement,
 L'équipe API Entreprise

--- a/app/views/jwt_api_entreprise_mailer/expiration_notice.text.erb
+++ b/app/views/jwt_api_entreprise_mailer/expiration_notice.text.erb
@@ -6,7 +6,7 @@ En effet, le jeton attribué dans le cadre d'utilisation "<%= @jwt.subject %>" (
 
 Passée la date du <%= @jwt.user_friendly_exp_date %> les appels à API Entreprise avec ce jeton seront rejetés.
 
-Merci de contacter le support à l'adresse <%= mail_to 'tech@entreprise.api.gouv.fr' %> afin de procéder au renouvellement.
+Merci de contacter le support à l'adresse <%= mail_to(Rails.configuration.emails_from_address) %> afin de procéder au renouvellement.
 
 Cordialement,
 L'équipe API Entreprise

--- a/app/views/jwt_api_entreprise_mailer/expiration_notice.text.erb
+++ b/app/views/jwt_api_entreprise_mailer/expiration_notice.text.erb
@@ -2,9 +2,9 @@ Bonjour,
 
 Un de vos jetons d'accès à API Entreprise expire dans moins de <%= @nb_days %> jours.
 
-En effet, le jeton utilisé dans le cadre "<%= @jwt.subject %>" (id : <%= @jwt.id %>) ne sera bientôt plus valide !
+En effet, le jeton attribué dans le cadre d'utilisation "<%= @jwt.subject %>" (id : <%= @jwt.id %>) ne sera bientôt plus valide !
 
-Passée la date du <%= Time.at(@jwt.exp).to_datetime %> les appels à API Entreprise seront rejetés.
+Passée la date du <%= @jwt.user_friendly_exp_date %> les appels à API Entreprise avec ce jeton seront rejetés.
 
 Merci de contacter le support à l'adresse <%= mail_to 'tech@entreprise.api.gouv.fr' %> afin de procéder au renouvellement.
 

--- a/app/views/user_mailer/confirm_account_action.html.erb
+++ b/app/views/user_mailer/confirm_account_action.html.erb
@@ -8,7 +8,7 @@
 
     <p>Un compte client à API Entreprise a été créé avec votre adresse e-mail.</p>
 
-    <p>Afin d'activer votre compte, merci de cliquer <%= link_to "ici", @confirmation_url %> ou sur le lien ci-dessous. Si vous n'êtes pas à l'origine de la demande d'un accès à nos services, merci de nous le signaler à <%= mail_to "tech@entreprise.api.gouv.fr" %>.<p>
+    <p>Afin d'activer votre compte, merci de cliquer <%= link_to "ici", @confirmation_url %> ou sur le lien ci-dessous. Si vous n'êtes pas à l'origine de la demande d'un accès à nos services, merci de nous le signaler à <%= mail_to(Rails.configuration.emails_from_address) %>.<p>
 
     <p>Lors de la confirmation de votre compte utilisateur il vous sera demandé de renseigner le mot de passe qui vous permettra d'accéder à votre espace client.</p>
 

--- a/app/views/user_mailer/confirm_account_action.html.erb
+++ b/app/views/user_mailer/confirm_account_action.html.erb
@@ -8,7 +8,7 @@
 
     <p>Un compte client à API Entreprise a été créé avec votre adresse e-mail.</p>
 
-    <p>Afin d'activer votre compte, merci de cliquer <%= link_to "ici", @confirmation_url %> ou sur le lien ci-dessous. Si vous n'êtes pas à l'origine de la demande d'un accès à nos services, merci de nous le signaler à <%= mail_to(Rails.configuration.emails_from_address) %>.<p>
+    <p>Afin d'activer votre compte, merci de cliquer <%= link_to "ici", @confirmation_url %> ou sur le lien ci-dessous. Si vous n'êtes pas à l'origine de la demande d'un accès à nos services, merci de nous le signaler à <%= mail_to(Rails.configuration.emails_sender_address) %>.<p>
 
     <p>Lors de la confirmation de votre compte utilisateur il vous sera demandé de renseigner le mot de passe qui vous permettra d'accéder à votre espace client.</p>
 

--- a/app/views/user_mailer/confirm_account_action.text.erb
+++ b/app/views/user_mailer/confirm_account_action.text.erb
@@ -2,7 +2,7 @@ Bonjour,
 
 Un compte client à API Entreprise a été créé avec votre adresse e-mail.
 
-Afin d'activer votre compte, merci de cliquer sur le lien ci-dessous. Si vous n'êtes pas à l'origine de la demande d'un accès à nos services, merci de nous le signaler à <%= mail_to(Rails.configuration.emails_from_address) %>.
+Afin d'activer votre compte, merci de cliquer sur le lien ci-dessous. Si vous n'êtes pas à l'origine de la demande d'un accès à nos services, merci de nous le signaler à <%= mail_to(Rails.configuration.emails_sender_address) %>.
 
 Lors de la confirmation de votre compte utilisateur il vous sera demandé de renseigner le mot de passe qui vous permettra d'accéder à votre espace client.
 

--- a/app/views/user_mailer/confirm_account_action.text.erb
+++ b/app/views/user_mailer/confirm_account_action.text.erb
@@ -2,7 +2,7 @@ Bonjour,
 
 Un compte client à API Entreprise a été créé avec votre adresse e-mail.
 
-Afin d'activer votre compte, merci de cliquer sur le lien ci-dessous. Si vous n'êtes pas à l'origine de la demande d'un accès à nos services, merci de nous le signaler à <%= mail_to "tech@entreprise.api.gouv.fr" %>.
+Afin d'activer votre compte, merci de cliquer sur le lien ci-dessous. Si vous n'êtes pas à l'origine de la demande d'un accès à nos services, merci de nous le signaler à <%= mail_to(Rails.configuration.emails_from_address) %>.
 
 Lors de la confirmation de votre compte utilisateur il vous sera demandé de renseigner le mot de passe qui vous permettra d'accéder à votre espace client.
 

--- a/app/views/user_mailer/confirm_account_notice.html.erb
+++ b/app/views/user_mailer/confirm_account_notice.html.erb
@@ -10,7 +10,7 @@
 
     <p>Afin de l'activer, votre administrateur (<%= @user.email %>) a reçu un e-mail avec un lien permettant de valider la création du compte et de choisir un mot de passe.</p>
 
-    <p>Si cette boite mail n'est pas consultée régulièrement ou si vous n'avez pas reçu l'e-mail de confirmation veuillez nous contacter à l'adresse suivante <%= mail_to(Rails.configuration.emails_from_address) %></p>
+    <p>Si cette boite mail n'est pas consultée régulièrement ou si vous n'avez pas reçu l'e-mail de confirmation veuillez nous contacter à l'adresse suivante <%= mail_to(Rails.configuration.emails_sender_address) %></p>
 
     <p>Cordialement,</p>
     <p>L'équipe API Entreprise</p>

--- a/app/views/user_mailer/confirm_account_notice.html.erb
+++ b/app/views/user_mailer/confirm_account_notice.html.erb
@@ -10,7 +10,7 @@
 
     <p>Afin de l'activer, votre administrateur (<%= @user.email %>) a reçu un e-mail avec un lien permettant de valider la création du compte et de choisir un mot de passe.</p>
 
-    <p>Si cette boite mail n'est pas consultée régulièrement ou si vous n'avez pas reçu l'e-mail de confirmation veuillez nous contacter à l'adresse suivante <%= mail_to 'tech@entreprise.api.gouv.fr' %></p>
+    <p>Si cette boite mail n'est pas consultée régulièrement ou si vous n'avez pas reçu l'e-mail de confirmation veuillez nous contacter à l'adresse suivante <%= mail_to(Rails.configuration.emails_from_address) %></p>
 
     <p>Cordialement,</p>
     <p>L'équipe API Entreprise</p>

--- a/app/views/user_mailer/confirm_account_notice.text.erb
+++ b/app/views/user_mailer/confirm_account_notice.text.erb
@@ -3,7 +3,7 @@ Un compte client API Entreprise a été créé avec l'adresse e-mail <%= @user.e
 
 Afin de l'activer, votre administrateur (<%= @user.email %>) a reçu un e-mail avec un lien permettant de valider la création du compte et de choisir un mot de passe.
 
-Si cette boite mail n'est pas consultée régulièrement ou si vous n'avez pas reçu l'e-mail de confirmation veuillez nous contacter à l'adresse suivante <%= mail_to 'tech@entreprise.api.gouv.fr' %>
+Si cette boite mail n'est pas consultée régulièrement ou si vous n'avez pas reçu l'e-mail de confirmation veuillez nous contacter à l'adresse suivante <%= mail_to(Rails.configuration.emails_from_address) %>
 
 Cordialement,
 L'équipe API Entreprise

--- a/app/views/user_mailer/confirm_account_notice.text.erb
+++ b/app/views/user_mailer/confirm_account_notice.text.erb
@@ -3,7 +3,7 @@ Un compte client API Entreprise a été créé avec l'adresse e-mail <%= @user.e
 
 Afin de l'activer, votre administrateur (<%= @user.email %>) a reçu un e-mail avec un lien permettant de valider la création du compte et de choisir un mot de passe.
 
-Si cette boite mail n'est pas consultée régulièrement ou si vous n'avez pas reçu l'e-mail de confirmation veuillez nous contacter à l'adresse suivante <%= mail_to(Rails.configuration.emails_from_address) %>
+Si cette boite mail n'est pas consultée régulièrement ou si vous n'avez pas reçu l'e-mail de confirmation veuillez nous contacter à l'adresse suivante <%= mail_to(Rails.configuration.emails_sender_address) %>
 
 Cordialement,
 L'équipe API Entreprise

--- a/app/views/user_mailer/token_creation_notice.html.erb
+++ b/app/views/user_mailer/token_creation_notice.html.erb
@@ -26,7 +26,7 @@
       <li>le nombre d'appels par API sur les dernières 30h/8j</li>
     </ul>
 
-    <p>Si vous avez besoin d'un nouveau token contactez-nous : tech@entreprise.api.gouv.fr</p>
+    <p>Si vous avez besoin d'un nouveau token contactez-nous : <%= mail_to(Rails.configuration.emails_from_address) %></p>
 
     <p>Vous recevez cet email car vous êtes renseigné parmi les contacts pour le compte <%= @user.email %>. Les accès se font uniquement à partir de cette adresse email.</p>
 

--- a/app/views/user_mailer/token_creation_notice.html.erb
+++ b/app/views/user_mailer/token_creation_notice.html.erb
@@ -26,7 +26,7 @@
       <li>le nombre d'appels par API sur les dernières 30h/8j</li>
     </ul>
 
-    <p>Si vous avez besoin d'un nouveau token contactez-nous : <%= mail_to(Rails.configuration.emails_from_address) %></p>
+    <p>Si vous avez besoin d'un nouveau token contactez-nous : <%= mail_to(Rails.configuration.emails_sender_address) %></p>
 
     <p>Vous recevez cet email car vous êtes renseigné parmi les contacts pour le compte <%= @user.email %>. Les accès se font uniquement à partir de cette adresse email.</p>
 

--- a/app/views/user_mailer/token_creation_notice.text.erb
+++ b/app/views/user_mailer/token_creation_notice.text.erb
@@ -15,7 +15,7 @@ N'oubliez pas, vous pouvez consulter les statistiques d'utilisations propre à c
   - les pourcentages des différents code HTTP sur les dernières 30h/8j
   - le nombre d'appels par API sur les dernières 30h/8j
 
-Si vous avez besoin d'un nouveau token contactez-nous : tech@entreprise.api.gouv.fr
+  Si vous avez besoin d'un nouveau token contactez-nous : <%= mail_to(Rails.configuration.emails_from_address) %>
 
 Vous recevez cet email car vous êtes renseigné parmi les contacts pour le compte <%= @user.email %>. Les accès se font uniquement à partir de cette adresse email.
 

--- a/app/views/user_mailer/token_creation_notice.text.erb
+++ b/app/views/user_mailer/token_creation_notice.text.erb
@@ -15,7 +15,7 @@ N'oubliez pas, vous pouvez consulter les statistiques d'utilisations propre à c
   - les pourcentages des différents code HTTP sur les dernières 30h/8j
   - le nombre d'appels par API sur les dernières 30h/8j
 
-  Si vous avez besoin d'un nouveau token contactez-nous : <%= mail_to(Rails.configuration.emails_from_address) %>
+  Si vous avez besoin d'un nouveau token contactez-nous : <%= mail_to(Rails.configuration.emails_sender_address) %>
 
 Vous recevez cet email car vous êtes renseigné parmi les contacts pour le compte <%= @user.email %>. Les accès se font uniquement à partir de cette adresse email.
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,7 @@ module AdminApientreprise
     # Set dry-validation as the validation engine for reform
     config.reform.validations = :dry
 
-    config.time_zone = 'Paris'
+    config.time_zone = 'Europe/Paris'
     config.i18n.available_locales = [:fr_FR]
     config.i18n.default_locale = :fr_FR
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -99,6 +99,7 @@ task :deploy => :environment do
       in_path(fetch(:current_path)) do
         command %{mkdir -p tmp/}
         command %{touch tmp/restart.txt}
+        invoke :restart_sidekiq
         invoke :'passenger'
       end
     end
@@ -106,6 +107,11 @@ task :deploy => :environment do
 
   # you can use `run :local` to run tasks on local machine before of after the deploy scripts
   # run(:local){ say 'done' }
+end
+
+task :restart_sidekiq do
+  comment 'Restarting Sidekiq (reloads code)'.green
+  command %(sudo systemctl restart sidekiq_admin_apientreprise_#{ENV['to']}_1.service)
 end
 
 task :passenger do

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,5 +51,5 @@ Rails.application.configure do
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/admin/users/%s/tokens/'
 
   config.redis_database = 'redis://localhost:6379/0'
-  config.emails_from_address = 'support@entreprise.api.gouv.fr'
+  config.emails_sender_address = 'support@entreprise.api.gouv.fr'
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,4 +51,5 @@ Rails.application.configure do
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/admin/users/%s/tokens/'
 
   config.redis_database = 'redis://localhost:6379/0'
+  config.emails_from_address = 'support@entreprise.api.gouv.fr'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,5 +103,5 @@ Rails.application.configure do
   config.trailblazer.enable_loader = true
 
   config.redis_database = 'redis://localhost:6379/0'
-  config.emails_from_address = 'support@entreprise.api.gouv.fr'
+  config.emails_sender_address = 'support@entreprise.api.gouv.fr'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,4 +103,5 @@ Rails.application.configure do
   config.trailblazer.enable_loader = true
 
   config.redis_database = 'redis://localhost:6379/0'
+  config.emails_from_address = 'support@entreprise.api.gouv.fr'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,4 +49,5 @@ Rails.application.configure do
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/admin/users/%s/tokens/'
 
   config.redis_database = 'redis://localhost:6379/0'
+  config.emails_from_address = 'support@entreprise.api.gouv.fr'
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,5 +49,5 @@ Rails.application.configure do
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/admin/users/%s/tokens/'
 
   config.redis_database = 'redis://localhost:6379/0'
-  config.emails_from_address = 'support@entreprise.api.gouv.fr'
+  config.emails_sender_address = 'support@entreprise.api.gouv.fr'
 end

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -6,12 +6,12 @@ development:
 
 sandbox:
   jwt_expiration_notice:
-    cron: '0 1 * * *'
+    cron: '0 */4 * * *'
     class: 'JwtApiEntrepriseExpirationNoticeJob'
     queue: default
 
 production:
   jwt_expiration_notice:
-    cron: '0 1 * * *'
+    cron: '0 */4 * * *'
     class: 'JwtApiEntrepriseExpirationNoticeJob'
     queue: default

--- a/spec/mailers/jwt_api_entreprise_mailer_spec.rb
+++ b/spec/mailers/jwt_api_entreprise_mailer_spec.rb
@@ -9,7 +9,7 @@ describe JwtApiEntrepriseMailer, type: :mailer do
     let(:nb_days) { '4000' }
 
     its(:subject) { is_expected.to eq("API Entreprise - Votre jeton expire dans #{nb_days} jours !") }
-    its(:from) { is_expected.to include('tech@entreprise.api.gouv.fr') }
+    its(:from) { is_expected.to include(Rails.configuration.emails_from_address) }
 
     describe 'notification recipients' do
       it 'sends the email to the account owner' do
@@ -58,7 +58,7 @@ describe JwtApiEntrepriseMailer, type: :mailer do
     end
 
     it 'contains the team email address to request a renewal' do
-      renewal_process = 'Merci de contacter le support à l\'adresse <a href="mailto:tech@entreprise.api.gouv.fr">tech@entreprise.api.gouv.fr</a> afin de procéder au renouvellement'
+      renewal_process = "Merci de contacter le support à l\'adresse <a href=\"mailto:#{Rails.configuration.emails_from_address}\">#{Rails.configuration.emails_from_address}</a> afin de procéder au renouvellement"
 
       expect(subject.html_part.decoded).to include(renewal_process)
       expect(subject.text_part.decoded).to include(renewal_process)

--- a/spec/mailers/jwt_api_entreprise_mailer_spec.rb
+++ b/spec/mailers/jwt_api_entreprise_mailer_spec.rb
@@ -9,7 +9,7 @@ describe JwtApiEntrepriseMailer, type: :mailer do
     let(:nb_days) { '4000' }
 
     its(:subject) { is_expected.to eq("API Entreprise - Votre jeton expire dans #{nb_days} jours !") }
-    its(:from) { is_expected.to include(Rails.configuration.emails_from_address) }
+    its(:from) { is_expected.to include(Rails.configuration.emails_sender_address) }
 
     describe 'notification recipients' do
       it 'sends the email to the account owner' do
@@ -58,7 +58,7 @@ describe JwtApiEntrepriseMailer, type: :mailer do
     end
 
     it 'contains the team email address to request a renewal' do
-      renewal_process = "Merci de contacter le support à l\'adresse <a href=\"mailto:#{Rails.configuration.emails_from_address}\">#{Rails.configuration.emails_from_address}</a> afin de procéder au renouvellement"
+      renewal_process = "Merci de contacter le support à l\'adresse <a href=\"mailto:#{Rails.configuration.emails_sender_address}\">#{Rails.configuration.emails_sender_address}</a> afin de procéder au renouvellement"
 
       expect(subject.html_part.decoded).to include(renewal_process)
       expect(subject.text_part.decoded).to include(renewal_process)

--- a/spec/mailers/jwt_api_entreprise_mailer_spec.rb
+++ b/spec/mailers/jwt_api_entreprise_mailer_spec.rb
@@ -25,15 +25,15 @@ describe JwtApiEntrepriseMailer, type: :mailer do
     end
 
     it 'contains the JWT information' do
-      jwt_info = "le jeton utilisé dans le cadre \"#{jwt.subject}\" (id : #{jwt.id}) ne sera bientôt plus valide !"
+      jwt_info = "le jeton attribué dans le cadre d'utilisation \"#{jwt.subject}\" (id : #{jwt.id}) ne sera bientôt plus valide !"
 
       expect(subject.html_part.decoded).to include(jwt_info)
       expect(subject.text_part.decoded).to include(jwt_info)
     end
 
     it 'contains the exact expiration time of the JWT' do
-      expiration_datetime = Time.at(jwt.exp).to_datetime
-      tested_corpus = "Passée la date du #{expiration_datetime} les appels à API Entreprise seront rejetés."
+      expiration_datetime = jwt.user_friendly_exp_date
+      tested_corpus = "Passée la date du #{expiration_datetime} les appels à API Entreprise avec ce jeton seront rejetés."
 
       expect(subject.html_part.decoded).to include(tested_corpus)
       expect(subject.text_part.decoded).to include(tested_corpus)

--- a/spec/mailers/user_spec.rb
+++ b/spec/mailers/user_spec.rb
@@ -8,7 +8,7 @@ describe UserMailer, type: :mailer do
 
     its(:subject) { is_expected.to eq 'API Entreprise - Activation de compte utilisateur' }
     its(:to) { is_expected.to eq [user.email] }
-    its(:from) { is_expected.to include(Rails.configuration.emails_from_address) }
+    its(:from) { is_expected.to include(Rails.configuration.emails_sender_address) }
 
     it 'contains the user confirmation URL' do
       confirmation_url = "https://sandbox.dashboard.entreprise.api.gouv.fr/account/confirm?confirmation_token=very_confirm"
@@ -30,7 +30,7 @@ describe UserMailer, type: :mailer do
 
       its(:subject) { is_expected.to eq 'API Entreprise - Activation de compte utilisateur' }
       its(:to) { is_expected.to eq user.contacts.pluck(:email) }
-      its(:from) { is_expected.to include(Rails.configuration.emails_from_address) }
+      its(:from) { is_expected.to include(Rails.configuration.emails_sender_address) }
 
       it 'contains the confirm account notice' do
         notice = "votre administrateur (#{user.email}) a reçu un e-mail"
@@ -69,7 +69,7 @@ describe UserMailer, type: :mailer do
     let(:new_token) { user.jwt_api_entreprise.first }
 
     its(:subject) { is_expected.to eq 'API Entreprise - Création d\'un nouveau token' }
-    its(:from) { is_expected.to include(Rails.configuration.emails_from_address) }
+    its(:from) { is_expected.to include(Rails.configuration.emails_sender_address) }
 
     it 'sends the email to all contacts (including the account owner)' do
       user.contacts.first.update email: user.email

--- a/spec/mailers/user_spec.rb
+++ b/spec/mailers/user_spec.rb
@@ -8,7 +8,7 @@ describe UserMailer, type: :mailer do
 
     its(:subject) { is_expected.to eq 'API Entreprise - Activation de compte utilisateur' }
     its(:to) { is_expected.to eq [user.email] }
-    its(:from) { is_expected.to eq ['tech@entreprise.api.gouv.fr'] }
+    its(:from) { is_expected.to include(Rails.configuration.emails_from_address) }
 
     it 'contains the user confirmation URL' do
       confirmation_url = "https://sandbox.dashboard.entreprise.api.gouv.fr/account/confirm?confirmation_token=very_confirm"
@@ -30,7 +30,7 @@ describe UserMailer, type: :mailer do
 
       its(:subject) { is_expected.to eq 'API Entreprise - Activation de compte utilisateur' }
       its(:to) { is_expected.to eq user.contacts.pluck(:email) }
-      its(:from) { is_expected.to eq ['tech@entreprise.api.gouv.fr'] }
+      its(:from) { is_expected.to include(Rails.configuration.emails_from_address) }
 
       it 'contains the confirm account notice' do
         notice = "votre administrateur (#{user.email}) a reçu un e-mail"
@@ -69,7 +69,7 @@ describe UserMailer, type: :mailer do
     let(:new_token) { user.jwt_api_entreprise.first }
 
     its(:subject) { is_expected.to eq 'API Entreprise - Création d\'un nouveau token' }
-    its(:from) { is_expected.to eq ['tech@entreprise.api.gouv.fr'] }
+    its(:from) { is_expected.to include(Rails.configuration.emails_from_address) }
 
     it 'sends the email to all contacts (including the account owner)' do
       user.contacts.first.update email: user.email

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -23,6 +23,17 @@ describe JwtApiEntreprise, type: :model do
     it { is_expected.to have_and_belong_to_many :roles }
   end
 
+  describe '#user_friendly_exp_date' do
+    it 'returns a friendly formated date' do
+      # About the offset here, during winter (March 17th here)
+      # it is UTC+01:00 so this is a valid datetime in Paris
+      datetime = DateTime.new(1998, 3, 17, 15, 28, 49, '+1')
+      jwt.exp = datetime.to_i
+
+      expect(jwt.user_friendly_exp_date).to eq('17/03/1998 à 15h28 (heure de Paris)')
+    end
+  end
+
   describe '#rehash' do
     let(:token) { jwt.rehash }
 


### PR DESCRIPTION
### Contenu de la PR 

Normalement derniers changements avant déploiement en production : 
* un format plus *user friendly* de la date d'expiration dans le corps du mail ; 
* le propriétaire du compte ainsi que tous les contacts métiers et techniques reçoivent l'email ; 
* la tâche Sidekiq CRON est exécutée toutes les 4h (le *pourquoi* est explicité en commentaire du commit) ; 
* l'adresse email de "l'envoyeur" a été externalisée dans les fichiers de configuration par environnements (qui sont déployés par Ansible, et qui vaut dorénavant *support@entreprise.api.gouv.fr*) 

### Comment faire la review 
Commits par commits.

Je suis pas trop fan du nom de ma variable pour l'adresse email *from* ; si ça vous va, très bien, sinon proposez autre chose.
Idem pour mon code qui gère l'envoie aux différents contacts métiers et business, sans être ignoble je le trouve pas terrible. Il ne vas pas résister aux changements dans le modèle (contacts rattachés aux jetons et non plus aux comptes utilisateurs) donc le refactor viendra à ce moment là.