### PR TITLE
Alignement SIRET/cas d'usage et ID de la demande Signup 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-rbenv:
-  - 1.1.1
 cache: bundle
 service:
   - postgresql

--- a/app/concepts/access_demand/operation/import_from_ds.rb
+++ b/app/concepts/access_demand/operation/import_from_ds.rb
@@ -1,0 +1,51 @@
+module AccessDemand::Operation
+  class ImportFromDs < Trailblazer::Operation
+    step :init_csv_reader
+    step :import_users_siret
+    step :manual_updates
+
+
+    def init_csv_reader(ctx, **)
+      ctx[:csv_reader] = CsvReader.new('./csv_dumps/ds-export.csv')
+    end
+
+    def import_users_siret(ctx, csv_reader:, **)
+      csv_reader.line_by_line do |line|
+        next if ignore_request?(line)
+
+        email_from_dump = line['Email'].downcase
+        user = User.find_by_email!(real_email(email_from_dump))
+        next if user_context_equals_siret?(user)
+
+        user.update(context: line['Numéro de SIRET'])
+      end
+    end
+
+    # Manualy updating the few remaning entries
+    def manual_updates(ctx, **)
+      User.find('91d31930-890e-485f-968d-758db60df82e').update(context: '54585044800030')
+      User.find('fe15a4e2-87cf-4e35-b8b1-20f1957dda72').update(context: '43196025100061')
+      User.find('b609f239-1078-434c-a403-feee97c1004a').update(context: '79004395400029')
+    end
+
+    private
+
+    def ignore_request?(line)
+      return true if line['État du dossier'] != 'Accepté'
+      return true if line['ID'] == '377645' # Test de V.M.
+      return true if line['ID'] == '394171' # J'ai retrouvé le jeton grâce au siret 24400067500151, le user a été supprimé...
+      return true if line['ID'] == '466577' # Aucune entrée en base correspondante pour cette demande...
+
+      false
+    end
+
+    def user_context_equals_siret?(user)
+      user.context =~ /\d{14}/
+    end
+
+    # Manualy matching email used for dashboard account from DS request
+    def real_email(email)
+      DSEmailHash[email] || email
+    end
+  end
+end

--- a/app/concepts/access_demand/operation/import_from_signup.rb
+++ b/app/concepts/access_demand/operation/import_from_signup.rb
@@ -1,0 +1,40 @@
+module AccessDemand::Operation
+  class ImportFromSignup < Trailblazer::Operation
+    step :init_csv_reader
+    step :import_access_request_id
+
+
+    def init_csv_reader(ctx, **)
+      ctx[:csv_reader] = CsvReader.new('./csv_dumps/signup-export.csv', ';')
+    end
+
+    def import_access_request_id(ctx, csv_reader:, **)
+      csv_reader.line_by_line do |line|
+        next if ignore_request?(line)
+
+        email_from_export = line['email']
+        user = User.find_by_email!(real_email(email_from_export))
+
+        if line['signup_id'] == '1173' # This is a renewal request, setting the authorization_request_id to the right JWT manually
+          JwtApiEntreprise.find('e1ff50f2-426d-49a3-b1c9-04a5427d8ce7').update(authorization_request_id: '1173')
+        elsif user.jwt_api_entreprise.count == 1
+          user.jwt_api_entreprise.first.update(authorization_request_id: line['signup_id'])
+        else
+          raise StandardError.new('Moults tokens')
+        end
+      end
+    end
+
+    private
+
+    def real_email(email)
+      SignupEmailHash[email] || email
+    end
+
+    def ignore_request?(line)
+      return true if line['signup_id'] == '848' # Aucune entrée correspondante trouvée en base...
+
+      false
+    end
+  end
+end

--- a/app/concepts/csv_reader.rb
+++ b/app/concepts/csv_reader.rb
@@ -1,0 +1,21 @@
+require 'csv'
+
+class CsvReader
+  attr_reader :file, :options
+
+  def initialize(file, col_sep = ',')
+    @file = file
+    @options = default_options(col_sep)
+  end
+
+  def line_by_line()
+    ::CSV.read(file, options).each { |row| yield(row) }
+  end
+
+  def default_options(sep)
+    {
+      col_sep: sep,
+      headers: true,
+    }
+  end
+end

--- a/app/concepts/jwt_api_entreprise/contract/create.rb
+++ b/app/concepts/jwt_api_entreprise/contract/create.rb
@@ -1,6 +1,7 @@
 module JwtApiEntreprise::Contract
   class Create < Reform::Form
     property :user_id
+    property :authorization_request_id
     property :subject
 
     validation do
@@ -15,6 +16,7 @@ module JwtApiEntreprise::Contract
 
       required(:user_id).filled(:str?, :user_exists?)
       required(:subject).filled(:str?)
+      required(:authorization_request_id).filled(:str?)
 
       # TODO Add a high level validation rule here to ensure at least one
       # business and one tech contact is provided in the payload

--- a/config/initializers/access_request_import.rb
+++ b/config/initializers/access_request_import.rb
@@ -1,0 +1,9 @@
+if File.exists?('csv_dumps/match_account_email.json')
+  file = File.read('csv_dumps/match_account_email.json')
+  DSEmailHash = JSON.parse(file)['DS']
+end
+
+if File.exists?('csv_dumps/match_account_email.json')
+  file = File.read('csv_dumps/match_account_email.json')
+  SignupEmailHash = JSON.parse(file)['SIGNUP']
+end

