### PR TITLE
fix(mail): remove <a> tags from plain-text templates

### DIFF
--- a/app/views/jwt_api_entreprise_mailer/creation_notice.text.erb
+++ b/app/views/jwt_api_entreprise_mailer/creation_notice.text.erb
@@ -2,9 +2,11 @@ Bonjour,
 
 Un nouveau token est disponible dans votre espace client.
 
-Vous pouvez le récupérer en suivant ce lien : <%= @url_to_jwt  %>
+Vous pouvez le récupérer en suivant ce lien :
 
-Ce token possède les droits d'accès suivants :
+<%= @url_to_jwt %>
+
+Ce token possède les droits d'accès suivants :
 <% @jwt.roles.each do |role| %>
   - <%= role.name %>
 <% end %>

--- a/app/views/jwt_api_entreprise_mailer/expiration_notice.text.erb
+++ b/app/views/jwt_api_entreprise_mailer/expiration_notice.text.erb
@@ -6,7 +6,7 @@ En effet, le jeton attribué dans le cadre d'utilisation "<%= @jwt.subject %>" (
 
 Passée la date du <%= @jwt.user_friendly_exp_date %> les appels à API Entreprise avec ce jeton seront rejetés.
 
-Le lien <%= link_to('suivant', @jwt.renewal_url) %> vous permet de demander le renouvellement de votre jeton. Le formulaire a été pré-rempli avec les données fournies lors de votre précédente demande d'accès, veuillez cependant vérifier que les informations sont à jour (notamment les coordonnées de contact) et les re-saisir dans le cas contraire. De plus, de nouvelles sources de données auxquelles vous auriez accès sont potentiellement disponibles depuis votre dernière demande !
+Le lien <%= @jwt.renewal_url %> vous permet de demander le renouvellement de votre jeton. Le formulaire a été pré-rempli avec les données fournies lors de votre précédente demande d'accès, veuillez cependant vérifier que les informations sont à jour (notamment les coordonnées de contact) et les re-saisir dans le cas contraire. De plus, de nouvelles sources de données auxquelles vous auriez accès sont potentiellement disponibles depuis votre dernière demande !
 
 N'hésitez pas à contacter le support en répondant directement à cet email si vous avez la moindre question.
 

--- a/app/views/user_mailer/renew_account_password.text.erb
+++ b/app/views/user_mailer/renew_account_password.text.erb
@@ -2,7 +2,9 @@ Bonjour,
 
 Une demande de renouvellement de mot de passe d'accès à l'espace cient API Entreprise a été effectuée pour cette adresse email.
 
-Si vous êtes bien à l'origine de cette opération vous pouvez ré-initialiser votre mot de passe en cliquant sur ce <%= link_to "lien", @renew_pwd_url %>.
+Si vous êtes bien à l'origine de cette opération vous pouvez ré-initialiser votre mot de passe en cliquant sur ce lien :
+
+<%= @renew_pwd_url %>
 
 Le lien de renouvellement est valide pendant 24 heures.
 

--- a/app/views/user_mailer/transfer_ownership.text.erb
+++ b/app/views/user_mailer/transfer_ownership.text.erb
@@ -3,14 +3,14 @@ Bonjour,
 L'accès au dashboard API Entreprise vient de vous être octroyé par <%= @old_owner.email %>.
 
 <% if @new_owner.oauth_api_gouv_id.nil? %>
-  Vous devez au préalable vous créer un compte <%= link_to 'API Gouv', @datapass_signup_url %> pour accéder à votre espace client API Entreprise. Il est impératif de renseigner les informations suivantes afin d'éviter des erreurs de réconciliation à votre première connexion :
+  Vous devez au préalable vous créer un compte API Gouv (<%= @datapass_signup_url %>) pour accéder à votre espace client API Entreprise. Il est impératif de renseigner les informations suivantes afin d'éviter des erreurs de réconciliation à votre première connexion :
   - adresse email : <%= @new_owner.email %>
   - siret de votre organisation : <%= @new_owner.context %>
 <% else %>
   Vos identifiants de compte API Gouv associés à votre addresse email <%= @new_owner.email %> vous seront demandés pour accéder à votre espace client API Entreprise.
 <% end %>
 
-Vous pouvez alors accéder aux jetons votre organisation : connectez-vous simplement au <%= link_to 'dashboard', @login_url %> en utilisant vos identifiants API Gouv.
+Vous pouvez alors accéder aux jetons votre organisation : connectez-vous simplement au dashboard (<%= @login_url %>) en utilisant vos identifiants API Gouv.
 
 Cordialement,
 L'équipe API Entreprise


### PR DESCRIPTION
Cette PR propose de supprimer les balises `<a>` des templates d'email au format texte-brute, en affichant directement le lien lui-même dans le contenu.