### PR TITLE
Use Time.zone instead of Time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ service:
   - postgresql
 addons:
   postgresql: '9.6'
-before_install:
-  - export TZ=Europe/Paris
 before_script:
   - bundle exec rake dev:init
   - psql -U postgres -f postgresql_setup.txt

--- a/app/concepts/jwt_api_entreprise/operation/admin_create.rb
+++ b/app/concepts/jwt_api_entreprise/operation/admin_create.rb
@@ -14,7 +14,7 @@ module JwtApiEntreprise::Operation
     def create_token(options, params:, user:, **)
       new_token = JwtApiEntreprise.create({
         subject: params[:subject],
-        iat: Time.now.to_i,
+        iat: Time.zone.now.to_i,
         version: '1.0',
         exp: 18.months.from_now.to_i
       })

--- a/app/concepts/jwt_api_entreprise/operation/user_create.rb
+++ b/app/concepts/jwt_api_entreprise/operation/user_create.rb
@@ -21,7 +21,7 @@ module JwtApiEntreprise::Operation
     def create_token(options, token_contact:, authorized_roles:, user:, params:, **)
       new_token = JwtApiEntreprise.create({
         subject: params[:subject],
-        iat: Time.now.to_i,
+        iat: Time.zone.now.to_i,
         version: '1.0',
         exp: 18.months.from_now.to_i
       })

--- a/app/concepts/user/operation/confirm.rb
+++ b/app/concepts/user/operation/confirm.rb
@@ -3,7 +3,7 @@ module User::Operation
     step self::Contract::Validate(constant: User::Contract::Confirm)
     step :retrieve_user_from_token
     fail :invalid_token, fail_fast: true
-    step ->(options, model:, **) { model.cgu_agreement_date = Time.now }
+    step ->(options, model:, **) { model.cgu_agreement_date = Time.zone.now }
     step ->(options, model:, **) { model.confirm }
     fail :user_already_confirmed
     step :set_user_password

--- a/app/concepts/user/operation/create.rb
+++ b/app/concepts/user/operation/create.rb
@@ -6,7 +6,7 @@ module User::Operation
     step self::Contract::Persist(method: :sync)
     step ->(options, model:, **) { model.email = model.email.downcase }
     step ->(options, model:, **) { model.generate_confirmation_token }
-    step ->(options, model:, **) { model.confirmation_sent_at = Time.now }
+    step ->(options, model:, **) { model.confirmation_sent_at = Time.zone.now }
     step ->(options, model:, **) { model.save }
     step ->(options, model:, **) { UserMailer.confirm_account_action(model).deliver_later }
     step :send_confirm_account_notice

--- a/app/models/jwt_api_entreprise.rb
+++ b/app/models/jwt_api_entreprise.rb
@@ -12,7 +12,7 @@ class JwtApiEntreprise < ApplicationRecord
   end
 
   def user_friendly_exp_date
-    "#{Time.at(exp).strftime('%d/%m/%Y à %Hh%M')} (heure de Paris)"
+    "#{Time.zone.at(exp).strftime('%d/%m/%Y à %Hh%M')} (heure de Paris)"
   end
 
   private

--- a/lib/tasks/create_admin.rake
+++ b/lib/tasks/create_admin.rake
@@ -6,6 +6,6 @@ task 'create_admin': :environment do
     email: 'admin@entreprise.api.gouv.fr',
     password: user_pwd,
     context: 'Admin',
-    confirmed_at: Time.now
+    confirmed_at: Time.zone.now
   )
 end

--- a/spec/concepts/user/operation/confirm_spec.rb
+++ b/spec/concepts/user/operation/confirm_spec.rb
@@ -37,7 +37,7 @@ describe User::Operation::Confirm do
       end
 
       it 'set the CGU agreements attribute to the current timestamp' do
-        expect(result[:model].cgu_agreement_date.to_i).to be_within(2).of(Time.now.to_i)
+        expect(result[:model].cgu_agreement_date.to_i).to be_within(2).of(Time.zone.now.to_i)
       end
 
       it 'sends a notification email to the user'

--- a/spec/concepts/user/operation/create_spec.rb
+++ b/spec/concepts/user/operation/create_spec.rb
@@ -157,7 +157,7 @@ describe User::Operation::Create do
       end
 
       it 'sets the confirmation request timestamp' do
-        expect(result[:model].confirmation_sent_at.to_i).to be_within(2).of(Time.now.to_i)
+        expect(result[:model].confirmation_sent_at.to_i).to be_within(2).of(Time.zone.now.to_i)
       end
 
       describe 'mail notifications' do

--- a/spec/factories/jwt_api_entreprise.rb
+++ b/spec/factories/jwt_api_entreprise.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :jwt_api_entreprise do
     subject { 'Humm testy' }
-    iat { Time.now.to_i }
+    iat { Time.zone.now.to_i }
     exp { 18.months.from_now.to_i }
     version { '1.0' }
     days_left_notification_sent { [] }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,8 +6,8 @@ FactoryBot.define do
     # TODO make user factory confirmed by default
     # use an :inactive_user factory for this specific state
     factory :confirmed_user do
-      confirmed_at { Time.now.to_i }
-      cgu_agreement_date { Time.now.to_i }
+      confirmed_at { Time.zone.now.to_i }
+      cgu_agreement_date { Time.zone.now.to_i }
     end
 
     factory :admin do

--- a/spec/lib/account_access_token_spec.rb
+++ b/spec/lib/account_access_token_spec.rb
@@ -20,7 +20,7 @@ describe 'JWT for account data access', type: :jwt do
 
     # giving the test 2 seconds lag security
     # look gem time cop
-    expect(creation_timestamp).to be_within(2).of(Time.now.to_i)
+    expect(creation_timestamp).to be_within(2).of(Time.zone.now.to_i)
   end
 
   it 'expires in 4 hours' do


### PR DESCRIPTION
- `Time.xxx` se base sur l'heure de la machine.
- `Time.zone.xxx` se base sur le fuseau horaire définit dans `config/application.rb` (`config.time_zone = 'Europe/Paris'`)

Il faut donc utiliser partout `Time.zone.xxx` pour que les tests passent sur des machines sur un autre fuseau horaire...

Et donc on peut supprimer la configuration Travis qui forçait le fuseau horaire à Paris pour que les tests passent ; ça n'est plus nécessaire