### PR TITLE
Update oauth api gouv

### DIFF
--- a/app/concepts/user/contract/update.rb
+++ b/app/concepts/user/contract/update.rb
@@ -1,9 +1,11 @@
 module User::Contract
   class Update < Reform::Form
     property :note
+    property :oauth_api_gouv_id
 
     validation do
       required(:note).maybe(:str?)
+      required(:oauth_api_gouv_id).maybe(:int?)
     end
   end
 end

--- a/app/concepts/user/operation/update.rb
+++ b/app/concepts/user/operation/update.rb
@@ -2,10 +2,11 @@ class User
   module Operation
     class Update < Trailblazer::Operation
       step Model(User, :find_by)
-      fail ->(options, params:, **) { options[:errors] = "User with id `#{params[:id]}` does not exist." }
+      fail ->(options, params:, **) { options[:errors] = "User with id `#{params[:id]}` does not exist." }, fail_fast: true
 
       step self::Contract::Build(constant: User::Contract::Update)
       step self::Contract::Validate()
+      fail ->(ctx, **) { ctx[:errors] = ctx['result.contract.default'].errors.messages }
       step self::Contract::Persist()
     end
   end

--- a/app/serializers/user_index_serializer.rb
+++ b/app/serializers/user_index_serializer.rb
@@ -1,5 +1,5 @@
 class UserIndexSerializer < ActiveModel::Serializer
-  attributes :id, :email, :context, :confirmed, :created_at
+  attributes :id, :email, :context, :oauth_api_gouv_id, :confirmed, :created_at
 
   def confirmed
     object.confirmed?

--- a/app/serializers/user_show_serializer.rb
+++ b/app/serializers/user_show_serializer.rb
@@ -1,5 +1,5 @@
 class UserShowSerializer < ActiveModel::Serializer
-  attributes :id, :email, :context
+  attributes :id, :email, :context, :oauth_api_gouv_id
   attribute :note, if: :admin?
 
   # This is to keep some kind of ascending compatibility with the dashboard

--- a/spec/concepts/user/operation/update_spec.rb
+++ b/spec/concepts/user/operation/update_spec.rb
@@ -5,7 +5,8 @@ describe User::Operation::Update do
   let(:operation_params) do
     {
       id: user_id,
-      note: 'Updated description'
+      note: 'Updated description',
+      oauth_api_gouv_id: 9001
     }
   end
   subject { described_class.call(params: operation_params) }
@@ -37,10 +38,31 @@ describe User::Operation::Update do
         expect(subject).to be_success
       end
 
-      it 'can be update' do
+      it 'can be updated' do
         updated_user = subject[:model]
 
         expect(updated_user.note).to eq('Updated description')
+      end
+    end
+
+    describe '#oauth_api_gouv_id' do
+      it 'is optional' do
+        operation_params.delete(:oauth_api_gouv_id)
+
+        expect(subject).to be_success
+      end
+
+      it 'must be an integer' do
+        operation_params[:oauth_api_gouv_id] = '42'
+
+        expect(subject).to be_failure
+        expect(subject[:errors]).to eq(oauth_api_gouv_id: ["must be an integer"])
+      end
+
+      it 'can be updated' do
+        updated_user = subject[:model]
+
+        expect(updated_user.oauth_api_gouv_id).to eq(9001)
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -32,6 +32,7 @@ describe UsersController, type: :controller do
             email: a_kind_of(String),
             context: a_kind_of(String),
             confirmed: be(true).or(be(false)),
+            oauth_api_gouv_id: a_kind_of(Integer),
             created_at: a_kind_of(String),
           }))
         end
@@ -116,6 +117,7 @@ describe UsersController, type: :controller do
             id: a_kind_of(String),
             email: a_kind_of(String),
             context: a_kind_of(String),
+            oauth_api_gouv_id: a_kind_of(Integer),
             note: '',
             tokens: [],
             contacts: [],
@@ -140,6 +142,7 @@ describe UsersController, type: :controller do
           id: a_kind_of(String),
           email: a_kind_of(String),
           context: a_kind_of(String),
+          oauth_api_gouv_id: a_kind_of(Integer),
           tokens: a_collection_including(
             a_hash_including({
               id: String,

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -365,18 +365,19 @@ describe UsersController, type: :controller do
     let(:user_params) do
       {
         id: user.id,
-        note: 'Test update'
+        note: 'Test update',
+        oauth_api_gouv_id: 9001
       }
     end
 
-    subject { put :update, params: user_params }
+    subject(:update_user!) { put :update, params: user_params, as: :json }
 
     context 'when requested from a user' do
       include_context 'user request'
       it_behaves_like 'client user unauthorized', :put, :update, { id: 'random' }
 
       it 'does not update the user' do
-        subject
+        update_user!
         user.reload
 
         expect(user.note).not_to eq('Test update')
@@ -388,15 +389,19 @@ describe UsersController, type: :controller do
 
       context 'when params are valid' do
         it 'returns code 200' do
-          subject
+          update_user!
+
           expect(response.code).to eq('200')
         end
 
         it 'updates the user' do
-          subject
+          update_user!
           user.reload
 
-          expect(user.note).to eq('Test update')
+          expect(user).to have_attributes({
+            note: 'Test update',
+            oauth_api_gouv_id: 9001
+          })
         end
       end
     end


### PR DESCRIPTION
Renvoyer l'ID des comptes API Gouv dans les payload de données relatives aux utilisateurs (index, update, etc...) et faire en sorte que l'attribut puisse  être mis à jour.

Closes #75 