### PR TITLE
Allow contacts without tokens

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,4 +1,4 @@
 class Contact < ApplicationRecord
-  belongs_to :jwt_api_entreprise
+  belongs_to :jwt_api_entreprise, optional: true
   scope :not_expired, -> { where(jwt_api_entreprises: { blacklisted: false, archived: false } ) }
 end

--- a/factories/contacts.rb
+++ b/factories/contacts.rb
@@ -3,7 +3,10 @@ FactoryBot.define do
     sequence(:email) { |n| "contact_#{n}@example.org" }
     phone_number { '0256743256' }
     contact_type { 'other' }
-    jwt_api_entreprise
+
+    trait :with_jwt do
+      jwt_api_entreprise
+    end
 
     trait :business do
       contact_type { 'admin' }

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -11,6 +11,6 @@ RSpec.describe Contact do
   end
 
   describe 'relationships' do
-    it { is_expected.to belong_to(:jwt_api_entreprise) }
+    it { is_expected.to belong_to(:jwt_api_entreprise).optional }
   end
 end


### PR DESCRIPTION
To be able to import contacts saved on external services (such as MailJet) within the database, this modification proposes to remove a validation by allowing contacts without associated tokens.