### PR TITLE
chore(rspec): allow to deterministically reproduce failures

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -116,5 +116,5 @@ RSpec.configure do |config|
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
-  # Kernel.srand config.seed
+  Kernel.srand config.seed
 end


### PR DESCRIPTION
Cette PR modifie [un paramètre](https://rubydoc.info/github/rspec/rspec-core/RSpec/Core/Configuration#seed-instance_method) RSpec afin de pouvoir rejouer à l'identique la suite de tests aléatoires.