### PR TITLE
Chore/disable rspec monkey patching

### DIFF
--- a/spec/concepts/contact/contract_spec.rb
+++ b/spec/concepts/contact/contract_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 # TODO Move those specs into future contact creation operation
-describe Contact::Contract::Upsert do
+RSpec.describe Contact::Contract::Upsert do
   let(:contact_params) { attributes_for :contact }
 
   describe 'contact creation' do

--- a/spec/concepts/incident/operation/create_spec.rb
+++ b/spec/concepts/incident/operation/create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Incident::Operation::Create do
+RSpec.describe Incident::Operation::Create do
   let(:operation_params) do
     {
       title: 'Test incident',

--- a/spec/concepts/incident/operation/save_spec.rb
+++ b/spec/concepts/incident/operation/save_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Incident::Operation::Save do
+RSpec.describe Incident::Operation::Save do
   let(:operation_params) do
     {
       title: 'Test incident',

--- a/spec/concepts/incident/operation/update_spec.rb
+++ b/spec/concepts/incident/operation/update_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Incident::Operation::Update do
+RSpec.describe Incident::Operation::Update do
   let(:operation_params) do
     {
       id: incident_id,

--- a/spec/concepts/jwt_api_entreprise/operation/create_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JwtApiEntreprise::Operation::Create do
+RSpec.describe JwtApiEntreprise::Operation::Create do
   let(:user) { create(:user) }
   let(:roles) { create_list(:role, 7) }
   let(:roles_code) { roles.map { |attr| attr.slice(:code) } }

--- a/spec/concepts/jwt_api_entreprise/operation/notify_expiration_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/notify_expiration_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JwtApiEntreprise::Operation::NotifyExpiration do
+RSpec.describe JwtApiEntreprise::Operation::NotifyExpiration do
   describe 'expire_in: option (provide a number of days)' do
     # Let's test with a 90 days (3 months) expiration notice
     let(:days) { 90 }

--- a/spec/concepts/jwt_api_entreprise/operation/purge_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/purge_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JwtApiEntreprise::Operation::Purge do
+RSpec.describe JwtApiEntreprise::Operation::Purge do
   subject(:purge!) { described_class.call }
 
   context 'when a JWT has expired' do

--- a/spec/concepts/jwt_api_entreprise/operation/update_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/update_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JwtApiEntreprise::Operation::Update do
+RSpec.describe JwtApiEntreprise::Operation::Update do
   subject(:update_jwt!) { described_class.call(params: op_params) }
 
   context 'when the JWT id is valid' do

--- a/spec/concepts/oauth_api_gouv/operation/login_spec.rb
+++ b/spec/concepts/oauth_api_gouv/operation/login_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe OAuthApiGouv::Operation::Login, type: :jwt do
+RSpec.describe OAuthApiGouv::Operation::Login, type: :jwt do
   let(:op_params) do
     { authorization_code: code }
   end

--- a/spec/concepts/oauth_api_gouv/tasks/retrieve_access_token_spec.rb
+++ b/spec/concepts/oauth_api_gouv/tasks/retrieve_access_token_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe OAuthApiGouv::Tasks::RetrieveAccessToken do
+RSpec.describe OAuthApiGouv::Tasks::RetrieveAccessToken do
   subject(:retrieve_tokens!) { described_class.call(authorization_code: code) }
 
   context 'when the authorization code is valid' do

--- a/spec/concepts/oauth_api_gouv/tasks/retrieve_user_info_spec.rb
+++ b/spec/concepts/oauth_api_gouv/tasks/retrieve_user_info_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe OAuthApiGouv::Tasks::RetrieveUserInfo do
+RSpec.describe OAuthApiGouv::Tasks::RetrieveUserInfo do
   subject(:fetch_user!) { described_class.call(access_token: token) }
 
   context 'when the access token is valid', vcr: { cassette_name: 'oauth_api_gouv_user_info_valid_token' } do

--- a/spec/concepts/role/operation/create_spec.rb
+++ b/spec/concepts/role/operation/create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Role::Operation::Create do
+RSpec.describe Role::Operation::Create do
   let(:role_params) do
     { name: 'Role test', code: 'rol1' }
   end

--- a/spec/concepts/role/operation/db_seed_spec.rb
+++ b/spec/concepts/role/operation/db_seed_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Role::Operation::DBSeed do
+RSpec.describe Role::Operation::DBSeed do
   describe 'with custom roles seed' do
     subject { described_class.call roles_seed: roles_seed }
 

--- a/spec/concepts/user/operation/ask_password_renewal_spec.rb
+++ b/spec/concepts/user/operation/ask_password_renewal_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User::Operation::AskPasswordRenewal do
+RSpec.describe User::Operation::AskPasswordRenewal do
   let(:op_params) { { email: account_email } }
 
   subject(:pwd_renewal_request) { described_class.call(params: op_params) }

--- a/spec/concepts/user/operation/create_ghost_spec.rb
+++ b/spec/concepts/user/operation/create_ghost_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User::Operation::CreateGhost do
+RSpec.describe User::Operation::CreateGhost do
   let(:op_params) do
     {
       email: 'new@record.com',

--- a/spec/concepts/user/operation/create_spec.rb
+++ b/spec/concepts/user/operation/create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User::Operation::Create do
+RSpec.describe User::Operation::Create do
   let(:user_email) { 'new@record.gg' }
   let(:user_params) do
     {

--- a/spec/concepts/user/operation/index_spec.rb
+++ b/spec/concepts/user/operation/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User::Operation::Index do
+RSpec.describe User::Operation::Index do
   before { create_list(:user, 8) }
 
   let(:op_params) { {} }

--- a/spec/concepts/user/operation/login_spec.rb
+++ b/spec/concepts/user/operation/login_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User::Operation::Login do
+RSpec.describe User::Operation::Login do
   let(:result) { described_class.call(params: login_params) }
 
   context 'when user email is unknown' do

--- a/spec/concepts/user/operation/reset_password_spec.rb
+++ b/spec/concepts/user/operation/reset_password_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User::Operation::ResetPassword do
+RSpec.describe User::Operation::ResetPassword do
   let(:user) { create(:user, pwd_renewal_token: 'coucou') }
   let(:reset_params) do
     {

--- a/spec/concepts/user/operation/transfer_ownership_spec.rb
+++ b/spec/concepts/user/operation/transfer_ownership_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User::Operation::TransferOwnership do
+RSpec.describe User::Operation::TransferOwnership do
   let(:end_state) { subject.event.to_h[:semantic] }
 
   subject { described_class.call(params: op_params) }

--- a/spec/concepts/user/operation/update_spec.rb
+++ b/spec/concepts/user/operation/update_spec.rb
@@ -1,7 +1,7 @@
 
 require 'rails_helper'
 
-describe User::Operation::Update do
+RSpec.describe User::Operation::Update do
   let(:operation_params) do
     {
       id: user_id,

--- a/spec/controllers/incidents_controller_spec.rb
+++ b/spec/controllers/incidents_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe IncidentsController, type: :controller do
+RSpec.describe IncidentsController, type: :controller do
   describe '#index' do
     let(:nb_incidents) { 5 }
     let(:body) { JSON.parse(response.body, symbolize_names: true) }

--- a/spec/controllers/jwt_api_entreprise_controller_spec.rb
+++ b/spec/controllers/jwt_api_entreprise_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JwtApiEntrepriseController, type: :controller do
+RSpec.describe JwtApiEntrepriseController, type: :controller do
   let(:token_params) do
     {
       roles: jwt_roles,

--- a/spec/controllers/oauth_api_gouv_controller_spec.rb
+++ b/spec/controllers/oauth_api_gouv_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe OAuthApiGouvController, type: :controller do
+RSpec.describe OAuthApiGouvController, type: :controller do
   describe '#login' do
     let(:login_params) { { authorization_code: code } }
 

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe RolesController, type: :controller do
+RSpec.describe RolesController, type: :controller do
   describe '#index' do
     let(:nb_roles) { 8 }
     before do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe UsersController, type: :controller do
+RSpec.describe UsersController, type: :controller do
   describe '#index' do
     before { create_list(:user, 5) }
 

--- a/spec/jobs/jwt_api_entreprise_expiration_notice_job_spec.rb
+++ b/spec/jobs/jwt_api_entreprise_expiration_notice_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JwtApiEntrepriseExpirationNoticeJob do
+RSpec.describe JwtApiEntrepriseExpirationNoticeJob do
   subject { described_class.perform_now }
 
   shared_examples 'sending expiration notices' do |nb_days|

--- a/spec/jobs/jwt_api_entreprise_purge_job_spec.rb
+++ b/spec/jobs/jwt_api_entreprise_purge_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JwtApiEntreprisePurgeJob do
+RSpec.describe JwtApiEntreprisePurgeJob do
   subject { described_class.perform_now }
 
   it 'calls the purge operation' do

--- a/spec/lib/access_token_spec.rb
+++ b/spec/lib/access_token_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe AccessToken do
+RSpec.describe AccessToken do
   context 'token encoding' do
     payload = { data: 'test', more_data: 'verytest' }
     token = described_class.create payload

--- a/spec/lib/account_access_token_spec.rb
+++ b/spec/lib/account_access_token_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 # TODO Replace "account" naming with "session"
 # JWT emited by doorkeeper on user login
-describe 'JWT for account data access', type: :jwt do
+RSpec.describe 'JWT for account data access', type: :jwt do
   let(:user) { create(:user) }
   let(:token_payload) do
     # call JWTF the way Doorkeeper does

--- a/spec/lib/jwt_user_spec.rb
+++ b/spec/lib/jwt_user_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JwtUser, type: :jwt do
+RSpec.describe JwtUser, type: :jwt do
   let(:token_payload) do
     # call JWTF the way Doorkeeper does
     token = JWTF.generate(resource_owner_id: user_id)

--- a/spec/mailers/jwt_api_entreprise_mailer_spec.rb
+++ b/spec/mailers/jwt_api_entreprise_mailer_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JwtApiEntrepriseMailer, type: :mailer do
+RSpec.describe JwtApiEntrepriseMailer, type: :mailer do
   describe 'Expiration notices (old and new)' do
     let(:jwt) { create(:jwt_api_entreprise, :with_contacts) }
     let(:user) { jwt.user }

--- a/spec/mailers/user_spec.rb
+++ b/spec/mailers/user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe UserMailer, type: :mailer do
+RSpec.describe UserMailer, type: :mailer do
   describe '#renew_account_password' do
     let(:user) { create(:user, pwd_renewal_token: 'coucou') }
 

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Contact do
+RSpec.describe Contact do
   describe 'db columns' do
     it { is_expected.to have_db_column(:id).of_type(:uuid) }
     it { is_expected.to have_db_column(:email).of_type(:string) }

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe JwtApiEntreprise, type: :model do
+RSpec.describe JwtApiEntreprise, type: :model do
   let(:jwt) { create(:jwt_api_entreprise) }
 
   describe 'db_columns' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe User do
+RSpec.describe User do
   let(:user) { create :user, :with_jwt }
 
   describe 'db_columns' do

--- a/spec/request_authentication_spec.rb
+++ b/spec/request_authentication_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Request authentication', type: :controller do
+RSpec.describe 'Request authentication', type: :controller do
   # Use of anonymous controller with random action which inherits from
   # ApplicationController to test authentication callback genericity
   controller(ApplicationController) do

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'Application routes' do
+RSpec.describe 'Application routes' do
   describe 'incidents' do
     it 'has an index route' do
       expect(get('api/admin/incidents'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,7 +89,7 @@ RSpec.configure do |config|
   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  # config.disable_monkey_patching!
+  config.disable_monkey_patching!
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an


### PR DESCRIPTION
Cette PR propose de désactiver la syntaxe RSpec issue du [monkey-patching](https://rubydoc.info/github/rspec/rspec-core/RSpec/Core/Configuration#disable_monkey_patching%21-instance_method). Cela permet en particulier de ne pas ajouter dans le module `Kernel` de Ruby la méthode de classe `describe` de RSpec.