### PR TITLE
chore(test, development): raises error for missing translations

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   config.active_job.queue_adapter = :async
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -52,7 +52,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true


### PR DESCRIPTION
Cette PR propose de déclencher une exception si d'aventure une traduction n'est pas présente.
Seulement environnement de test et de développement.