### PR TITLE
Remove the 'french number format' validation rules for contacts

### DIFF
--- a/app/concepts/contact/contract/upsert.rb
+++ b/app/concepts/contact/contract/upsert.rb
@@ -8,7 +8,7 @@ module Contact::Contract
       required(:email).filled(
         format?: /\A[a-zA-Z0-9_.+\-]+@[a-zA-Z0-9\-]+\.[a-zA-Z0-9\-.]+\z/
       )
-      required(:phone_number).maybe(format?: /\A0\d(\d{2}){4}\z/)
+      required(:phone_number).maybe(:str?)
       required(:contact_type).filled(included_in?: %w(admin tech other))
     end
   end

--- a/spec/concepts/contact/contract_spec.rb
+++ b/spec/concepts/contact/contract_spec.rb
@@ -44,11 +44,11 @@ describe Contact::Contract::Upsert do
         expect(errors).to be_empty
       end
 
-      it 'has a french number format' do
-        contact_params[:phone_number] = '202-555-0110'
+      it 'can be anything' do # We won't validate any phone number format now...
+        contact_params[:phone_number] = '+33 coucou lol'
         contact_form.validate contact_params
 
-        expect(err_messages).to include('is in invalid format')
+        expect(errors).to be_empty
       end
     end
 


### PR DESCRIPTION
In order to accept DOM TOM phone number for example.