### PR TITLE
style(rspec): enforced "to_not" style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,9 @@ AllCops:
     - 'db/**/*'
     - 'config/**/*'
 
+require:
+  - rubocop-rspec
+
 Style/FrozenStringLiteralComment:
   Enabled: false
 
@@ -26,3 +29,6 @@ Layout/ParameterAlignment:
 
 Style/StringLiterals:
   EnforcedStyle: single_quotes
+
+RSpec/NotToNot:
+  EnforcedStyle: to_not

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ group :development do
   gem 'spring-watcher-listen'
   gem 'mina', '~> 1.2'
   gem 'rubocop', require: false
+  gem 'rubocop-rspec', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,9 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.4.1)
       parser (>= 2.7.1.5)
+    rubocop-rspec (2.3.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
     shellany (0.0.1)
     shoulda-matchers (4.5.1)
@@ -448,6 +451,7 @@ DEPENDENCIES
   rspec-its
   rspec-rails
   rubocop
+  rubocop-rspec
   shoulda-matchers
   sidekiq
   sidekiq-cron

--- a/spec/concepts/jwt_api_entreprise/operation/access_request_satisfaction_survey_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/access_request_satisfaction_survey_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe JwtApiEntreprise::Operation::AccessRequestSatisfactionSurvey do
 
     it 'does not send the survey' do
       expect { call! }
-        .not_to have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey)
+        .to_not have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey)
     end
 
     it 'does not change the JWT state' do
@@ -74,7 +74,7 @@ RSpec.describe JwtApiEntreprise::Operation::AccessRequestSatisfactionSurvey do
         it 'does not send it again' do
           expect {
             call!
-          }.not_to have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey)
+          }.to_not have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey)
         end
 
         it 'does not change the JWT state' do
@@ -91,7 +91,7 @@ RSpec.describe JwtApiEntreprise::Operation::AccessRequestSatisfactionSurvey do
         it 'does not send it again' do
           expect {
             call!
-          }.not_to have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey)
+          }.to_not have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey)
         end
 
         it 'does not change the JWT state' do

--- a/spec/concepts/jwt_api_entreprise/operation/create_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/create_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe JwtApiEntreprise::Operation::Create do
       # TODO move into a 'when input is invalid' context group
       it 'does not call the mailer' do
         token_params.delete(:user_id)
-        expect(JwtApiEntrepriseMailer).not_to receive(:creation_notice)
+        expect(JwtApiEntrepriseMailer).to_not receive(:creation_notice)
 
         subject
       end

--- a/spec/controllers/incidents_controller_spec.rb
+++ b/spec/controllers/incidents_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe IncidentsController, type: :controller do
         subject
         incident.reload
 
-        expect(incident.title).not_to eq('Test update')
+        expect(incident.title).to_not eq('Test update')
       end
     end
 
@@ -120,7 +120,7 @@ RSpec.describe IncidentsController, type: :controller do
           subject
           incident.reload
 
-          expect(incident.subtitle).not_to eq('Updated subtitle')
+          expect(incident.subtitle).to_not eq('Updated subtitle')
         end
 
         it 'returns 422' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -405,7 +405,7 @@ RSpec.describe UsersController, type: :controller do
         update_user!
         user.reload
 
-        expect(user.note).not_to eq('Test update')
+        expect(user.note).to_not eq('Test update')
       end
     end
 

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe JwtApiEntreprise, type: :model do
         expect {
           instance.mark_access_request_survey_sent!
           instance.reload
-        }.not_to change(instance, :access_request_survey_sent?)
+        }.to_not change(instance, :access_request_survey_sent?)
       end
     end
   end
@@ -65,7 +65,7 @@ RSpec.describe JwtApiEntreprise, type: :model do
     context 'when the token was issued up to maximum 6 days ago' do
       let(:datetime_of_issue) { :less_than_seven_days_ago }
 
-      its(:issued_in_last_seven_days) { is_expected.not_to be_exist token.id }
+      its(:issued_in_last_seven_days) { is_expected.to_not be_exist token.id }
     end
 
     context 'when the token was issued since at least 7 days ago' do
@@ -89,7 +89,7 @@ RSpec.describe JwtApiEntreprise, type: :model do
     context 'when the access request survey was sent' do
       let(:sent_state) { :access_request_survey_sent }
 
-      its(:access_request_survey_not_sent) { is_expected.not_to be_exist token.id }
+      its(:access_request_survey_not_sent) { is_expected.to_not be_exist token.id }
     end
   end
 


### PR DESCRIPTION
Cette PR propose d'harmoniser toute la base de code sur cette règle RuboCop :

```yaml
RSpec/NotToNot:
  EnforcedStyle: to_not
```

Commande utilisée :

```sh
bundle exec rubocop --require rubocop-rspec --auto-correct --only RSpec/NotToNot
```