### PR TITLE
Fournir la date d'acceptation des CGUs à la création d'un utilisateur

### DIFF
--- a/app/concepts/user/contract/confirm.rb
+++ b/app/concepts/user/contract/confirm.rb
@@ -18,7 +18,5 @@ module User::Contract
       :confirmation_token_exists?,
       :confirmation_token_used?
     )
-
-    required(:cgu_checked).value(eql?: true)
   end
 end

--- a/app/concepts/user/contract/create.rb
+++ b/app/concepts/user/contract/create.rb
@@ -3,6 +3,7 @@ module User::Contract
     property :email
     property :context
     property :note
+    property :cgu_agreement_date
 
     validation do
       configure do
@@ -13,6 +14,12 @@ module User::Contract
           existing_email = User.find_by(email: value)
           !existing_email
         end
+
+        def datetime?(value)
+          Time.zone.parse(value)
+        rescue ArgumentError
+          false
+        end
       end
 
       required(:email).filled(
@@ -21,6 +28,7 @@ module User::Contract
       )
       required(:context).maybe(:str?)
       required(:note).maybe(:str?)
+      required(:cgu_agreement_date).filled(:datetime?)
     end
   end
 end

--- a/app/concepts/user/operation/confirm.rb
+++ b/app/concepts/user/operation/confirm.rb
@@ -3,7 +3,6 @@ module User::Operation
     step self::Contract::Validate(constant: User::Contract::Confirm)
     fail :contract_errors, fail_fast: true
     step :retrieve_user_from_token
-    step ->(options, model:, **) { model.cgu_agreement_date = Time.zone.now }
     step ->(options, model:, **) { model.confirm }
     step :set_user_password
     step :dispose_session_token

--- a/config/dry_validation_errors.yml
+++ b/config/dry_validation_errors.yml
@@ -6,9 +6,9 @@ en:
       password:
         format?: 'minimum eight characters, at least one uppercase letter, one lowercase letter and one number'
 
-    cgu_checked: 'CGU must be accepted'
-
     unique?: 'value already exists'
+
+    datetime?: 'must be a datetime format'
 
     confirmation_token_exists?: 'confirmation token not found'
     confirmation_token_used?: 'user already confirmed'

--- a/spec/concepts/user/operation/confirm_spec.rb
+++ b/spec/concepts/user/operation/confirm_spec.rb
@@ -8,7 +8,6 @@ describe User::Operation::Confirm do
       password: 'couCOU23',
       password_confirmation: 'couCOU23',
       confirmation_token: inactive_user.confirmation_token,
-      cgu_checked: true
     }
   end
 
@@ -34,13 +33,6 @@ describe User::Operation::Confirm do
 
       it 'returns a session JWT for user dashboard access' do
         expect(result['access_token']).to be_truthy
-      end
-
-      it 'set the CGU agreements attribute to the current timestamp' do
-        Timecop.freeze
-
-        expect(result[:model].cgu_agreement_date.to_i).to eq(Time.zone.now.to_i)
-        Timecop.return
       end
 
       it 'sends a notification email to the user'
@@ -87,31 +79,6 @@ describe User::Operation::Confirm do
 
     describe ':password' do
       it_behaves_like :password_renewal_contract
-    end
-
-    describe '#accepted_cgu_check' do
-      let(:cgu_error_message) { result[:errors][:cgu_checked] }
-
-      it 'is required' do
-        confirmation_params.delete(:cgu_checked)
-
-        expect(result).to be_failure
-        expect(cgu_error_message).to include('CGU must be accepted')
-      end
-
-      it 'is a boolean' do
-        confirmation_params[:cgu_checked] = 'truthy value'
-
-        expect(result).to be_failure
-        expect(cgu_error_message).to include('CGU must be accepted')
-      end
-
-      it 'cannot be false' do
-        confirmation_params[:cgu_checked] = false
-
-        expect(result).to be_failure
-        expect(cgu_error_message).to include('CGU must be accepted')
-      end
     end
   end
 end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -32,8 +32,14 @@ describe UsersController, type: :controller do
   end
 
   describe '#create' do
-    # getting attributes from :user Factory
     let(:user_params) { attributes_for :user }
+    let(:user_params) do
+      {
+        email: 'user@email.com',
+        context: 'very create',
+        cgu_agreement_date: '2020-01-07T12:38:45.490Z'
+      }
+    end
 
     context 'when requested from an admin' do
       include_context 'admin request'
@@ -239,7 +245,6 @@ describe UsersController, type: :controller do
       let(:confirmation_params) do
         {
           confirmation_token: inactive_user.confirmation_token,
-          cgu_checked: true,
           password: 'validPWD12',
           password_confirmation: 'validPWD12'
         }
@@ -267,7 +272,6 @@ describe UsersController, type: :controller do
      let(:confirmation_params) do
         {
           confirmation_token: 'oups',
-          cgu_checked: true,
           password: 'validPWD12',
           password_confirmation: 'validPWD12'
         }

--- a/spec/helpers/factories/users.rb
+++ b/spec/helpers/factories/users.rb
@@ -2,7 +2,7 @@ require 'rake'
 
 module UsersFactory
   def self.inactive_user
-    params = { email: 'in@ctive.user', context: 'testing confirmation' }
+    params = { email: 'in@ctive.user', context: 'testing confirmation', cgu_agreement_date: '2019-12-26T14:38:45.490Z' }
     operation_result = User::Operation::Create.call(params: params)
     operation_result[:model]
   end
@@ -10,7 +10,6 @@ module UsersFactory
   def self.confirmed_user
     unconfirmed_user = inactive_user
     params = { confirmation_token: unconfirmed_user.confirmation_token,
-               cgu_checked: true,
                password: 'couCOU123',
                password_confirmation: 'couCOU123'
     }


### PR DESCRIPTION
### Contenu de la PR 
* la date d'acceptation des CGU doit maintenant être fournie dans les paramètres de la requête de création d'un utilisateur. L'attribut n'est plus set lors de la confirmation du compte.

### Mais pourquoi ? 
Initialement il y avait une case à cocher pour l'acceptation des CGU dans le formulaire de confirmation de compte utilisateur. A présent cette case à cocher est déjà présente dans le formulaire de demande d'accès Signup. C'est donc Signup qui fourni la date d'acceptation des CGU à la validation de la demande qui créé maintenant un compte usager automatiquement.

### Ce qu'il reste à faire 
Supprimer la checkbox du formulaire de confirmation de compte (qui contiendra uniquement le mot de passe et la confirmation).