### PR TITLE
JWT index et détails 

### DIFF
--- a/app/controllers/jwt_api_entreprise_controller.rb
+++ b/app/controllers/jwt_api_entreprise_controller.rb
@@ -3,7 +3,7 @@ class JwtApiEntrepriseController < ApplicationController
     authorize :admin, :admin?
 
     jwt_list = JwtApiEntreprise.all
-    render json: jwt_list, each_serializer: JwtApiEntrepriseSerializer, status: 200
+    render json: jwt_list, each_serializer: JwtApiEntrepriseIndexSerializer, status: 200
   end
 
   def create

--- a/app/controllers/jwt_api_entreprise_controller.rb
+++ b/app/controllers/jwt_api_entreprise_controller.rb
@@ -1,4 +1,11 @@
 class JwtApiEntrepriseController < ApplicationController
+  def index
+    authorize :admin, :admin?
+
+    jwt_list = JwtApiEntreprise.all
+    render json: jwt_list, each_serializer: JwtApiEntrepriseSerializer, status: 200
+  end
+
   def create
     authorize :admin, :admin?
     result = JwtApiEntreprise::Operation::Create.call(params: params)

--- a/app/models/jwt_api_entreprise.rb
+++ b/app/models/jwt_api_entreprise.rb
@@ -19,6 +19,13 @@ class JwtApiEntreprise < ApplicationRecord
     Set[*contacts.pluck(:email)] << user.email
   end
 
+  # TODO XXX This is temporary, the real "subject" of a JWT is set into the
+  # #temp_use_case attribute when the #subject was fill with a SIRET number
+  # (legacy reasons). Fix when the #temp_use_case attirbute isn't use anymore
+  def displayed_subject
+    temp_use_case || subject
+  end
+
   private
 
   def token_payload

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,16 +28,9 @@ class User < ApplicationRecord
     jwt_api_entreprise.where(blacklisted: false, archived: false).map(&:rehash)
   end
 
-  def blacklisted_jwt
-    jwt_api_entreprise.where(blacklisted: true).map(&:rehash)
-  end
-
-  def archived_jwt
-    jwt_api_entreprise.where(archived: true).map(&:rehash)
-  end
-
   private
 
+  # TODO XXX FIXME This may be dead code, test to remove it
   def combine_roles_from_tokens
     roles = self.jwt_api_entreprise.reduce([]) { |result, jwt| result + jwt.access_roles }
     roles.uniq

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,17 +24,7 @@ class User < ApplicationRecord
     update(pwd_renewal_token: random_token_for(:pwd_renewal_token))
   end
 
-  def encoded_jwt
-    jwt_api_entreprise.where(blacklisted: false, archived: false).map(&:rehash)
-  end
-
   private
-
-  # TODO XXX FIXME This may be dead code, test to remove it
-  def combine_roles_from_tokens
-    roles = self.jwt_api_entreprise.reduce([]) { |result, jwt| result + jwt.access_roles }
-    roles.uniq
-  end
 
   def random_token_for(attr)
     constraint = {}

--- a/app/serializers/contact_serializer.rb
+++ b/app/serializers/contact_serializer.rb
@@ -9,7 +9,7 @@ class ContactSerializer < ActiveModel::Serializer
   )
 
   def jwt_usage_policy
-    object.jwt_api_entreprise.subject
+    object.jwt_api_entreprise.displayed_subject
   end
 
   def jwt_id

--- a/app/serializers/jwt_api_entreprise_index_serializer.rb
+++ b/app/serializers/jwt_api_entreprise_index_serializer.rb
@@ -1,4 +1,4 @@
-class JwtApiEntrepriseSerializer < ActiveModel::Serializer
+class JwtApiEntrepriseIndexSerializer < ActiveModel::Serializer
   attributes :id, :user_id, :iat, :exp, :blacklisted, :archived
 
   attribute :subject

--- a/app/serializers/jwt_api_entreprise_serializer.rb
+++ b/app/serializers/jwt_api_entreprise_serializer.rb
@@ -1,0 +1,9 @@
+class JwtApiEntrepriseSerializer < ActiveModel::Serializer
+  attributes :id, :user_id, :iat, :exp, :blacklisted, :archived
+
+  attribute :subject
+
+  def subject
+    object.displayed_subject
+  end
+end

