### PR TITLE
Fix/i18n missing translation data

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,8 +38,8 @@ module AdminApientreprise
     config.reform.validations = :dry
 
     config.time_zone = 'Europe/Paris'
-    config.i18n.available_locales = [:fr_FR]
-    config.i18n.default_locale = :fr_FR
+    config.i18n.available_locales = [:fr]
+    config.i18n.default_locale = :fr
 
     config.active_job.queue_adapter = :sidekiq
     config.active_job.queue_name_prefix = "admin_api_entreprise_#{Rails.env}"


### PR DESCRIPTION
Cette PR permet notamment d'utiliser `Faker`.

Avant :

```ruby
Faker::Name.name
```

> I18n::MissingTranslationData: translation missing: en.faker.name.name

Après :

```ruby
Faker::Name.name # => "Dr Ambre Robert"
```