### PR TITLE
style(StringLiterals): single quotes everywhere

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,6 @@ Style/CommentAnnotation:
 
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
+
+Style/StringLiterals:
+  EnforcedStyle: single_quotes

--- a/app/concepts/oauth_api_gouv/tasks/retrieve_access_token.rb
+++ b/app/concepts/oauth_api_gouv/tasks/retrieve_access_token.rb
@@ -1,4 +1,4 @@
-require "net/http"
+require 'net/http'
 
 module OAuthApiGouv::Tasks
   class RetrieveAccessToken < Trailblazer::Operation
@@ -53,7 +53,7 @@ module OAuthApiGouv::Tasks
 
     def invalid_authorization_code?(ctx, oauth_response:, **)
       body = JSON.parse(oauth_response.body)
-      oauth_response.code == '400' && body["error"] = 'invalid_grant'
+      oauth_response.code == '400' && body['error'] = 'invalid_grant'
     end
   end
 end

--- a/app/concepts/oauth_api_gouv/tasks/retrieve_user_info.rb
+++ b/app/concepts/oauth_api_gouv/tasks/retrieve_user_info.rb
@@ -1,4 +1,4 @@
-require "net/http"
+require 'net/http'
 
 module OAuthApiGouv::Tasks
   class RetrieveUserInfo < Trailblazer::Operation

--- a/config.ru
+++ b/config.ru
@@ -1,6 +1,6 @@
 # This file is used by Rack-based servers to start the application.
 
-require_relative "config/environment"
+require_relative 'config/environment'
 
 run Rails.application
 Rails.application.load_server

--- a/spec/controllers/oauth_api_gouv_controller_spec.rb
+++ b/spec/controllers/oauth_api_gouv_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe OAuthApiGouvController, type: :controller do
         get :login, params: login_params, as: :json
         msg = response_json[:errors]
 
-        expect(msg).to eq(authorization_code: ["must be filled"])
+        expect(msg).to eq(authorization_code: ['must be filled'])
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -542,7 +542,7 @@ RSpec.describe UsersController, type: :controller do
           call!
 
           expect(response_json).to match({
-            errors: { email: ["is in invalid format"] }
+            errors: { email: ['is in invalid format'] }
           })
         end
       end
@@ -573,7 +573,7 @@ RSpec.describe UsersController, type: :controller do
 
       it 'returns an error message' do
         expect(response_json).to match({
-          errors: "Forbidden"
+          errors: 'Forbidden'
         })
       end
     end

--- a/spec/mailers/jwt_api_entreprise_mailer_spec.rb
+++ b/spec/mailers/jwt_api_entreprise_mailer_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe JwtApiEntrepriseMailer, type: :mailer do
     end
 
     it 'contains the link to the token' do
-      token_url = "https://sandbox.dashboard.entreprise.api.gouv.fr/me/tokens/"
+      token_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/me/tokens/'
       expect(subject.html_part.decoded).to include(token_url)
       expect(subject.text_part.decoded).to include(token_url)
     end

--- a/spec/mailers/user_spec.rb
+++ b/spec/mailers/user_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe UserMailer, type: :mailer do
   describe '#renew_account_password' do
@@ -12,7 +12,7 @@ RSpec.describe UserMailer, type: :mailer do
 
     describe 'body' do
       it 'contains the URL for a password update' do
-        reset_pwd_url = "https://sandbox.dashboard.entreprise.api.gouv.fr/account/password_reset?token=coucou"
+        reset_pwd_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/account/password_reset?token=coucou'
 
         expect(subject.html_part.decoded).to include(reset_pwd_url)
         expect(subject.text_part.decoded).to include(reset_pwd_url)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -21,8 +21,8 @@ require 'rspec/rails'
 # option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
 
 # Require helpers files containing factories
-Dir[Rails.root.join("spec/helpers/**/*.rb")].each { |f| require f }
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
+Dir[Rails.root.join('spec/helpers/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 require 'fixtures/oauth_api_gouv_token.rb'
 
 # Checks for pending migration and applies them before tests are run.


### PR DESCRIPTION
Cette PR propose d'harmoniser toute la base de code sur cette règle RuboCop :

```yaml
Style/StringLiterals:
  EnforcedStyle: single_quotes
```

Commande utilisée :

```sh
bundle exec rubocop --auto-correct --only Style/StringLiterals
```