--- a/app/serializers/jwt_api_entreprise_show_serializer.rb
+++ b/app/serializers/jwt_api_entreprise_show_serializer.rb
@@ -1,0 +1,18 @@
+class JwtApiEntrepriseShowSerializer < ActiveModel::Serializer
+  attributes :id, :authorization_request_id, :iat, :exp, :blacklisted, :archived
+  attribute :subject
+  attribute :secret_key
+  attribute :roles
+
+  def subject
+    object.displayed_subject
+  end
+
+  def secret_key
+    object.rehash
+  end
+
+  def roles
+    object.access_roles
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,8 @@ Rails.application.routes.draw do
     post '/users/password_reset'   => 'users#password_reset'
 
     # jwt_api_entreprise
-    post '/users/:user_id/jwt_api_entreprise' => 'jwt_api_entreprise#create'
-    patch '/jwt_api_entreprise/:id'           => 'jwt_api_entreprise#update'
+    get   '/jwt_api_entreprise'                => 'jwt_api_entreprise#index'
+    post  '/users/:user_id/jwt_api_entreprise' => 'jwt_api_entreprise#create'
+    patch '/jwt_api_entreprise/:id'            => 'jwt_api_entreprise#update'
   end
 end

--- a/spec/controllers/jwt_api_entreprise_controller_spec.rb
+++ b/spec/controllers/jwt_api_entreprise_controller_spec.rb
@@ -13,6 +13,44 @@ describe JwtApiEntrepriseController, type: :controller do
     }
   end
 
+  describe '#index' do
+    before { create_list(:jwt_api_entreprise, 8) }
+
+    context 'when requested from an admin' do
+      include_context 'admin request'
+
+      it 'returns an HTTP code 200' do
+        get :index
+
+        expect(response.code).to eq('200')
+      end
+
+      it 'returns all JWT from the database' do
+        get :index
+
+        expect(response_json.size).to eq(8)
+      end
+
+      it 'has a valid payload' do
+        get :index
+
+        expect(response_json).to all(
+          match({
+            id: String,
+            user_id: String,
+            subject: String,
+            iat: Integer,
+            exp: Integer,
+            blacklisted: be(true).or(be(false)),
+            archived: be(true).or(be(false))
+          })
+        )
+      end
+    end
+
+    it_behaves_like 'client user unauthorized', :get, :index
+  end
+
   describe '#create' do
     let(:user) { UsersFactory.confirmed_user }
     let(:jwt_roles) do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,12 +2,12 @@ FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "user_#{n}@example.org" }
     context { 'VERY_DEVELOPMENT' }
+    cgu_agreement_date { Time.zone.now.to_i }
 
     # TODO make user factory confirmed by default
     # use an :inactive_user factory for this specific state
-    factory :confirmed_user do
+    trait :confirmed do
       confirmed_at { Time.zone.now.to_i }
-      cgu_agreement_date { Time.zone.now.to_i }
     end
 
     factory :admin do

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -86,6 +86,23 @@ describe JwtApiEntreprise, type: :model do
     end
   end
 
