### PR TITLE
Renvoyer les jetons archivés dans le détail d'un user

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,11 +25,15 @@ class User < ApplicationRecord
   end
 
   def encoded_jwt
-    jwt_api_entreprise.where(blacklisted: false).map(&:rehash)
+    jwt_api_entreprise.where(blacklisted: false, archived: false).map(&:rehash)
   end
 
   def blacklisted_jwt
     jwt_api_entreprise.where(blacklisted: true).map(&:rehash)
+  end
+
+  def archived_jwt
+    jwt_api_entreprise.where(archived: true).map(&:rehash)
   end
 
   private

--- a/app/serializers/user_show_serializer.rb
+++ b/app/serializers/user_show_serializer.rb
@@ -2,6 +2,7 @@ class UserShowSerializer < ActiveModel::Serializer
   attributes :id, :email, :context
   attribute :note, if: :admin?
   attribute :blacklisted_tokens, if: :admin?
+  attribute :archived_tokens, if: :admin?
   attributes :tokens
 
   # This is to keep some kind of ascending compatibility with the dashboard
@@ -17,6 +18,10 @@ class UserShowSerializer < ActiveModel::Serializer
 
   def blacklisted_tokens
     object.blacklisted_jwt
+  end
+
+  def archived_tokens
+    object.archived_jwt
   end
 
   def admin?

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -125,7 +125,8 @@ describe UsersController, type: :controller do
             note: '',
             tokens: [],
             contacts: [],
-            blacklisted_tokens: []
+            blacklisted_tokens: [],
+            archived_tokens: []
           })
         end
       end
@@ -135,7 +136,7 @@ describe UsersController, type: :controller do
   end
 
   describe '#show' do
-    let(:user) { create(:user, :with_jwt, :with_blacklisted_jwt) }
+    let(:user) { create(:user, :with_jwt, :with_blacklisted_jwt, :with_archived_jwt) }
 
     shared_examples 'show user' do
       it 'returns the user data' do
@@ -181,6 +182,14 @@ describe UsersController, type: :controller do
             blacklisted_tokens: a_collection_including(a_kind_of(String))
           )
         end
+
+        it 'shows archived jwt' do
+          get :show, params: { id: user.id }
+
+          expect(response_json).to include(
+            archived_tokens: a_collection_including(a_kind_of(String))
+          )
+        end
       end
 
       it 'also returns the user note attribute' do
@@ -210,6 +219,12 @@ describe UsersController, type: :controller do
         get :show, params: { id: user.id }
 
         expect(response_json).to_not include(:blacklisted_tokens)
+      end
+
+      it 'does not return the user archived jwt' do
+        get :show, params: { id: user.id }
+
+        expect(response_json).to_not include(:archived_tokens)
       end
 
       it 'denies access to other users data' do

--- a/spec/factories/jwt_api_entreprise.rb
+++ b/spec/factories/jwt_api_entreprise.rb
@@ -31,6 +31,10 @@ FactoryBot.define do
     blacklisted { true }
   end
 
+  trait :archived do
+    archived { true }
+  end
+
   trait :with_contacts do
     after(:create) do |jwt|
       create(:contact, :business, jwt_api_entreprise: jwt)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -26,5 +26,11 @@ FactoryBot.define do
         create(:jwt_api_entreprise, :blacklisted, user: u)
       end
     end
+
+    trait :with_archived_jwt do
+      after(:create) do |u|
+        create(:jwt_api_entreprise, :archived, user: u)
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -46,12 +46,7 @@ describe User do
     end
 
     context 'when one token is blacklisted' do
-      let!(:blacklisted_jwt) do
-        user
-          .jwt_api_entreprise
-          .first
-          .tap { |jwt| jwt.update(blacklisted: true) }
-      end
+      let!(:blacklisted_jwt) { create(:jwt_api_entreprise, :blacklisted, user: user) }
 
       it 'does not return blacklisted token with #encoded_jwt' do
         expect(user.encoded_jwt).not_to include blacklisted_jwt.rehash
@@ -60,6 +55,19 @@ describe User do
 
       it 'returns one #blacklisted_jwt'  do
         expect(user.blacklisted_jwt).to eq [blacklisted_jwt.rehash]
+      end
+    end
+
+    context 'when one token is archived' do
+      let!(:archived_jwt) { create(:jwt_api_entreprise, :archived, user: user) }
+
+      it 'does not return blacklisted token with #encoded_jwt' do
+        expect(user.encoded_jwt).not_to include archived_jwt.rehash
+        expect(user.encoded_jwt.size).to eq (user.jwt_api_entreprise.size - 1)
+      end
+
+      it 'returns one #archived_jwt'  do
+        expect(user.archived_jwt).to eq [archived_jwt.rehash]
       end
     end
 


### PR DESCRIPTION
### Contenu de la PR 
Ajoute la liste des jetons archivés dans la payload de retour du détail d'un utilisateur (sur le même principe que les jetons blacklistés).