### PR TITLE
fix(rubocop): rename `Layout/AlignParameters` cop into `Layout/ParameterAlignment`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,5 +21,5 @@ Style/PercentLiteralDelimiters:
 Style/CommentAnnotation:
   Enabled: false
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation


### PR DESCRIPTION
Quick RuboCop's config fix as the version was upgraded.