--- a/db/migrate/20200117133206_add_temp_use_case_to_jwt_api_entreprise.rb
+++ b/db/migrate/20200117133206_add_temp_use_case_to_jwt_api_entreprise.rb
@@ -1,0 +1,11 @@
+class AddTempUseCaseToJwtApiEntreprise < ActiveRecord::Migration[6.0]
+  def change
+    add_column :jwt_api_entreprises, :temp_use_case, :string, default: nil
+
+    # Fetching JWT where the subject equals to a SIRET number so we can set
+    # the new and temporary attribute to it's user context (containing the
+    # actual use case of the token).
+    jwt_to_update = JwtApiEntreprise.where.not(user_id: nil).where("subject ~ '\\d{14}'")
+    jwt_to_update.each { |j| j.update(temp_use_case: j.user.context) }
+  end
+end

--- a/db/migrate/20200122133628_add_demande_id_to_jwt_api_entreprise.rb
+++ b/db/migrate/20200122133628_add_demande_id_to_jwt_api_entreprise.rb
@@ -1,0 +1,5 @@
+class AddDemandeIdToJwtApiEntreprise < ActiveRecord::Migration[6.0]
+  def change
+    add_column :jwt_api_entreprises, :demande_id, :string, default: nil
+  end
+end

--- a/db/migrate/20200123140518_rename_jwt_demande_id.rb
+++ b/db/migrate/20200123140518_rename_jwt_demande_id.rb
@@ -1,0 +1,5 @@
+class RenameJwtDemandeId < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :jwt_api_entreprises, :demande_id, :authorization_request_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_30_093629) do
+ActiveRecord::Schema.define(version: 2020_01_23_140518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -45,6 +45,8 @@ ActiveRecord::Schema.define(version: 2019_12_30_093629) do
     t.boolean "blacklisted", default: false
     t.json "days_left_notification_sent", default: [], null: false
     t.boolean "archived", default: false
+    t.string "temp_use_case"
+    t.string "authorization_request_id"
     t.index ["user_id"], name: "index_jwt_api_entreprises_on_user_id"
   end
 

--- a/spec/concepts/jwt_api_entreprise/operation/create_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/create_spec.rb
@@ -7,6 +7,7 @@ describe JwtApiEntreprise::Operation::Create do
   let(:token_params) do
     {
       user_id: user.id,
+      authorization_request_id: '1234',
       roles: roles_code,
       subject: 'So testy',
       contacts: [
@@ -39,6 +40,10 @@ describe JwtApiEntreprise::Operation::Create do
 
     it 'belongs to the correct user' do
       expect(created_token.user).to eq(user)
+    end
+
+    it 'saves the related authorization request id' do
+      expect(created_token.authorization_request_id).to eq(token_params[:authorization_request_id])
     end
 
     it 'is has the valid access rights' do
@@ -133,6 +138,24 @@ describe JwtApiEntreprise::Operation::Create do
 
         expect(subject).to be_failure
         expect(errors).to include('user with ID "not a user id" does not exist')
+      end
+    end
+
+    describe ':authorization_request_id' do
+      let(:errors) { subject['result.contract.default'].errors[:authorization_request_id] }
+
+      it 'is required' do
+        token_params.delete(:authorization_request_id)
+
+        expect(subject).to be_failure
+        expect(errors).to include('must be filled')
+      end
+
+      it 'is a string' do
+        token_params[:authorization_request_id] = true
+
+        expect(subject).to be_failure
+        expect(errors).to include('must be a string')
       end
     end
 

--- a/spec/controllers/jwt_api_entreprise_controller_spec.rb
+++ b/spec/controllers/jwt_api_entreprise_controller_spec.rb
@@ -23,6 +23,7 @@ describe JwtApiEntrepriseController, type: :controller do
       {
         roles: jwt_roles,
         user_id: user.id,
+        authorization_request_id: '1234',
         subject: 'coucou',
         contacts: [
           {

--- a/spec/factories/jwt_api_entreprise.rb
+++ b/spec/factories/jwt_api_entreprise.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :jwt_api_entreprise do
     subject { 'Humm testy' }
+    authorization_request_id { '1234' }
     iat { Time.zone.now.to_i }
     exp { 18.months.from_now.to_i }
     blacklisted { false }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -108,7 +108,7 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  # config.order = :random
+  config.order = :random
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce


### PR DESCRIPTION
### Contenu de la PR 
Les quatre premiers commits concernent les scripts d'import des données depuis l'export des demandes réalisées dans DS et Signup. Je n'ai pas fait de specs, mais vérifié en base que tout marchait bien, et dans les trois quarts du temps j'ai fait les rapprochements à la main. Je compte bien faire un backup avant d'effectuer l'opération en prod dans tous les cas.

Le dernier commit concerne l'ajout de l'ID de la demande Signup lors de la création d'un JWT. C'est pour pouvoir rediriger l'utilisateur vers sa demande, depuis les informations de son jeton dans le dashboard ou lors du renouvellement.

### Déploiement en production 

1. Choisir un créneau de "maintenance". Plus de validation de demande dans Signup, de création d'utilisateurs ou de jetons ; si tout se passe bien ça ne prendra pas plus de quelques minutes. 
2. Backup de la BDD de prod
3. Déployer 
4. Copier l'export DS et le fichier JSON de configuration d'emails dans `csv_dumps` sur le serveur
5. Exporter les dernières demandes validée dans Signup pour récupérer l'ID et le "ranger" dans `csv_dumps/signup-export,csv`. 
6. En console : `AccessDemand::Operation::ImportFromDs.call` puis `AccessDemand::Operation::ImportFromSignup.call `
7. Code à supprimer : 
    * `app/concept/access_demand` 
    * `app/concepts/csv_reader.rb` 
    * `csv_dumps`
    * `config/initializers/access_request_import.rb`