+  # TODO XXX This is temporary, the real "subject" of a JWT is set into the
+  # #temp_use_case attribute when the #subject was fill with a SIRET number
+  # (legacy reasons). Fix when the #temp_use_case attirbute isn't use anymore
+  describe '#displayed_subject' do
+    it 'returns the #subject value if #temp_use_case is nil' do
+      j = create(:jwt_api_entreprise, subject: 'coucou subject', temp_use_case: nil)
+
+      expect(j.displayed_subject).to eq('coucou subject')
+    end
+
+    it 'returns #temp_use_case value if it is not nil' do
+      j = create(:jwt_api_entreprise, subject: 'coucou subject', temp_use_case: 'coucou use case')
+
+      expect(j.displayed_subject).to eq('coucou use case')
+    end
+  end
+
   describe '#user_and_contacts_email' do
     let(:jwt) { create(:jwt_api_entreprise, :with_contacts) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -39,35 +39,4 @@ describe User do
       expect(user.confirmation_token).to match(/\A[0-9a-f]{20}\z/)
     end
   end
-
-  describe '#encoded_jwt' do
-    it 'returns an array of all user\'s jwt' do
-      expect(user.encoded_jwt.size).to eq(user.jwt_api_entreprise.size)
-    end
-
-    context 'when one token is blacklisted' do
-      let!(:blacklisted_jwt) { create(:jwt_api_entreprise, :blacklisted, user: user) }
-
-      it 'does not return blacklisted token with #encoded_jwt' do
-        expect(user.encoded_jwt).not_to include blacklisted_jwt.rehash
-        expect(user.encoded_jwt.size).to eq (user.jwt_api_entreprise.size - 1)
-      end
-    end
-
-    context 'when one token is archived' do
-      let!(:archived_jwt) { create(:jwt_api_entreprise, :archived, user: user) }
-
-      it 'does not return blacklisted token with #encoded_jwt' do
-        expect(user.encoded_jwt).not_to include archived_jwt.rehash
-        expect(user.encoded_jwt.size).to eq (user.jwt_api_entreprise.size - 1)
-      end
-    end
-
-    context 'JWT generation' do
-      before { expect_any_instance_of(JwtApiEntreprise).to receive(:rehash).and_return('Much token') }
-
-      # TODO learn how to stub this
-      pending 'is delegated to the Role#rehash method'
-    end
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -52,10 +52,6 @@ describe User do
         expect(user.encoded_jwt).not_to include blacklisted_jwt.rehash
         expect(user.encoded_jwt.size).to eq (user.jwt_api_entreprise.size - 1)
       end
-
-      it 'returns one #blacklisted_jwt'  do
-        expect(user.blacklisted_jwt).to eq [blacklisted_jwt.rehash]
-      end
     end
 
     context 'when one token is archived' do
@@ -64,10 +60,6 @@ describe User do
       it 'does not return blacklisted token with #encoded_jwt' do
         expect(user.encoded_jwt).not_to include archived_jwt.rehash
         expect(user.encoded_jwt.size).to eq (user.jwt_api_entreprise.size - 1)
-      end
-
-      it 'returns one #archived_jwt'  do
-        expect(user.archived_jwt).to eq [archived_jwt.rehash]
       end
     end
 

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -6,7 +6,7 @@ end
 
 RSpec.shared_context 'user request' do
   before do
-    user = create(:confirmed_user)
+    user = create(:user, :confirmed)
     fill_request_headers_with_user_jwt(user.id)
   end
 end


### PR DESCRIPTION
### Contenu de la PR 
* Ajout d'un endpoint pour servir la liste complète des JWT (uniquement pour un administrateur évidemment) ; objectifs : recherche par cas d'usage, suivi des jetons arrivant à expiration, ...
* **breaking change** dans la payload du détail d'un utilisateur, notamment la liste des JWTs lui appartenant : 
  * avant : on renvoyait la liste des JWT (les clés secrètes elles même) uniquement ; comme il s'agit de JWT cela ne posait pas de problème, le front peut décoder la payload et récupérer les données du jeton (rôles d'accès, cas d'usage, date d'expiration, ...)
  * maintenant : on renvoie le jeton (son hash, la clé) ainsi que les données qui y sont associées, le tout dans un "dictionnaire JSON" ; la raison initiale qui m'a poussée à faire ça c'est que j'avais besoin de renvoyer un *subject* pour l'affichage (l'intitulé du cas d'usage du jeton) potentiellement différent du subject de la payload du jeton (lorsque initialement créé avec un numéro SIRET). Après un moment de réflection j'ai opté pour un refactor assez complet, car je n'avais pas envie de faire un patch un peu dégueux pour cette histoire de *subject*, et parce que ce format de payload s'inscrit dans la volonté d'une mutualisation du dashboard : cela peut maintenant être utilisé tel quel quel que soit le format de jeton, là où précédemment ça ne pouvait marcher qu'avec des JWTs. Et honnêtement je trouve la base de code plus propre comme ça ^^

### Comment faire la review
C'est pas forcément très conséquent, mais le refactor sera plus facilement visible commits par commits amha.

### Ce qu'il reste à faire 
Mettre le front à jour