### PR TITLE
style(rspec): enforce parentheses in method calls containing parameters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,6 +21,13 @@ Style/PercentLiteralDelimiters:
 Style/CommentAnnotation:
   Enabled: false
 
+Style/MethodCallWithArgsParentheses:
+  EnforcedStyle: require_parentheses
+  IgnoreMacros: true
+  AllowParenthesesInMultilineCall: true
+  AllowParenthesesInCamelCaseMethod: true
+  AllowParenthesesInStringInterpolation: true
+
 Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 

--- a/app/concepts/user/operation/ask_password_renewal.rb
+++ b/app/concepts/user/operation/ask_password_renewal.rb
@@ -26,7 +26,7 @@ module User::Operation
 
     def validation_errors(ctx, **)
       ctx[:errors] = {} if ctx[:errors].nil?
-      ctx[:errors].merge! ctx['result.contract.default'].errors
+      ctx[:errors].merge!(ctx['result.contract.default'].errors)
     end
   end
 end

--- a/app/concepts/user/operation/reset_password.rb
+++ b/app/concepts/user/operation/reset_password.rb
@@ -10,7 +10,7 @@ module User::Operation
 
     def validation_errors(ctx, **)
       ctx[:errors] = {} if ctx[:errors].nil?
-      ctx[:errors].merge! ctx['result.contract.default'].errors
+      ctx[:errors].merge!(ctx['result.contract.default'].errors)
     end
 
     def retrieve_user_from_token(ctx, params:, **)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::API
   end
 
   def unauthorized
-    render json: { error: 'Unauthorized' }, status: 401
+    render(json: { error: 'Unauthorized' }, status: 401)
   end
 
   # Method called by Pundit to get the current user of the request
@@ -31,6 +31,6 @@ class ApplicationController < ActionController::API
   end
 
   def user_not_authorized
-    render json: { errors: 'Forbidden' }, status: 403
+    render(json: { errors: 'Forbidden' }, status: 403)
   end
 end

--- a/app/controllers/incidents_controller.rb
+++ b/app/controllers/incidents_controller.rb
@@ -3,30 +3,30 @@ class IncidentsController < ApplicationController
 
   def index
     incidents = Incident.all
-    render json: incidents, each_serializer: IncidentIndexSerializer, status: 200
+    render(json: incidents, each_serializer: IncidentIndexSerializer, status: 200)
   end
 
   def create
-    authorize :admin, :admin?
+    authorize(:admin, :admin?)
     result = Incident::Operation::Create.call(params: params)
 
     if result.success?
-      render json: result[:model], status: 201
+      render(json: result[:model], status: 201)
     else
       errors = result['result.contract.default'].errors
-      render json: { errors: errors }, status: 422
+      render(json: { errors: errors }, status: 422)
     end
   end
 
   def update
-    authorize :admin, :admin?
+    authorize(:admin, :admin?)
     result = Incident::Operation::Update.call(params: params)
 
     if result.success?
-      render json: result[:model], status: 200
+      render(json: result[:model], status: 200)
 
     else
-      render json: { errors: result[:errors] }, status: 422
+      render(json: { errors: result[:errors] }, status: 422)
     end
   end
 end

--- a/app/controllers/jwt_api_entreprise_controller.rb
+++ b/app/controllers/jwt_api_entreprise_controller.rb
@@ -1,33 +1,33 @@
 class JwtApiEntrepriseController < ApplicationController
   def index
-    authorize :admin, :admin?
+    authorize(:admin, :admin?)
 
     jwt_list = JwtApiEntreprise.all
-    render json: jwt_list, each_serializer: JwtApiEntrepriseIndexSerializer, status: 200
+    render(json: jwt_list, each_serializer: JwtApiEntrepriseIndexSerializer, status: 200)
   end
 
   def create
-    authorize :admin, :admin?
+    authorize(:admin, :admin?)
     result = JwtApiEntreprise::Operation::Create.call(params: params)
 
     if result.success?
-      render json: { new_token: result[:model].rehash }, status: 201
+      render(json: { new_token: result[:model].rehash }, status: 201)
 
     else
       errors = result['result.contract.default'].errors.messages
-      render json: { errors: errors }, status: 422
+      render(json: { errors: errors }, status: 422)
     end
   end
 
   def update
-    authorize :admin, :admin?
+    authorize(:admin, :admin?)
 
     update = JwtApiEntreprise::Operation::Update.call(params: update_params)
 
     if update.success?
-      render json: {}, status: 200
+      render(json: {}, status: 200)
     else
-      render json: { errors: update[:errors] }, status: 422
+      render(json: { errors: update[:errors] }, status: 422)
     end
   end
 

--- a/app/controllers/oauth_api_gouv_controller.rb
+++ b/app/controllers/oauth_api_gouv_controller.rb
@@ -6,19 +6,19 @@ class OAuthApiGouvController < ApplicationController
 
     if signin.success?
       access_token = signin[:dashboard_token]
-      render json: { access_token: access_token }, status: 200
+      render(json: { access_token: access_token }, status: 200)
     else
       final_state = signin.event.to_h[:semantic]
 
       if final_state == :unknown_user
-        render json: { errors: 'Utilisateur inconnu du service API Entreprise.' }, status: 422
+        render(json: { errors: 'Utilisateur inconnu du service API Entreprise.' }, status: 422)
       elsif final_state == :invalid_authorization_code
-        render json: { errors: 'Erreur lors de l\'authentification : authorization code invalide.' }, status: 401
+        render(json: { errors: 'Erreur lors de l\'authentification : authorization code invalide.' }, status: 401)
       elsif final_state == :invalid_params
         err = signin['result.contract.default'].errors
-        render json: { errors: err }, status: 422
+        render(json: { errors: err }, status: 422)
       elsif final_state == :failure
-        render json: { errors: 'Une erreur est survenue lors des échanges avec OAuth API Gouv. Contactez API Entreprise à support@entreprise.api.gouv.fr si le problème persiste.' }, status: 502
+        render(json: { errors: 'Une erreur est survenue lors des échanges avec OAuth API Gouv. Contactez API Entreprise à support@entreprise.api.gouv.fr si le problème persiste.' }, status: 502)
       end
     end
   end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -3,19 +3,19 @@ class RolesController < ApplicationController
 
   def index
     roles = Role.all
-    render json: roles, status: 200
+    render(json: roles, status: 200)
   end
 
   def create
-    authorize :admin, :admin?
+    authorize(:admin, :admin?)
     result = Role::Operation::Create.call(params: params)
 
     if result.success?
-      render json: result[:model], status: 201
+      render(json: result[:model], status: 201)
 
     else
       errors = result['result.contract.default'].errors
-      render json: { errors: errors }, status: 422
+      render(json: { errors: errors }, status: 422)
     end
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,63 +2,63 @@ class UsersController < ApplicationController
   skip_before_action :jwt_authenticate!, only: [:password_renewal, :password_reset]
 
   def index
-    authorize :admin, :admin?
+    authorize(:admin, :admin?)
     result = User::Operation::Index.call(params: user_params)
     if result.success?
       user_list = result[:user_list]
-      render json: user_list, each_serializer: UserIndexSerializer, status: 200
+      render(json: user_list, each_serializer: UserIndexSerializer, status: 200)
     end
   end
 
   def create
-    authorize :admin, :admin?
+    authorize(:admin, :admin?)
     result = User::Operation::Create.call(params: params)
 
     if result.success?
-      render json: result[:model], serializer: UserShowSerializer, status: 201
+      render(json: result[:model], serializer: UserShowSerializer, status: 201)
 
     else
       errors = result['result.contract.default'].errors.messages
-      render json: { errors: errors }, status: 422
+      render(json: { errors: errors }, status: 422)
     end
   end
 
   def show
     user = User.find(params[:id])
-    authorize user
+    authorize(user)
 
-    render json: user, serializer: UserShowSerializer, status: 200
+    render(json: user, serializer: UserShowSerializer, status: 200)
   rescue ActiveRecord::RecordNotFound
-    render json: {}, status: 404
+    render(json: {}, status: 404)
   end
 
   def update
-    authorize :admin, :admin?
+    authorize(:admin, :admin?)
     result = User::Operation::Update.call(params: params)
 
     if result.success?
-      render json: result[:model], status: 200
+      render(json: result[:model], status: 200)
 
     else
-      render json: { errors: result[:errors] }, status: 422
+      render(json: { errors: result[:errors] }, status: 422)
     end
   end
 
   def destroy
-    authorize :admin, :admin?
+    authorize(:admin, :admin?)
     User.destroy(params[:id])
-    render json: {}, status: 204
+    render(json: {}, status: 204)
   rescue ActiveRecord::RecordNotFound
-    render json: {}, status: 404
+    render(json: {}, status: 404)
   end
 
   def password_reset
     result = User::Operation::ResetPassword.call(params: params)
 
     if result.success?
-      render json: { access_token: result[:access_token] }, status: 200
+      render(json: { access_token: result[:access_token] }, status: 200)
     else
-      render json: { errors: result['errors'] }, status: 422
+      render(json: { errors: result['errors'] }, status: 422)
     end
   end
 
@@ -66,26 +66,26 @@ class UsersController < ApplicationController
     renewal_request = User::Operation::AskPasswordRenewal.call({ params: { email: params[:email] } })
 
     if renewal_request.success?
-      render json: {}, status: 200
+      render(json: {}, status: 200)
     else
-      render json: { errors: renewal_request[:errors] }, status: 422
+      render(json: { errors: renewal_request[:errors] }, status: 422)
     end
   end
 
   def transfer_ownership
     user = User.find(params[:id])
-    authorize user
+    authorize(user)
     transfer = User::Operation::TransferOwnership.call(params: transfer_account_params)
     transfer_final_state = transfer.event.to_h[:semantic]
 
     case transfer_final_state
     when :success
-      render json: transfer[:model], serializer: UserShowSerializer, status: 200
+      render(json: transfer[:model], serializer: UserShowSerializer, status: 200)
     when :invalid_params
-      render json: { errors: transfer[:contract_errors] }, status: 422
+      render(json: { errors: transfer[:contract_errors] }, status: 422)
     when :not_found
       msg = "Current owner account with ID `#{params[:id]}` does not exist."
-      render json: { errors: msg }, status: 404
+      render(json: { errors: msg }, status: 404)
     end
   end
 

--- a/app/lib/access_token.rb
+++ b/app/lib/access_token.rb
@@ -5,13 +5,13 @@ class AccessToken
     HASH_ALGO = Rails.application.credentials.jwt_hash_algo
 
     def create(payload)
-      JWT.encode payload, HASH_SECRET, HASH_ALGO
+      JWT.encode(payload, HASH_SECRET, HASH_ALGO)
     end
 
     def decode(token)
-      payload = JWT.decode token, HASH_SECRET, true,
+      payload = JWT.decode(token, HASH_SECRET, true,
         verify_iat: true,
-        algorithm: HASH_ALGO
+        algorithm: HASH_ALGO)
       payload.map(&:deep_symbolize_keys!)
       payload.first
     end

--- a/spec/concepts/contact/contract_spec.rb
+++ b/spec/concepts/contact/contract_spec.rb
@@ -1,18 +1,18 @@
 require 'rails_helper'
 
 # TODO Move those specs into future contact creation operation
-RSpec.describe Contact::Contract::Upsert do
+RSpec.describe(Contact::Contract::Upsert) do
   let(:contact_params) { attributes_for :contact }
 
   describe 'contact creation' do
-    let(:contact_form) { described_class.new Contact.new }
+    let(:contact_form) { described_class.new(Contact.new) }
     let(:errors) { contact_form.errors.messages }
 
     context 'when params are valid' do
       it 'is valid' do
-        contact_form.validate contact_params
+        contact_form.validate(contact_params)
 
-        expect(errors).to be_empty
+        expect(errors).to(be_empty)
       end
     end
 
@@ -21,16 +21,16 @@ RSpec.describe Contact::Contract::Upsert do
 
       it 'is required' do
         contact_params[:email] = nil
-        contact_form.validate contact_params
+        contact_form.validate(contact_params)
 
-        expect(err_messages).to include('must be filled')
+        expect(err_messages).to(include('must be filled'))
       end
 
       it 'has an email format' do
         contact_params[:email] = 'not@nemai1'
-        contact_form.validate contact_params
+        contact_form.validate(contact_params)
 
-        expect(err_messages).to include('is in invalid format')
+        expect(err_messages).to(include('is in invalid format'))
       end
     end
 
@@ -39,16 +39,16 @@ RSpec.describe Contact::Contract::Upsert do
 
       it 'can be nil' do
         contact_params[:phone_number] = nil
-        contact_form.validate contact_params
+        contact_form.validate(contact_params)
 
-        expect(errors).to be_empty
+        expect(errors).to(be_empty)
       end
 
       it 'can be anything' do # We won't validate any phone number format now...
         contact_params[:phone_number] = '+33 coucou lol'
-        contact_form.validate contact_params
+        contact_form.validate(contact_params)
 
-        expect(errors).to be_empty
+        expect(errors).to(be_empty)
       end
     end
 
@@ -57,37 +57,37 @@ RSpec.describe Contact::Contract::Upsert do
 
       it 'is required' do
         contact_params[:contact_type] = nil
-        contact_form.validate contact_params
+        contact_form.validate(contact_params)
 
-        expect(err_messages).to include('must be filled')
+        expect(err_messages).to(include('must be filled'))
       end
 
       it 'accepts "admin" value' do
         contact_params[:contact_type] = 'admin'
-        contact_form.validate contact_params
+        contact_form.validate(contact_params)
 
-        expect(errors).to be_empty
+        expect(errors).to(be_empty)
       end
 
       it 'accepts "tech" value' do
         contact_params[:contact_type] = 'tech'
-        contact_form.validate contact_params
+        contact_form.validate(contact_params)
 
-        expect(errors).to be_empty
+        expect(errors).to(be_empty)
       end
 
       it 'accepts "other" value' do
         contact_params[:contact_type] = 'other'
-        contact_form.validate contact_params
+        contact_form.validate(contact_params)
 
-        expect(errors).to be_empty
+        expect(errors).to(be_empty)
       end
 
       it 'does not accept another value' do
         contact_params[:contact_type] = 'nope'
-        contact_form.validate contact_params
+        contact_form.validate(contact_params)
 
-        expect(err_messages).to include('must be one of: admin, tech, other')
+        expect(err_messages).to(include('must be one of: admin, tech, other'))
       end
     end
   end

--- a/spec/concepts/incident/operation/create_spec.rb
+++ b/spec/concepts/incident/operation/create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Incident::Operation::Create do
+RSpec.describe(Incident::Operation::Create) do
   let(:operation_params) do
     {
       title: 'Test incident',
@@ -14,15 +14,15 @@ RSpec.describe Incident::Operation::Create do
   it 'delegates the call and validations to the Save operation'
 
   it 'creates a new incident' do
-    expect { subject }.to change(Incident, :count).by(1)
+    expect { subject }.to(change(Incident, :count).by(1))
   end
 
   it 'references the new incident into the :model result field' do
     new_incindent = subject[:model]
 
-    expect(new_incindent).to be_persisted
-    expect(new_incindent.title).to eq('Test incident')
-    expect(new_incindent.subtitle).to eq('From yesterday to tomorrow')
-    expect(new_incindent.description).to eq('I\'m the incident description.')
+    expect(new_incindent).to(be_persisted)
+    expect(new_incindent.title).to(eq('Test incident'))
+    expect(new_incindent.subtitle).to(eq('From yesterday to tomorrow'))
+    expect(new_incindent.description).to(eq('I\'m the incident description.'))
   end
 end

--- a/spec/concepts/incident/operation/save_spec.rb
+++ b/spec/concepts/incident/operation/save_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Incident::Operation::Save do
+RSpec.describe(Incident::Operation::Save) do
   let(:operation_params) do
     {
       title: 'Test incident',
@@ -13,8 +13,8 @@ RSpec.describe Incident::Operation::Save do
 
   context 'when no incident record is present in params' do
     it 'saves a new incident into the database' do
-      expect { subject }.to change(Incident, :count).by(1)
-      expect(subject).to be_success
+      expect { subject }.to(change(Incident, :count).by(1))
+      expect(subject).to(be_success)
     end
   end
 
@@ -25,9 +25,9 @@ RSpec.describe Incident::Operation::Save do
       subject
       incident_record.reload
 
-      expect(incident_record.title).to eq('Test incident')
-      expect(incident_record.subtitle).to eq('From yesterday to tomorrow')
-      expect(incident_record.description).to eq('I\'m the incident description.')
+      expect(incident_record.title).to(eq('Test incident'))
+      expect(incident_record.subtitle).to(eq('From yesterday to tomorrow'))
+      expect(incident_record.description).to(eq('I\'m the incident description.'))
     end
   end
 
@@ -40,15 +40,15 @@ RSpec.describe Incident::Operation::Save do
       it 'is required' do
         operation_params.delete(:title)
 
-        expect(subject).to be_failure
-        expect(errors).to include 'must be filled'
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be filled'))
       end
 
       it 'is max 128 characters long' do
         operation_params[:title] = 'a' * 129
 
-        expect(subject).to be_failure
-        expect(errors).to include 'size cannot be greater than 128'
+        expect(subject).to(be_failure)
+        expect(errors).to(include('size cannot be greater than 128'))
       end
     end
 
@@ -58,15 +58,15 @@ RSpec.describe Incident::Operation::Save do
       it 'is required' do
         operation_params.delete(:subtitle)
 
-        expect(subject).to be_failure
-        expect(errors).to include 'must be filled'
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be filled'))
       end
 
       it 'is max 128 characters long' do
         operation_params[:subtitle] = 'a' * 129
 
-        expect(subject).to be_failure
-        expect(errors).to include 'size cannot be greater than 128'
+        expect(subject).to(be_failure)
+        expect(errors).to(include('size cannot be greater than 128'))
       end
     end
 
@@ -76,8 +76,8 @@ RSpec.describe Incident::Operation::Save do
       it 'is required' do
         operation_params.delete(:description)
 
-        expect(subject).to be_failure
-        expect(errors).to include 'must be filled'
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be filled'))
       end
     end
   end

--- a/spec/concepts/incident/operation/update_spec.rb
+++ b/spec/concepts/incident/operation/update_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Incident::Operation::Update do
+RSpec.describe(Incident::Operation::Update) do
   let(:operation_params) do
     {
       id: incident_id,
@@ -15,11 +15,11 @@ RSpec.describe Incident::Operation::Update do
     let(:incident_id) { 0 }
 
     it 'fails' do
-      expect(subject).to be_failure
+      expect(subject).to(be_failure)
     end
 
     it 'returns an error message' do
-      expect(subject[:errors]).to include("Incident with id `#{incident_id}` does not exist.")
+      expect(subject[:errors]).to(include("Incident with id `#{incident_id}` does not exist."))
     end
   end
 
@@ -35,9 +35,9 @@ RSpec.describe Incident::Operation::Update do
     it 'references the updated incident into the :model result field' do
       updated_incident = subject[:model]
 
-      expect(updated_incident.title).to eq('Updated title')
-      expect(updated_incident.subtitle).to eq('Updated subtitle')
-      expect(updated_incident.description).to eq('Updated description')
+      expect(updated_incident.title).to(eq('Updated title'))
+      expect(updated_incident.subtitle).to(eq('Updated subtitle'))
+      expect(updated_incident.description).to(eq('Updated description'))
     end
   end
 end

--- a/spec/concepts/jwt_api_entreprise/operation/access_request_satisfaction_survey_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/access_request_satisfaction_survey_spec.rb
@@ -1,22 +1,22 @@
 require 'rails_helper'
 
-RSpec.describe JwtApiEntreprise::Operation::AccessRequestSatisfactionSurvey do
+RSpec.describe(JwtApiEntreprise::Operation::AccessRequestSatisfactionSurvey) do
   subject(:call!) { described_class.call }
 
 
   context 'when the JWT is less than 7 days old' do
     let!(:token) { create(:jwt_api_entreprise, :less_than_seven_days_ago) }
 
-    it { is_expected.to be_a_failure }
+    it { is_expected.to(be_a_failure) }
 
     it 'does not send the survey' do
       expect { call! }
-        .not_to have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey)
+        .not_to(have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey))
     end
 
     it 'does not change the JWT state' do
       expect { call! }
-        .to_not change(token, :access_request_survey_sent)
+        .to_not(change(token, :access_request_survey_sent))
     end
   end
 
@@ -29,28 +29,28 @@ RSpec.describe JwtApiEntreprise::Operation::AccessRequestSatisfactionSurvey do
       context 'when the token is blacklisted' do
         let(:blacklisted_or_not_blacklisted) { :blacklisted }
 
-        it { is_expected.to be_a_failure }
+        it { is_expected.to(be_a_failure) }
 
         it 'does not send the survey' do
           expect { call! }
-            .to_not have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey)
+            .to_not(have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey))
         end
 
         it 'does not change the JWT state' do
           expect { call! }
-            .to_not change(token, :access_request_survey_sent)
+            .to_not(change(token, :access_request_survey_sent))
         end
       end
 
       context 'when the token is not blacklisted' do
         let(:blacklisted_or_not_blacklisted) { :not_blacklisted }
 
-        it { is_expected.to be_a_success }
+        it { is_expected.to(be_a_success) }
 
         it 'sends an email survey' do
           expect { call! }
-            .to have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey)
-            .with(args: [token])
+            .to(have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey)
+            .with(args: [token]))
         end
 
         it 'saves that the survey was sent' do
@@ -58,7 +58,7 @@ RSpec.describe JwtApiEntreprise::Operation::AccessRequestSatisfactionSurvey do
             call!
             token.reload
           end
-            .to change(token, :access_request_survey_sent).from(false).to(true)
+            .to(change(token, :access_request_survey_sent).from(false).to(true))
         end
       end
     end
@@ -69,34 +69,34 @@ RSpec.describe JwtApiEntreprise::Operation::AccessRequestSatisfactionSurvey do
       context 'when the token is blacklisted' do
         let(:blacklisted_or_not_blacklisted) { :blacklisted }
 
-        it { is_expected.to be_a_failure }
+        it { is_expected.to(be_a_failure) }
 
         it 'does not send it again' do
           expect {
             call!
-          }.not_to have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey)
+          }.not_to(have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey))
         end
 
         it 'does not change the JWT state' do
           expect { call! }
-            .to_not change(token, :access_request_survey_sent)
+            .to_not(change(token, :access_request_survey_sent))
         end
       end
 
       context 'when the token is not blacklisted' do
         let(:blacklisted_or_not_blacklisted) { :not_blacklisted }
 
-        it { is_expected.to be_a_failure }
+        it { is_expected.to(be_a_failure) }
 
         it 'does not send it again' do
           expect {
             call!
-          }.not_to have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey)
+          }.not_to(have_enqueued_mail(JwtApiEntrepriseMailer, :satisfaction_survey))
         end
 
         it 'does not change the JWT state' do
           expect { call! }
-            .to_not change(token, :access_request_survey_sent)
+            .to_not(change(token, :access_request_survey_sent))
         end
       end
     end

--- a/spec/concepts/jwt_api_entreprise/operation/create_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe JwtApiEntreprise::Operation::Create do
+RSpec.describe(JwtApiEntreprise::Operation::Create) do
   let(:user) { create(:user) }
   let(:roles) { create_list(:role, 7) }
   let(:roles_code) { roles.map { |attr| attr.slice(:code) } }
@@ -31,49 +31,49 @@ RSpec.describe JwtApiEntreprise::Operation::Create do
     let(:created_token) { subject[:model] }
 
     it 'is successful' do
-      expect(subject).to be_success
+      expect(subject).to(be_success)
     end
 
     it 'creates the jwt' do
-      expect { subject }.to change(JwtApiEntreprise, :count).by(1)
+      expect { subject }.to(change(JwtApiEntreprise, :count).by(1))
     end
 
     it 'belongs to the correct user' do
-      expect(created_token.user).to eq(user)
+      expect(created_token.user).to(eq(user))
     end
 
     it 'saves the related authorization request id' do
-      expect(created_token.authorization_request_id).to eq(token_params[:authorization_request_id])
+      expect(created_token.authorization_request_id).to(eq(token_params[:authorization_request_id]))
     end
 
     it 'is has the valid access rights' do
-      expect(created_token.roles.to_a).to contain_exactly(*roles.to_a)
+      expect(created_token.roles.to_a).to(contain_exactly(*roles.to_a))
     end
 
     it 'expires after 18 months' do
       Timecop.freeze
 
-      expect(created_token.exp).to eq(18.months.from_now.to_i)
+      expect(created_token.exp).to(eq(18.months.from_now.to_i))
       Timecop.return
     end
 
     it 'has a timestamp of creation' do
       Timecop.freeze
 
-      expect(created_token.iat).to eq(Time.zone.now.to_i)
+      expect(created_token.iat).to(eq(Time.zone.now.to_i))
       Timecop.return
     end
 
     it 'is saved with a default version number' do
-      expect(created_token.version).to eq('1.0')
+      expect(created_token.version).to(eq('1.0'))
     end
 
     it 'creates the related contacts' do
-      expect { subject }.to change(Contact, :count).by(2)
+      expect { subject }.to(change(Contact, :count).by(2))
     end
 
     it 'persists valid contacts data' do
-      expect(created_token.contacts).to contain_exactly(
+      expect(created_token.contacts).to(contain_exactly(
         an_object_having_attributes(
           email: 'coucou@hello.fr',
           phone_number: '0123456789',
@@ -84,12 +84,12 @@ RSpec.describe JwtApiEntreprise::Operation::Create do
           phone_number: '0987654321',
           contact_type: 'tech'
         )
-      )
+      ))
     end
 
     describe 'mail notifications' do
       it 'calls the mailer to notice for a JWT creation' do
-        expect(JwtApiEntrepriseMailer).to receive(:creation_notice).and_call_original
+        expect(JwtApiEntrepriseMailer).to(receive(:creation_notice).and_call_original)
 
         subject
       end
@@ -97,7 +97,7 @@ RSpec.describe JwtApiEntreprise::Operation::Create do
       # TODO move into a 'when input is invalid' context group
       it 'does not call the mailer' do
         token_params.delete(:user_id)
-        expect(JwtApiEntrepriseMailer).not_to receive(:creation_notice)
+        expect(JwtApiEntrepriseMailer).not_to(receive(:creation_notice))
 
         subject
       end
@@ -111,15 +111,15 @@ RSpec.describe JwtApiEntreprise::Operation::Create do
       it 'is required' do
         token_params[:roles] = []
 
-        expect(subject).to be_failure
-        expect(errors[:roles]).to include 'must be filled'
+        expect(subject).to(be_failure)
+        expect(errors[:roles]).to(include('must be filled'))
       end
 
       it 'fails if provided roles does not exist' do
         token_params[:roles].push({ code: 'ghost_code' })
 
-        expect(subject).to be_failure
-        expect(errors[:'roles.code']).to include('role "ghost_code" does not exist')
+        expect(subject).to(be_failure)
+        expect(errors[:'roles.code']).to(include('role "ghost_code" does not exist'))
       end
     end
 
@@ -129,15 +129,15 @@ RSpec.describe JwtApiEntreprise::Operation::Create do
       it 'is required' do
         token_params.delete(:user_id)
 
-        expect(subject).to be_failure
-        expect(errors).to include('must be filled')
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be filled'))
       end
 
       it 'is an existing user id' do
         token_params[:user_id] = 'not a user id'
 
-        expect(subject).to be_failure
-        expect(errors).to include('user with ID "not a user id" does not exist')
+        expect(subject).to(be_failure)
+        expect(errors).to(include('user with ID "not a user id" does not exist'))
       end
     end
 
@@ -147,15 +147,15 @@ RSpec.describe JwtApiEntreprise::Operation::Create do
       it 'is required' do
         token_params.delete(:authorization_request_id)
 
-        expect(subject).to be_failure
-        expect(errors).to include('must be filled')
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be filled'))
       end
 
       it 'is a string' do
         token_params[:authorization_request_id] = true
 
-        expect(subject).to be_failure
-        expect(errors).to include('must be a string')
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be a string'))
       end
     end
 
@@ -165,8 +165,8 @@ RSpec.describe JwtApiEntreprise::Operation::Create do
       it 'is required' do
         token_params[:subject] = ''
 
-        expect(subject).to be_failure
-        expect(errors).to include('must be filled')
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be filled'))
       end
     end
 
@@ -176,14 +176,14 @@ RSpec.describe JwtApiEntreprise::Operation::Create do
       it 'fails if contact\'s data is not valid' do
         token_params[:contacts].append(email: 'not an email')
 
-        expect(subject).to be_failure
+        expect(subject).to(be_failure)
       end
 
       it 'is required' do
         token_params.delete(:contacts)
 
-        expect(subject).to be_failure
-        expect(errors).to include('must be filled')
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be filled'))
       end
 
       pending 'business and tech contacts are required'

--- a/spec/concepts/jwt_api_entreprise/operation/notify_expiration_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/notify_expiration_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe JwtApiEntreprise::Operation::NotifyExpiration do
+RSpec.describe(JwtApiEntreprise::Operation::NotifyExpiration) do
   describe 'expire_in: option (provide a number of days)' do
     # Let's test with a 90 days (3 months) expiration notice
     let(:days) { 90 }
@@ -8,20 +8,20 @@ RSpec.describe JwtApiEntreprise::Operation::NotifyExpiration do
     shared_examples 'JWT notification mailer' do |mailer_action|
       subject { described_class.call(expire_in: days) }
 
-      it { is_expected.to be_success }
+      it { is_expected.to(be_success) }
 
       it 'calls the mailer for the affected JWT only' do
-        expect(JwtApiEntrepriseMailer).to receive(mailer_action).with(jwt_1, days).and_call_original
-        expect(JwtApiEntrepriseMailer).to receive(mailer_action).with(jwt_2, days).and_call_original
-        expect(JwtApiEntrepriseMailer).to_not receive(mailer_action).with(jwt_3, days).and_call_original
+        expect(JwtApiEntrepriseMailer).to(receive(mailer_action).with(jwt_1, days).and_call_original)
+        expect(JwtApiEntrepriseMailer).to(receive(mailer_action).with(jwt_2, days).and_call_original)
+        expect(JwtApiEntrepriseMailer).to_not(receive(mailer_action).with(jwt_3, days).and_call_original)
 
         subject
       end
 
       it 'does not send the same notification twice' do
         described_class.call(expire_in: days)
-        expect(JwtApiEntrepriseMailer).to_not receive(mailer_action).with(jwt_1, days)
-        expect(JwtApiEntrepriseMailer).to_not receive(mailer_action).with(jwt_2, days)
+        expect(JwtApiEntrepriseMailer).to_not(receive(mailer_action).with(jwt_1, days))
+        expect(JwtApiEntrepriseMailer).to_not(receive(mailer_action).with(jwt_2, days))
 
         subject
       end
@@ -29,9 +29,9 @@ RSpec.describe JwtApiEntreprise::Operation::NotifyExpiration do
       it 'does not call the mailer for archived JWTs' do
         archived_jwt = create(:jwt_api_entreprise, :expiring_within_3_month, archived: true)
         # Expectations for sent notifications are needed, otherwise the code runs against the "dumb" double
-        expect(JwtApiEntrepriseMailer).to receive(mailer_action).with(jwt_1, days).and_call_original
-        expect(JwtApiEntrepriseMailer).to receive(mailer_action).with(jwt_2, days).and_call_original
-        expect(JwtApiEntrepriseMailer).to_not receive(mailer_action).with(archived_jwt, days)
+        expect(JwtApiEntrepriseMailer).to(receive(mailer_action).with(jwt_1, days).and_call_original)
+        expect(JwtApiEntrepriseMailer).to(receive(mailer_action).with(jwt_2, days).and_call_original)
+        expect(JwtApiEntrepriseMailer).to_not(receive(mailer_action).with(archived_jwt, days))
 
         subject
       end
@@ -39,9 +39,9 @@ RSpec.describe JwtApiEntreprise::Operation::NotifyExpiration do
       it 'does not call the mailer for blacklisted JWTs' do
         blacklisted_jwt = create(:jwt_api_entreprise, :expiring_within_3_month, blacklisted: true)
         # Expectations for sent notifications are needed, otherwise the code runs against the "dumb" double
-        expect(JwtApiEntrepriseMailer).to receive(mailer_action).with(jwt_1, days).and_call_original
-        expect(JwtApiEntrepriseMailer).to receive(mailer_action).with(jwt_2, days).and_call_original
-        expect(JwtApiEntrepriseMailer).to_not receive(mailer_action).with(blacklisted_jwt, days)
+        expect(JwtApiEntrepriseMailer).to(receive(mailer_action).with(jwt_1, days).and_call_original)
+        expect(JwtApiEntrepriseMailer).to(receive(mailer_action).with(jwt_2, days).and_call_original)
+        expect(JwtApiEntrepriseMailer).to_not(receive(mailer_action).with(blacklisted_jwt, days))
 
         subject
       end
@@ -51,7 +51,7 @@ RSpec.describe JwtApiEntreprise::Operation::NotifyExpiration do
         jwt_1.reload
         jwt_2.reload
 
-        expect([jwt_1, jwt_2]).to all(have_attributes(days_left_notification_sent: a_collection_including(days)))
+        expect([jwt_1, jwt_2]).to(all(have_attributes(days_left_notification_sent: a_collection_including(days))))
       end
     end
 
@@ -77,7 +77,7 @@ RSpec.describe JwtApiEntreprise::Operation::NotifyExpiration do
 
   context 'when expire_in: is not specified' do
     it 'raises an error' do
-      expect { described_class.call }.to raise_error(ArgumentError, a_string_matching(/missing keyword: :expire_in/))
+      expect { described_class.call }.to(raise_error(ArgumentError, a_string_matching(/missing keyword: :expire_in/)))
     end
   end
 end

--- a/spec/concepts/jwt_api_entreprise/operation/update_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/update_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe JwtApiEntreprise::Operation::Update do
+RSpec.describe(JwtApiEntreprise::Operation::Update) do
   subject(:update_jwt!) { described_class.call(params: op_params) }
 
   context 'when the JWT id is valid' do
@@ -8,29 +8,29 @@ RSpec.describe JwtApiEntreprise::Operation::Update do
     let(:op_params) { { id: jwt.id, blacklisted: true, archived: true } }
 
     describe '#blacklisted' do
-      it { is_expected.to be_success }
+      it { is_expected.to(be_success) }
 
       it 'updates the resource' do
         update_jwt!
         jwt.reload
 
-        expect(jwt.blacklisted).to eq(true)
+        expect(jwt.blacklisted).to(eq(true))
       end
     end
 
     describe '#archived' do
-      it { is_expected.to be_success }
+      it { is_expected.to(be_success) }
 
       it 'updates the resource' do
         update_jwt!
         jwt.reload
 
-        expect(jwt.archived).to eq(true)
+        expect(jwt.archived).to(eq(true))
       end
     end
 
     describe 'non-updatable attributes' do
-      it { is_expected.to be_success }
+      it { is_expected.to(be_success) }
 
       it 'does not update the resource' do
         op_params.merge!({
@@ -43,10 +43,10 @@ RSpec.describe JwtApiEntreprise::Operation::Update do
         update_jwt!
         jwt.reload
 
-        expect(jwt.subject).to_not eq('new subject')
-        expect(jwt.iat).to_not eq(9000)
-        expect(jwt.exp).to_not eq(10000)
-        expect(jwt.version).to_not eq('2.1')
+        expect(jwt.subject).to_not(eq('new subject'))
+        expect(jwt.iat).to_not(eq(9000))
+        expect(jwt.exp).to_not(eq(10000))
+        expect(jwt.version).to_not(eq('2.1'))
       end
     end
 
@@ -64,14 +64,14 @@ RSpec.describe JwtApiEntreprise::Operation::Update do
         it 'is optional' do
           op_params.delete(:blacklisted)
 
-          expect(update_jwt!).to be_success
+          expect(update_jwt!).to(be_success)
         end
 
         it 'must be boolean' do
           op_params[:blacklisted] = 'no bool'
 
-          expect(update_jwt!).to be_failure
-          expect(errors).to include(blacklisted: ['must be boolean'])
+          expect(update_jwt!).to(be_failure)
+          expect(errors).to(include(blacklisted: ['must be boolean']))
         end
       end
 
@@ -79,14 +79,14 @@ RSpec.describe JwtApiEntreprise::Operation::Update do
         it 'is optional' do
           op_params.delete(:archived)
 
-          expect(update_jwt!).to be_success
+          expect(update_jwt!).to(be_success)
         end
 
         it 'must be boolean' do
           op_params[:archived] = 'no bool'
 
-          expect(update_jwt!).to be_failure
-          expect(errors).to include(archived: ['must be boolean'])
+          expect(update_jwt!).to(be_failure)
+          expect(errors).to(include(archived: ['must be boolean']))
         end
       end
 
@@ -96,8 +96,8 @@ RSpec.describe JwtApiEntreprise::Operation::Update do
           op_params.delete(:blacklisted)
           op_params.delete(:archived)
 
-          expect(update_jwt!).to be_failure
-          expect(errors).to include('dunno yet')
+          expect(update_jwt!).to(be_failure)
+          expect(errors).to(include('dunno yet'))
         end
       end
     end
@@ -107,12 +107,12 @@ RSpec.describe JwtApiEntreprise::Operation::Update do
     let(:op_params) { { id: '0102', blacklisted: true, archived: true } }
     let(:errors) { update_jwt![:errors] }
 
-    it { is_expected.to be_failure }
+    it { is_expected.to(be_failure) }
 
     it 'returns an error message' do
       update_jwt!
 
-      expect(errors).to include(jwt_api_entreprise: ['the resource with id `0102` is not found'])
+      expect(errors).to(include(jwt_api_entreprise: ['the resource with id `0102` is not found']))
     end
   end
 end

--- a/spec/concepts/oauth_api_gouv/operation/login_spec.rb
+++ b/spec/concepts/oauth_api_gouv/operation/login_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe OAuthApiGouv::Operation::Login, type: :jwt do
+RSpec.describe(OAuthApiGouv::Operation::Login, type: :jwt) do
   let(:op_params) do
     { authorization_code: code }
   end
@@ -14,38 +14,38 @@ RSpec.describe OAuthApiGouv::Operation::Login, type: :jwt do
     context 'when the authenticated user exists' do
       let!(:user) { create(:user, :known_api_gouv_user) }
 
-      it { is_expected.to be_success }
+      it { is_expected.to(be_success) }
 
       it 'returns a valid JWT to access the dashboard' do
         dashboard_jwt = login![:dashboard_token]
         jwt_payload = extract_payload_from(dashboard_jwt)
 
-        expect(jwt_payload).to include({
+        expect(jwt_payload).to(include({
           uid: user.id,
           iat: Integer,
           exp: Integer
-        })
+        }))
       end
     end
 
     context 'when the authenticated user does not exist' do
-      it { is_expected.to be_failure }
+      it { is_expected.to(be_failure) }
 
       it 'ends in the :unknown_user state' do
         state = login!.event.to_h[:semantic]
 
-        expect(state).to eq(:unknown_user)
+        expect(state).to(eq(:unknown_user))
       end
     end
 
     # Internal communication error with OAuth API Gouv (bad client secrets for instance)
     context 'when an internal error occurs', vcr: { cassette_name: 'oauth_api_gouv_invalid_client_credentials' } do
-      it { is_expected.to be_failure }
+      it { is_expected.to(be_failure) }
 
       it 'ends in the :failure state' do
         state = login!.event.to_h[:semantic]
 
-        expect(state).to eq(:failure)
+        expect(state).to(eq(:failure))
       end
     end
   end
@@ -53,12 +53,12 @@ RSpec.describe OAuthApiGouv::Operation::Login, type: :jwt do
   context 'when the authorization code is not valid', vcr: { cassette_name: 'oauth_api_gouv_invalid_authorization_code' } do
     let(:code) { OAuthApiGouv::AuthorizationCode.invalid }
 
-    it { is_expected.to be_failure }
+    it { is_expected.to(be_failure) }
 
     it 'ends in the :invalid_authorization_code state' do
       state = login!.event.to_h[:semantic]
 
-      expect(state).to eq(:invalid_authorization_code)
+      expect(state).to(eq(:invalid_authorization_code))
     end
   end
 
@@ -72,18 +72,18 @@ RSpec.describe OAuthApiGouv::Operation::Login, type: :jwt do
         op_params.delete(:authorization_code)
         final_state = login!.event.to_h[:semantic]
 
-        expect(login!).to be_failure
-        expect(final_state).to eq(:invalid_params)
-        expect(errors).to include(authorization_code: ['is missing'])
+        expect(login!).to(be_failure)
+        expect(final_state).to(eq(:invalid_params))
+        expect(errors).to(include(authorization_code: ['is missing']))
       end
 
       it 'is a string' do
         op_params[:authorization_code] = 123
         final_state = login!.event.to_h[:semantic]
 
-        expect(login!).to be_failure
-        expect(final_state).to eq(:invalid_params)
-        expect(errors).to include(authorization_code: ['must be a string'])
+        expect(login!).to(be_failure)
+        expect(final_state).to(eq(:invalid_params))
+        expect(errors).to(include(authorization_code: ['must be a string']))
       end
     end
   end

--- a/spec/concepts/oauth_api_gouv/tasks/retrieve_access_token_spec.rb
+++ b/spec/concepts/oauth_api_gouv/tasks/retrieve_access_token_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe OAuthApiGouv::Tasks::RetrieveAccessToken do
+RSpec.describe(OAuthApiGouv::Tasks::RetrieveAccessToken) do
   subject(:retrieve_tokens!) { described_class.call(authorization_code: code) }
 
   context 'when the authorization code is valid' do
@@ -13,48 +13,48 @@ RSpec.describe OAuthApiGouv::Tasks::RetrieveAccessToken do
         it 'returns an Access Token' do
           access_token = retrieve_tokens![:access_token]
 
-          expect(access_token).to be_a(String)
+          expect(access_token).to(be_a(String))
         end
 
         it 'returns an ID Token' do
           id_token = retrieve_tokens![:access_token]
 
-          expect(id_token).to be_a(String)
+          expect(id_token).to(be_a(String))
         end
 
-        it { is_expected.to be_success }
+        it { is_expected.to(be_success) }
 
         it 'returns the user ID (from OAuth API Gouv)' do
           user_id = retrieve_tokens![:oauth_api_gouv_user_id]
 
-          expect(user_id).to be_a(String)
+          expect(user_id).to(be_a(String))
         end
       end
 
       context 'when the ID Token is not valid' do
         shared_examples :jwt_validation_failure do
-          it { is_expected.to be_failure }
+          it { is_expected.to(be_failure) }
 
           it 'ends in the :failure' do
             res = retrieve_tokens!
             state = res.event.to_h[:semantic]
 
-            expect(state).to eq(:failure)
+            expect(state).to(eq(:failure))
           end
         end
 
         describe 'invalid signature' do
           # Here we provide an invalid ID Token on code execution
           before do
-            allow(AccessToken).to receive(:decode_oauth_api_gouv_id_token)
-              .and_wrap_original { |m, jwt, jwks| m.call(OAuthApiGouv::IdToken.invalid_signature, jwks) }
+            allow(AccessToken).to(receive(:decode_oauth_api_gouv_id_token)
+              .and_wrap_original { |m, jwt, jwks| m.call(OAuthApiGouv::IdToken.invalid_signature, jwks) })
           end
 
           it_behaves_like :jwt_validation_failure
 
           it 'logs the error' do
-            expect(Rails.logger).to receive(:error)
-              .with('ID Token verification error: Signature verification raised')
+            expect(Rails.logger).to(receive(:error)
+              .with('ID Token verification error: Signature verification raised'))
 
             retrieve_tokens!
           end
@@ -65,14 +65,14 @@ RSpec.describe OAuthApiGouv::Tasks::RetrieveAccessToken do
           # No way to forge the JWT with another 'aud' claim, so let's use the
           # valid JWT and modify the expected audience value instead
           before do
-            allow(Rails.configuration).to receive(:oauth_api_gouv_client_id).and_return('lol audience')
+            allow(Rails.configuration).to(receive(:oauth_api_gouv_client_id).and_return('lol audience'))
           end
 
           it_behaves_like :jwt_validation_failure
 
           it 'logs the error' do
-            expect(Rails.logger).to receive(:error)
-              .with(a_string_starting_with('ID Token verification error: Invalid audience. Expected lol audience, received'))
+            expect(Rails.logger).to(receive(:error)
+              .with(a_string_starting_with('ID Token verification error: Invalid audience. Expected lol audience, received')))
 
             retrieve_tokens!
           end
@@ -83,14 +83,14 @@ RSpec.describe OAuthApiGouv::Tasks::RetrieveAccessToken do
           # No way to forge the JWT with another 'iss' claim, so let's use the
           # valid JWT and modify the expected issuer value instead
           before do
-            allow(Rails.configuration).to receive(:oauth_api_gouv_issuer).and_return('http://www.issuer.fr')
+            allow(Rails.configuration).to(receive(:oauth_api_gouv_issuer).and_return('http://www.issuer.fr'))
           end
 
           it_behaves_like :jwt_validation_failure
 
           it 'logs the error' do
-            expect(Rails.logger).to receive(:error)
-              .with(a_string_starting_with('ID Token verification error: Invalid issuer. Expected http://www.issuer.fr, received'))
+            expect(Rails.logger).to(receive(:error)
+              .with(a_string_starting_with('ID Token verification error: Invalid issuer. Expected http://www.issuer.fr, received')))
 
             retrieve_tokens!
           end
@@ -104,8 +104,8 @@ RSpec.describe OAuthApiGouv::Tasks::RetrieveAccessToken do
           it_behaves_like :jwt_validation_failure
 
           it 'logs the error' do
-            expect(Rails.logger).to receive(:error)
-              .with(a_string_starting_with('ID Token verification error: Signature has expired'))
+            expect(Rails.logger).to(receive(:error)
+              .with(a_string_starting_with('ID Token verification error: Signature has expired')))
 
             retrieve_tokens!
           end
@@ -117,15 +117,15 @@ RSpec.describe OAuthApiGouv::Tasks::RetrieveAccessToken do
 
     context 'when Admin API credentials are not valid', vcr: { cassette_name: 'oauth_api_gouv_invalid_client_credentials' } do
       before do
-        allow(Rails.application.credentials).to receive(:oauth_api_gouv_client_secret)
-          .and_return('lecodecestlecode')
+        allow(Rails.application.credentials).to(receive(:oauth_api_gouv_client_secret)
+          .and_return('lecodecestlecode'))
       end
 
-      it { is_expected.to be_failure }
+      it { is_expected.to(be_failure) }
 
       it 'logs the error' do
-        expect(Rails.logger).to receive(:error)
-          .with('OAuth API Gouv call failed: status 401, description {"error":"invalid_client","error_description":"client authentication failed"}')
+        expect(Rails.logger).to(receive(:error)
+          .with('OAuth API Gouv call failed: status 401, description {"error":"invalid_client","error_description":"client authentication failed"}'))
 
         retrieve_tokens!
       end
@@ -134,7 +134,7 @@ RSpec.describe OAuthApiGouv::Tasks::RetrieveAccessToken do
         res = retrieve_tokens!
         state = res.event.to_h[:semantic]
 
-        expect(state).to eq(:failure)
+        expect(state).to(eq(:failure))
       end
     end
   end
@@ -142,11 +142,11 @@ RSpec.describe OAuthApiGouv::Tasks::RetrieveAccessToken do
   context 'when the authorization code is invalid', vcr: { cassette_name: 'oauth_api_gouv_invalid_authorization_code' } do
     let(:code) { OAuthApiGouv::AuthorizationCode.invalid }
 
-    it { is_expected.to be_failure }
+    it { is_expected.to(be_failure) }
 
     it 'logs the error' do
-      expect(Rails.logger).to receive(:error)
-        .with('OAuth API Gouv call failed: status 400, description {"error":"invalid_grant","error_description":"grant request is invalid"}')
+      expect(Rails.logger).to(receive(:error)
+        .with('OAuth API Gouv call failed: status 400, description {"error":"invalid_grant","error_description":"grant request is invalid"}'))
 
       retrieve_tokens!
     end
@@ -155,7 +155,7 @@ RSpec.describe OAuthApiGouv::Tasks::RetrieveAccessToken do
       res = retrieve_tokens!
       state = res.event.to_h[:semantic]
 
-      expect(state).to eq(:invalid_authorization_code)
+      expect(state).to(eq(:invalid_authorization_code))
     end
   end
 end

--- a/spec/concepts/oauth_api_gouv/tasks/retrieve_user_info_spec.rb
+++ b/spec/concepts/oauth_api_gouv/tasks/retrieve_user_info_spec.rb
@@ -1,31 +1,31 @@
 require 'rails_helper'
 
-RSpec.describe OAuthApiGouv::Tasks::RetrieveUserInfo do
+RSpec.describe(OAuthApiGouv::Tasks::RetrieveUserInfo) do
   subject(:fetch_user!) { described_class.call(access_token: token) }
 
   context 'when the access token is valid', vcr: { cassette_name: 'oauth_api_gouv_user_info_valid_token' } do
     let(:token) { OAuthApiGouv::AccessToken.valid }
 
     context 'when the related user does not exist' do
-      it { is_expected.to be_failure }
+      it { is_expected.to(be_failure) }
 
       it 'ends in the :unknown_user state' do
         res = fetch_user!
         state = res.event.to_h[:semantic]
 
-        expect(state).to eq(:unknown_user)
+        expect(state).to(eq(:unknown_user))
       end
     end
 
     context 'when the related user exists' do
       let!(:user) { create(:user, :known_api_gouv_user) }
 
-      it { is_expected.to be_success }
+      it { is_expected.to(be_success) }
 
       it 'returns the related user record' do
         db_user = fetch_user![:user]
 
-        expect(db_user).to eq(user)
+        expect(db_user).to(eq(user))
       end
 
       context 'when the user is not confirmed yet (:oauth_api_gouv_id unknown)' do
@@ -37,12 +37,12 @@ RSpec.describe OAuthApiGouv::Tasks::RetrieveUserInfo do
           fetch_user!
           user.reload
 
-          expect(user.oauth_api_gouv_id).to eq(hard_coded_id_in_cassette)
+          expect(user.oauth_api_gouv_id).to(eq(hard_coded_id_in_cassette))
         end
 
         describe 'non-regression test' do
           it 'does not send any email to DataPass' do
-            expect(UserMailer).to_not receive(:notify_datapass_for_data_reconciliation)
+            expect(UserMailer).to_not(receive(:notify_datapass_for_data_reconciliation))
 
             fetch_user!
           end
@@ -56,16 +56,16 @@ RSpec.describe OAuthApiGouv::Tasks::RetrieveUserInfo do
           fetch_user!
           user.reload
 
-          expect(user.tokens_newly_transfered).to eq(false)
+          expect(user.tokens_newly_transfered).to(eq(false))
         end
 
         # This is temporary, right now DataPass ensures manually our user
         # tokens are linked to the appropriate access requests (the information
         # might be loss for DataPass after a user account has been transfered
         it 'sends an email to the DataPass support team' do
-          expect(UserMailer).to receive(:notify_datapass_for_data_reconciliation)
+          expect(UserMailer).to(receive(:notify_datapass_for_data_reconciliation)
             .with(user)
-            .and_call_original
+            .and_call_original)
 
           fetch_user!
         end
@@ -76,18 +76,18 @@ RSpec.describe OAuthApiGouv::Tasks::RetrieveUserInfo do
   context 'when the access token is not valid', vcr: { cassette_name: 'oauth_api_gouv_user_info_invalid_token' } do
     let(:token) { 'LET.ME.IN' }
 
-    it { is_expected.to be_failure }
+    it { is_expected.to(be_failure) }
 
     it 'ends in the :failure state' do
       res = fetch_user!
       state = res.event.to_h[:semantic]
 
-      expect(state).to eq(:failure)
+      expect(state).to(eq(:failure))
     end
 
     it 'logs the error' do
-      expect(Rails.logger).to receive(:error)
-        .with(a_string_matching(/OAuth User Info call failed: status \d+, description .+/))
+      expect(Rails.logger).to(receive(:error)
+        .with(a_string_matching(/OAuth User Info call failed: status \d+, description .+/)))
 
       fetch_user!
     end

--- a/spec/concepts/role/operation/create_spec.rb
+++ b/spec/concepts/role/operation/create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Role::Operation::Create do
+RSpec.describe(Role::Operation::Create) do
   let(:role_params) do
     { name: 'Role test', code: 'rol1' }
   end
@@ -10,10 +10,10 @@ RSpec.describe Role::Operation::Create do
     it 'creates a new role' do
       created_role = result[:model]
 
-      expect(result).to be_success
-      expect(created_role).to be_persisted
-      expect(created_role.name).to eq role_params[:name]
-      expect(created_role.code).to eq role_params[:code]
+      expect(result).to(be_success)
+      expect(created_role).to(be_persisted)
+      expect(created_role.name).to(eq(role_params[:name]))
+      expect(created_role.code).to(eq(role_params[:code]))
     end
   end
 
@@ -24,24 +24,24 @@ RSpec.describe Role::Operation::Create do
       it 'is required' do
         role_params[:name] = ''
 
-        expect(result).to be_failure
-        expect(errors).to include 'must be filled'
+        expect(result).to(be_failure)
+        expect(errors).to(include('must be filled'))
       end
 
       it 'is 50 characters max' do
         role_params[:name] = 'a' * 51
 
-        expect(result).to be_failure
-        expect(errors).to include 'size cannot be greater than 50'
+        expect(result).to(be_failure)
+        expect(errors).to(include('size cannot be greater than 50'))
       end
 
       it 'is unique' do
-        role = create :role
+        role = create(:role)
         role_params[:name] = role.name
 
-        expect { result }.to_not change(Role, :count)
-        expect(result).to be_failure
-        expect(errors).to include 'value already exists'
+        expect { result }.to_not(change(Role, :count))
+        expect(result).to(be_failure)
+        expect(errors).to(include('value already exists'))
       end
     end
 
@@ -51,8 +51,8 @@ RSpec.describe Role::Operation::Create do
       it 'is required' do
         role_params[:code] = nil
 
-        expect(result).to be_failure
-        expect(errors).to include 'must be filled'
+        expect(result).to(be_failure)
+        expect(errors).to(include('must be filled'))
       end
 
       # TODO deal with this constraint to restrain jwt size
@@ -64,12 +64,12 @@ RSpec.describe Role::Operation::Create do
       #end
 
       it 'is unique' do
-        role = create :role
+        role = create(:role)
         role_params[:code] = role.code
 
-        expect { result }.to_not change(Role, :count)
-        expect(result).to be_failure
-        expect(errors).to include 'value already exists'
+        expect { result }.to_not(change(Role, :count))
+        expect(result).to(be_failure)
+        expect(errors).to(include('value already exists'))
       end
     end
   end

--- a/spec/concepts/role/operation/db_seed_spec.rb
+++ b/spec/concepts/role/operation/db_seed_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-RSpec.describe Role::Operation::DBSeed do
+RSpec.describe(Role::Operation::DBSeed) do
   describe 'with custom roles seed' do
-    subject { described_class.call roles_seed: roles_seed }
+    subject { described_class.call(roles_seed: roles_seed) }
 
     let(:roles_seed) do
       [
@@ -14,12 +14,12 @@ RSpec.describe Role::Operation::DBSeed do
 
     context 'when roles do not exist' do
       it 'saves them into db' do
-        expect { subject }.to change(Role, :count).by(2)
+        expect { subject }.to(change(Role, :count).by(2))
       end
 
       it 'logs role\'s creation' do
-        expect(log).to include('Role created : name "Role 1", code "rol1"')
-        expect(log).to include('Role created : name "Role 2", code "rol2"')
+        expect(log).to(include('Role created : name "Role 1", code "rol1"'))
+        expect(log).to(include('Role created : name "Role 2", code "rol2"'))
       end
     end
 
@@ -30,12 +30,12 @@ RSpec.describe Role::Operation::DBSeed do
       end
 
       it 'does not saves the roles' do
-        expect { subject }.to_not change(Role, :count)
+        expect { subject }.to_not(change(Role, :count))
       end
 
       it 'logs the error' do
-        expect(log).to include('Warning role already exists : name "Role 1", code "rol1"')
-        expect(log).to include('Warning role already exists : name "Role 2", code "rol2"')
+        expect(log).to(include('Warning role already exists : name "Role 1", code "rol1"'))
+        expect(log).to(include('Warning role already exists : name "Role 2", code "rol2"'))
       end
     end
   end
@@ -44,7 +44,7 @@ RSpec.describe Role::Operation::DBSeed do
     subject { described_class.call }
 
     it 'saves all roles in the database' do
-      expect { subject }.to change(Role, :count).by(22)
+      expect { subject }.to(change(Role, :count).by(22))
     end
   end
 end

--- a/spec/concepts/user/operation/ask_password_renewal_spec.rb
+++ b/spec/concepts/user/operation/ask_password_renewal_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe User::Operation::AskPasswordRenewal do
+RSpec.describe(User::Operation::AskPasswordRenewal) do
   let(:op_params) { { email: account_email } }
 
   subject(:pwd_renewal_request) { described_class.call(params: op_params) }
@@ -13,15 +13,15 @@ RSpec.describe User::Operation::AskPasswordRenewal do
         op_params[:email] = nil
         err_msg = pwd_renewal_request[:errors][:email]
 
-        expect(pwd_renewal_request).to be_failure
-        expect(err_msg).to include('must be filled')
+        expect(pwd_renewal_request).to(be_failure)
+        expect(err_msg).to(include('must be filled'))
       end
 
       it 'must identify an existing user' do
         err_msg = pwd_renewal_request[:errors][:email]
 
-        expect(pwd_renewal_request).to be_failure
-        expect(err_msg).to include("user with email \"#{account_email}\" does not exist")
+        expect(pwd_renewal_request).to(be_failure)
+        expect(err_msg).to(include("user with email \"#{account_email}\" does not exist"))
       end
     end
   end
@@ -30,13 +30,13 @@ RSpec.describe User::Operation::AskPasswordRenewal do
     let(:user) { create(:user) }
     let(:account_email) { user.email }
 
-    it { is_expected.to be_success }
+    it { is_expected.to(be_success) }
 
     it 'sets a renewal token for the user' do
       pwd_renewal_request
       user.reload
 
-      expect(user.pwd_renewal_token).to match(/\A[0-9a-f]{20}\z/)
+      expect(user.pwd_renewal_token).to(match(/\A[0-9a-f]{20}\z/))
     end
 
     it 'sets the timestamp the link has been sent at' do
@@ -44,15 +44,15 @@ RSpec.describe User::Operation::AskPasswordRenewal do
       pwd_renewal_request
       user.reload
 
-      expect(user.pwd_renewal_token_sent_at.to_i).to eq(Time.zone.now.to_i)
+      expect(user.pwd_renewal_token_sent_at.to_i).to(eq(Time.zone.now.to_i))
       Timecop.return
     end
 
     it 'sends a password renewal email' do
-      allow(UserMailer).to receive(:renew_account_password)
-      expect(UserMailer).to receive(:renew_account_password)
+      allow(UserMailer).to(receive(:renew_account_password))
+      expect(UserMailer).to(receive(:renew_account_password)
         .with(an_object_having_attributes(email: account_email, class: User))
-        .and_call_original
+        .and_call_original)
 
       pwd_renewal_request
     end

--- a/spec/concepts/user/operation/create_ghost_spec.rb
+++ b/spec/concepts/user/operation/create_ghost_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe User::Operation::CreateGhost do
+RSpec.describe(User::Operation::CreateGhost) do
   let(:op_params) do
     {
       email: 'new@record.com',
@@ -21,13 +21,13 @@ RSpec.describe User::Operation::CreateGhost do
       it 'is required' do
         op_params[:email] = ''
 
-        expect(errors).to include 'must be filled'
+        expect(errors).to(include('must be filled'))
       end
 
       it 'has an email format' do
         op_params[:email] = 'verymail'
 
-        expect(errors).to include 'is in invalid format'
+        expect(errors).to(include('is in invalid format'))
       end
     end
 
@@ -37,27 +37,27 @@ RSpec.describe User::Operation::CreateGhost do
       it 'is required' do
         op_params[:context] = ''
 
-        expect(errors).to include 'must be filled'
+        expect(errors).to(include('must be filled'))
       end
     end
   end
 
   context 'when :email is valid' do
-    it { is_expected.to be_success }
+    it { is_expected.to(be_success) }
 
     it 'creates a user' do
-      expect { subject }.to change(User, :count).by(1)
+      expect { subject }.to(change(User, :count).by(1))
     end
 
     describe 'new ghost user' do
       let(:ghost_user) { subject[:model] }
 
       it 'does not have an ID API Gouv' do
-        expect(ghost_user.oauth_api_gouv_id).to be_nil
+        expect(ghost_user.oauth_api_gouv_id).to(be_nil)
       end
 
       it 'is not confirmed' do
-        expect(ghost_user).to_not be_confirmed
+        expect(ghost_user).to_not(be_confirmed)
       end
     end
   end
@@ -65,10 +65,10 @@ RSpec.describe User::Operation::CreateGhost do
   context 'when the contract fails' do
     before { op_params.delete(:email) }
 
-    it { is_expected.to be_failure }
+    it { is_expected.to(be_failure) }
 
     it 'does not create a new user' do
-      expect { subject }.to_not change(User, :count)
+      expect { subject }.to_not(change(User, :count))
     end
   end
 end

--- a/spec/concepts/user/operation/create_spec.rb
+++ b/spec/concepts/user/operation/create_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe User::Operation::Create do
+RSpec.describe(User::Operation::Create) do
   let(:user_email) { 'new@record.gg' }
   let(:user_params) do
     {
@@ -16,11 +16,11 @@ RSpec.describe User::Operation::Create do
   context 'when params are valid' do
     let(:new_user) { subject[:model] }
 
-    it { is_expected.to be_success }
+    it { is_expected.to(be_success) }
 
     it 'creates a new user' do
-      expect { subject }.to change(User, :count).by(1)
-      expect(new_user).to be_persisted
+      expect { subject }.to(change(User, :count).by(1))
+      expect(new_user).to(be_persisted)
     end
 
     describe 'created user' do
@@ -29,17 +29,17 @@ RSpec.describe User::Operation::Create do
         result[:model]
       end
 
-      its(:email) { is_expected.to eq(user_params[:email]) }
-      its(:admin) { is_expected.to eq(false) }
-      its(:tokens_newly_transfered) { is_expected.to eq(false) }
-      its(:oauth_api_gouv_id) { is_expected.to eq('31442') }
-      its(:context) { is_expected.to eq(user_params[:context]) }
-      its(:password_digest) { is_expected.to be_blank }
+      its(:email) { is_expected.to(eq(user_params[:email])) }
+      its(:admin) { is_expected.to(eq(false)) }
+      its(:tokens_newly_transfered) { is_expected.to(eq(false)) }
+      its(:oauth_api_gouv_id) { is_expected.to(eq('31442')) }
+      its(:context) { is_expected.to(eq(user_params[:context])) }
+      its(:password_digest) { is_expected.to(be_blank) }
 
       it 'sets the CGU agreement timestamp' do
         params_cgu_time = Time.zone.parse(user_params[:cgu_agreement_date])
 
-        expect(subject.cgu_agreement_date).to eq(params_cgu_time)
+        expect(subject.cgu_agreement_date).to(eq(params_cgu_time))
       end
     end
   end
@@ -53,23 +53,23 @@ RSpec.describe User::Operation::Create do
       it 'is required' do
         user_params[:email] = ''
 
-        expect(subject).to be_failure
-        expect(errors).to include 'must be filled'
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be filled'))
       end
 
       it 'has an email format' do
         user_params[:email] = 'verymail'
 
-        expect(subject).to be_failure
-        expect(errors).to include 'is in invalid format'
+        expect(subject).to(be_failure)
+        expect(errors).to(include('is in invalid format'))
       end
 
       it 'is unique' do
         user = create(:user)
         user_params[:email] = user.email
 
-        expect(subject).to be_failure
-        expect(errors).to include 'value already exists'
+        expect(subject).to(be_failure)
+        expect(errors).to(include('value already exists'))
       end
     end
 
@@ -81,8 +81,8 @@ RSpec.describe User::Operation::Create do
       it 'can be blank' do
         user_params[:context] = ''
 
-        expect(subject).to be_success
-        expect(errors).to be_nil
+        expect(subject).to(be_success)
+        expect(errors).to(be_nil)
       end
     end
 
@@ -92,15 +92,15 @@ RSpec.describe User::Operation::Create do
       it 'is required' do
         user_params.delete(:oauth_api_gouv_id)
 
-        expect(subject).to be_failure
-        expect(errors).to include('must be filled')
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be filled'))
       end
 
       it 'is a string' do
         user_params[:oauth_api_gouv_id] = 123
 
-        expect(subject).to be_failure
-        expect(errors).to include('must be a string')
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be a string'))
       end
     end
 
@@ -112,15 +112,15 @@ RSpec.describe User::Operation::Create do
       it 'is required' do
         user_params.delete(:cgu_agreement_date)
 
-        expect(subject).to be_failure
-        expect(errors).to include('must be filled')
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be filled'))
       end
 
       it 'has a valid date format' do
         user_params[:cgu_agreement_date] = 'not a datetime'
 
-        expect(subject).to be_failure
-        expect(errors).to include('must be a datetime format')
+        expect(subject).to(be_failure)
+        expect(errors).to(include('must be a datetime format'))
       end
     end
   end

--- a/spec/concepts/user/operation/index_spec.rb
+++ b/spec/concepts/user/operation/index_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe User::Operation::Index do
+RSpec.describe(User::Operation::Index) do
   before { create_list(:user, 8) }
 
   let(:op_params) { {} }
@@ -9,22 +9,22 @@ RSpec.describe User::Operation::Index do
   let(:user_list) { subject[:user_list] }
 
   context 'when no filters are provided' do
-    it { is_expected.to be_success }
+    it { is_expected.to(be_success) }
 
     it 'returns all users in database' do
-      expect(user_list).to eq(User.all)
+      expect(user_list).to(eq(User.all))
     end
   end
 
   context 'when filters are provided' do
-    it { is_expected.to be_success }
+    it { is_expected.to(be_success) }
 
     it 'filters by :email' do
       user = User.take
       user.update(email: 'test@lol.fr')
       op_params[:email] = user.email
 
-      expect(user_list).to contain_exactly(user)
+      expect(user_list).to(contain_exactly(user))
     end
 
     it 'filters by :context' do
@@ -32,7 +32,7 @@ RSpec.describe User::Operation::Index do
       user.update(context: 'dat context wow')
       op_params[:context] = user.context
 
-      expect(user_list).to contain_exactly(user)
+      expect(user_list).to(contain_exactly(user))
     end
 
     it 'combines filters' do
@@ -41,14 +41,14 @@ RSpec.describe User::Operation::Index do
       op_params[:email] = user.email
       op_params[:context] = user.context
 
-      expect(user_list).to contain_exactly(user)
+      expect(user_list).to(contain_exactly(user))
     end
 
     it 'returns [] if no user are found' do
       op_params[:email] = 'no_user'
       op_params[:context] = 'whatami'
 
-      expect(user_list).to be_empty
+      expect(user_list).to(be_empty)
     end
   end
 end

--- a/spec/concepts/user/operation/login_spec.rb
+++ b/spec/concepts/user/operation/login_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe User::Operation::Login do
+RSpec.describe(User::Operation::Login) do
   let(:result) { described_class.call(params: login_params) }
 
   context 'when user email is unknown' do
@@ -9,7 +9,7 @@ RSpec.describe User::Operation::Login do
     end
 
     it 'fails authentication' do
-      expect(result).to be_failure
+      expect(result).to(be_failure)
     end
   end
 
@@ -24,7 +24,7 @@ RSpec.describe User::Operation::Login do
       it 'fails authentication' do
         login_params[:password] = 'invalid password'
 
-        expect(result).to be_failure
+        expect(result).to(be_failure)
       end
 
       it 'increments counter before lock'
@@ -32,8 +32,8 @@ RSpec.describe User::Operation::Login do
 
     context 'when incomming params are valid' do
       it 'returns the user' do
-        expect(result).to be_success
-        expect(result[:model]).to eq user
+        expect(result).to(be_success)
+        expect(result[:model]).to(eq(user))
       end
 
       it 'resets counter before lock'
@@ -42,7 +42,7 @@ RSpec.describe User::Operation::Login do
     context 'with empty spaces around email' do
       it 'strips spaces' do
         user.email = '   ' + user.email + '    '
-        expect(result).to be_success
+        expect(result).to(be_success)
       end
     end
 

--- a/spec/concepts/user/operation/reset_password_spec.rb
+++ b/spec/concepts/user/operation/reset_password_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe User::Operation::ResetPassword do
+RSpec.describe(User::Operation::ResetPassword) do
   let(:user) { create(:user, pwd_renewal_token: 'coucou') }
   let(:reset_params) do
     {
@@ -20,16 +20,16 @@ RSpec.describe User::Operation::ResetPassword do
         reset_params[:token] = nil
         subject
 
-        expect(subject).to be_failure
-        expect(errors[:token]).to include('must be filled')
+        expect(subject).to(be_failure)
+        expect(errors[:token]).to(include('must be filled'))
       end
 
       it 'must exists in database' do
         reset_params[:token] = 'ghost'
         subject
 
-        expect(subject).to be_failure
-        expect(errors[:token]).to include('Le lien de régénération de mot de passe est invalide')
+        expect(subject).to(be_failure)
+        expect(errors[:token]).to(include('Le lien de régénération de mot de passe est invalide'))
       end
     end
 
@@ -42,36 +42,36 @@ RSpec.describe User::Operation::ResetPassword do
     context 'when the token has not expired' do
       before { user.update(pwd_renewal_token_sent_at: 12.hours.ago) }
 
-      it { is_expected.to be_success }
+      it { is_expected.to(be_success) }
 
       it 'sets the new password' do
         user = subject[:user]
 
-        expect(user.authenticate(reset_params[:password])).to be_truthy
+        expect(user.authenticate(reset_params[:password])).to(be_truthy)
       end
 
       it 'expires the token' do
         user = subject[:user]
 
-        expect(user.pwd_renewal_token).to eq(nil)
+        expect(user.pwd_renewal_token).to(eq(nil))
       end
     end
 
     context 'when the token has expired' do
       before { user.update(pwd_renewal_token_sent_at: 25.hours.ago) }
 
-      it { is_expected.to be_failure }
+      it { is_expected.to(be_failure) }
 
       it 'does not change the password' do
         user = subject[:user]
 
-        expect(user.authenticate(reset_params[:password])).to eq(false)
+        expect(user.authenticate(reset_params[:password])).to(eq(false))
       end
 
       it 'returns an error' do
         err_msg = subject[:errors]
 
-        expect(err_msg).to eq('Le lien de renouvellement de mot de passe a expiré')
+        expect(err_msg).to(eq('Le lien de renouvellement de mot de passe a expiré'))
       end
     end
   end

--- a/spec/concepts/user/operation/transfer_ownership_spec.rb
+++ b/spec/concepts/user/operation/transfer_ownership_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe User::Operation::TransferOwnership do
+RSpec.describe(User::Operation::TransferOwnership) do
   let(:end_state) { subject.event.to_h[:semantic] }
 
   subject { described_class.call(params: op_params) }
@@ -13,10 +13,10 @@ RSpec.describe User::Operation::TransferOwnership do
       }
     end
 
-    it { is_expected.to be_failure }
+    it { is_expected.to(be_failure) }
 
     it 'ends in :not_found state' do
-      expect(end_state).to eq(:not_found)
+      expect(end_state).to(eq(:not_found))
     end
   end
 
@@ -33,32 +33,32 @@ RSpec.describe User::Operation::TransferOwnership do
       let(:new_owner_email) { 'already@known.com' }
       let!(:new_owner) { create(:user, email: new_owner_email) }
 
-      it { is_expected.to be_success }
+      it { is_expected.to(be_success) }
 
       it 'gives the token ownership to the new user' do
         transfered_jwt_ids = old_owner.jwt_api_entreprise_ids
         subject
 
-        expect(new_owner.jwt_api_entreprise_ids).to include(*transfered_jwt_ids)
+        expect(new_owner.jwt_api_entreprise_ids).to(include(*transfered_jwt_ids))
       end
 
       it 'keeps the existing tokens of the target user' do
         existing_tokens_id = new_owner.jwt_api_entreprise_ids
         subject
 
-        expect(new_owner.jwt_api_entreprise_ids).to include(*existing_tokens_id)
+        expect(new_owner.jwt_api_entreprise_ids).to(include(*existing_tokens_id))
       end
 
       it 'removes token ownership from the old user' do
         subject
 
-        expect(old_owner.jwt_api_entreprise).to be_empty
+        expect(old_owner.jwt_api_entreprise).to(be_empty)
       end
 
       it 'sends a notification email' do
-        expect(UserMailer).to receive(:transfer_ownership)
+        expect(UserMailer).to(receive(:transfer_ownership)
           .with(old_owner, new_owner)
-          .and_call_original
+          .and_call_original)
 
         subject
       end
@@ -67,55 +67,55 @@ RSpec.describe User::Operation::TransferOwnership do
         subject
         new_owner.reload
 
-        expect(new_owner.tokens_newly_transfered).to eq(true)
+        expect(new_owner.tokens_newly_transfered).to(eq(true))
       end
 
       it 'does not create a new user' do
-        expect { subject }.to_not change(User, :count)
+        expect { subject }.to_not(change(User, :count))
       end
     end
 
     context 'when the new owner does not exist in database' do
       let(:new_owner_email) { 'not@known.com' }
 
-      it { is_expected.to be_success }
+      it { is_expected.to(be_success) }
 
       it 'gives the token ownership to the new user' do
         transfered_jwt_ids = old_owner.jwt_api_entreprise_ids
         subject
         new_owner = User.find_by_email(new_owner_email)
 
-        expect(new_owner.jwt_api_entreprise_ids).to eq(transfered_jwt_ids)
+        expect(new_owner.jwt_api_entreprise_ids).to(eq(transfered_jwt_ids))
       end
 
       it 'removes token ownership to the old user' do
         subject
 
-        expect(old_owner.jwt_api_entreprise).to be_empty
+        expect(old_owner.jwt_api_entreprise).to(be_empty)
       end
 
       it 'sends a notification email for account creation' do
-        expect(UserMailer).to receive(:transfer_ownership)
-          .and_call_original
+        expect(UserMailer).to(receive(:transfer_ownership)
+          .and_call_original)
 
         subject
       end
 
       it 'creates the new user record' do
-        expect { subject }.to change(User, :count).by(1)
+        expect { subject }.to(change(User, :count).by(1))
       end
 
       it 'creates a ghost user' do
         subject
         new_owner = User.find_by_email(new_owner_email)
 
-        expect(new_owner).to have_attributes({
+        expect(new_owner).to(have_attributes({
           email: new_owner_email,
           context: old_owner.context,
           oauth_api_gouv_id: nil,
           tokens_newly_transfered: true,
           confirmed?: false
-        })
+        }))
       end
 
       describe 'validation contract' do
@@ -127,20 +127,20 @@ RSpec.describe User::Operation::TransferOwnership do
           it 'is required' do
             op_params[:email] = ''
 
-            expect(errors).to include 'must be filled'
+            expect(errors).to(include('must be filled'))
           end
 
           it 'has an email format' do
             op_params[:email] = 'verymail'
 
-            expect(errors).to include 'is in invalid format'
+            expect(errors).to(include('is in invalid format'))
           end
 
           it 'is failure' do
             op_params[:email] = ''
 
-            expect(subject).to be_failure
-            expect(end_state).to eq(:invalid_params)
+            expect(subject).to(be_failure)
+            expect(end_state).to(eq(:invalid_params))
           end
         end
       end

--- a/spec/concepts/user/operation/update_spec.rb
+++ b/spec/concepts/user/operation/update_spec.rb
@@ -1,7 +1,7 @@
 
 require 'rails_helper'
 
-RSpec.describe User::Operation::Update do
+RSpec.describe(User::Operation::Update) do
   let(:operation_params) do
     {
       id: user_id,
@@ -15,11 +15,11 @@ RSpec.describe User::Operation::Update do
     let(:user_id) { 0 }
 
     it 'fails' do
-      expect(subject).to be_failure
+      expect(subject).to(be_failure)
     end
 
     it 'returns an error message' do
-      expect(subject[:errors]).to include("User with id `#{user_id}` does not exist.")
+      expect(subject[:errors]).to(include("User with id `#{user_id}` does not exist."))
     end
   end
 
@@ -29,19 +29,19 @@ RSpec.describe User::Operation::Update do
       user.id
     end
 
-    it { is_expected.to be_success }
+    it { is_expected.to(be_success) }
 
     describe '#note' do
       it 'is optional' do
         operation_params.delete(:note)
 
-        expect(subject).to be_success
+        expect(subject).to(be_success)
       end
 
       it 'can be updated' do
         updated_user = subject[:model]
 
-        expect(updated_user.note).to eq('Updated description')
+        expect(updated_user.note).to(eq('Updated description'))
       end
     end
 
@@ -49,20 +49,20 @@ RSpec.describe User::Operation::Update do
       it 'is optional' do
         operation_params.delete(:oauth_api_gouv_id)
 
-        expect(subject).to be_success
+        expect(subject).to(be_success)
       end
 
       it 'must be an string' do
         operation_params[:oauth_api_gouv_id] = 42
 
-        expect(subject).to be_failure
-        expect(subject[:errors]).to eq(oauth_api_gouv_id: ['must be a string'])
+        expect(subject).to(be_failure)
+        expect(subject[:errors]).to(eq(oauth_api_gouv_id: ['must be a string']))
       end
 
       it 'can be updated' do
         updated_user = subject[:model]
 
-        expect(updated_user.oauth_api_gouv_id).to eq('9001')
+        expect(updated_user.oauth_api_gouv_id).to(eq('9001'))
       end
     end
   end

--- a/spec/controllers/incidents_controller_spec.rb
+++ b/spec/controllers/incidents_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe IncidentsController, type: :controller do
+RSpec.describe(IncidentsController, type: :controller) do
   describe '#index' do
     let(:nb_incidents) { 5 }
     let(:body) { JSON.parse(response.body, symbolize_names: true) }
@@ -10,21 +10,21 @@ RSpec.describe IncidentsController, type: :controller do
     end
 
     it 'returns 200' do
-      expect(response.code).to eq '200'
+      expect(response.code).to(eq('200'))
     end
 
     it 'returns the right payload format' do
-      expect(body).to be_an_instance_of(Array)
-      expect(body.size).to eq(5)
+      expect(body).to(be_an_instance_of(Array))
+      expect(body.size).to(eq(5))
 
       incident_raw = body.first
-      expect(incident_raw).to be_an_instance_of(Hash)
-      expect(incident_raw.size).to eq(5)
-      expect(incident_raw.key?(:id)).to eq(true)
-      expect(incident_raw.key?(:title)).to eq(true)
-      expect(incident_raw.key?(:subtitle)).to eq(true)
-      expect(incident_raw.key?(:description)).to eq(true)
-      expect(incident_raw.key?(:created_at)).to eq(true)
+      expect(incident_raw).to(be_an_instance_of(Hash))
+      expect(incident_raw.size).to(eq(5))
+      expect(incident_raw.key?(:id)).to(eq(true))
+      expect(incident_raw.key?(:title)).to(eq(true))
+      expect(incident_raw.key?(:subtitle)).to(eq(true))
+      expect(incident_raw.key?(:description)).to(eq(true))
+      expect(incident_raw.key?(:created_at)).to(eq(true))
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.describe IncidentsController, type: :controller do
       it_behaves_like 'client user unauthorized', :post, :create
 
       it 'does not save the incident' do
-        expect { subject }.to_not change(Incident, :count)
+        expect { subject }.to_not(change(Incident, :count))
       end
     end
 
@@ -47,11 +47,11 @@ RSpec.describe IncidentsController, type: :controller do
       context 'when params are valid' do
         it 'returns code 201' do
           subject
-          expect(response.code).to eq('201')
+          expect(response.code).to(eq('201'))
         end
 
         it 'saves the new incident' do
-          expect { subject }.to change(Incident, :count).by(1)
+          expect { subject }.to(change(Incident, :count).by(1))
         end
       end
 
@@ -59,12 +59,12 @@ RSpec.describe IncidentsController, type: :controller do
         before { incident_params.delete(:title) }
 
         it 'does not save the incident' do
-          expect { subject }.to_not change(Incident, :count)
+          expect { subject }.to_not(change(Incident, :count))
         end
 
         it 'returns 422' do
           subject
-          expect(response.code).to eq('422')
+          expect(response.code).to(eq('422'))
         end
       end
     end
@@ -88,7 +88,7 @@ RSpec.describe IncidentsController, type: :controller do
         subject
         incident.reload
 
-        expect(incident.title).not_to eq('Test update')
+        expect(incident.title).not_to(eq('Test update'))
       end
     end
 
@@ -98,7 +98,7 @@ RSpec.describe IncidentsController, type: :controller do
       context 'when params are valid' do
         it 'returns code 200' do
           subject
-          expect(response.code).to eq('200')
+          expect(response.code).to(eq('200'))
         end
 
         it 'updates the incident' do
@@ -106,7 +106,7 @@ RSpec.describe IncidentsController, type: :controller do
           subject
           incident.reload
 
-          expect(incident.title).to eq('Updated title')
+          expect(incident.title).to(eq('Updated title'))
         end
       end
 
@@ -120,12 +120,12 @@ RSpec.describe IncidentsController, type: :controller do
           subject
           incident.reload
 
-          expect(incident.subtitle).not_to eq('Updated subtitle')
+          expect(incident.subtitle).not_to(eq('Updated subtitle'))
         end
 
         it 'returns 422' do
           subject
-          expect(response.code).to eq('422')
+          expect(response.code).to(eq('422'))
         end
       end
     end

--- a/spec/controllers/jwt_api_entreprise_controller_spec.rb
+++ b/spec/controllers/jwt_api_entreprise_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe JwtApiEntrepriseController, type: :controller do
+RSpec.describe(JwtApiEntrepriseController, type: :controller) do
   let(:token_params) do
     {
       roles: jwt_roles,
@@ -22,19 +22,19 @@ RSpec.describe JwtApiEntrepriseController, type: :controller do
       it 'returns an HTTP code 200' do
         get :index
 
-        expect(response.code).to eq('200')
+        expect(response.code).to(eq('200'))
       end
 
       it 'returns all JWT from the database' do
         get :index
 
-        expect(response_json.size).to eq(8)
+        expect(response_json.size).to(eq(8))
       end
 
       it 'has a valid payload' do
         get :index
 
-        expect(response_json).to all(
+        expect(response_json).to(all(
           match({
             id: String,
             user_id: String,
@@ -45,7 +45,7 @@ RSpec.describe JwtApiEntrepriseController, type: :controller do
             archived: be(true).or(be(false)),
             authorization_request_id: String
           })
-        )
+        ))
       end
     end
 
@@ -84,24 +84,24 @@ RSpec.describe JwtApiEntrepriseController, type: :controller do
 
       context 'when data is valid' do
         it 'creates a valid token' do
-          expect { post :create, params: token_params }
-            .to change(JwtApiEntreprise, :count).by(1)
+          expect { post(:create, params: token_params) }
+            .to(change(JwtApiEntreprise, :count).by(1))
         end
 
         it 'creates the contacts' do
-          expect { post :create, params: token_params }
-            .to change(Contact, :count).by(2)
+          expect { post(:create, params: token_params) }
+            .to(change(Contact, :count).by(2))
         end
 
         it 'returns code 201' do
           post :create, params: token_params
-          expect(response.code).to eq '201'
+          expect(response.code).to(eq('201'))
         end
 
         it 'returns the created JWT' do
           post :create, params: token_params
 
-          expect(response_json[:new_token]).to be_a(String)
+          expect(response_json[:new_token]).to(be_a(String))
         end
       end
 
@@ -114,22 +114,22 @@ RSpec.describe JwtApiEntrepriseController, type: :controller do
         it 'returns a 422' do
           post :create, params: invalid_params
 
-          expect(response.code).to eq '422'
+          expect(response.code).to(eq('422'))
         end
 
         it 'returns error messages' do
           post :create, params: invalid_params
 
-          expect(response_json).to match({
+          expect(response_json).to(match({
             errors: {
               user_id: a_collection_including(String)
             }
-          })
+          }))
         end
 
         it 'does not create the token' do
-          expect { post :create, params: invalid_params }
-            .to_not change(JwtApiEntreprise, :count)
+          expect { post(:create, params: invalid_params) }
+            .to_not(change(JwtApiEntreprise, :count))
         end
       end
     end
@@ -156,19 +156,19 @@ RSpec.describe JwtApiEntrepriseController, type: :controller do
         it 'changes updatable attributes' do
           update!
 
-          expect(jwt.reload).to have_attributes(archived: true, blacklisted: true)
+          expect(jwt.reload).to(have_attributes(archived: true, blacklisted: true))
         end
 
         it 'ignores non-updatable attributes' do
           update!
 
-          expect(jwt.reload.subject).to_not eq('New subject')
+          expect(jwt.reload.subject).to_not(eq('New subject'))
         end
 
         it 'returns an HTTP code 200' do
           update!
 
-          expect(response.code).to eq('200')
+          expect(response.code).to(eq('200'))
         end
       end
 
@@ -176,11 +176,11 @@ RSpec.describe JwtApiEntrepriseController, type: :controller do
         before { patch :update, params: { id: 0 }, as: :json }
 
         it 'returns an HTTP code 422' do
-          expect(response.code).to eq('422')
+          expect(response.code).to(eq('422'))
         end
 
         it 'returns an error message' do
-          expect(response_json).to include(:errors)
+          expect(response_json).to(include(:errors))
         end
       end
     end

--- a/spec/controllers/oauth_api_gouv_controller_spec.rb
+++ b/spec/controllers/oauth_api_gouv_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe OAuthApiGouvController, type: :controller do
+RSpec.describe(OAuthApiGouvController, type: :controller) do
   describe '#login' do
     let(:login_params) { { authorization_code: code } }
 
@@ -14,13 +14,13 @@ RSpec.describe OAuthApiGouvController, type: :controller do
         it 'returns HTTP code 200' do
           get :login, params: login_params, as: :json
 
-          expect(response.code).to eq('200')
+          expect(response.code).to(eq('200'))
         end
 
         it 'returns an access token' do
           get :login, params: login_params, as: :json
 
-          expect(response_json).to include(access_token: String)
+          expect(response_json).to(include(access_token: String))
         end
       end
 
@@ -28,14 +28,14 @@ RSpec.describe OAuthApiGouvController, type: :controller do
         it 'returns HTTP code 422' do
           get :login, params: login_params, as: :json
 
-          expect(response.code).to eq('422')
+          expect(response.code).to(eq('422'))
         end
 
         it 'returns an error message' do
           get :login, params: login_params, as: :json
           msg = response_json[:errors]
 
-          expect(msg).to eq('Utilisateur inconnu du service API Entreprise.')
+          expect(msg).to(eq('Utilisateur inconnu du service API Entreprise.'))
         end
       end
 
@@ -43,14 +43,14 @@ RSpec.describe OAuthApiGouvController, type: :controller do
         it 'returns HTTP code 502' do
           get :login, params: login_params, as: :json
 
-          expect(response.code).to eq('502')
+          expect(response.code).to(eq('502'))
         end
 
         it 'returns an error message' do
           get :login, params: login_params, as: :json
           msg = response_json[:errors]
 
-          expect(msg).to eq('Une erreur est survenue lors des échanges avec OAuth API Gouv. Contactez API Entreprise à support@entreprise.api.gouv.fr si le problème persiste.')
+          expect(msg).to(eq('Une erreur est survenue lors des échanges avec OAuth API Gouv. Contactez API Entreprise à support@entreprise.api.gouv.fr si le problème persiste.'))
         end
       end
     end
@@ -61,14 +61,14 @@ RSpec.describe OAuthApiGouvController, type: :controller do
       it 'returns HTTP code 401' do
         get :login, params: login_params, as: :json
 
-        expect(response.code).to eq('401')
+        expect(response.code).to(eq('401'))
       end
 
       it 'returns an error message' do
         get :login, params: login_params, as: :json
         msg = response_json[:errors]
 
-        expect(msg).to eq('Erreur lors de l\'authentification : authorization code invalide.')
+        expect(msg).to(eq('Erreur lors de l\'authentification : authorization code invalide.'))
       end
     end
 
@@ -78,14 +78,14 @@ RSpec.describe OAuthApiGouvController, type: :controller do
       it 'returns HTTP code 422' do
         get :login, params: login_params, as: :json
 
-        expect(response.code).to eq('422')
+        expect(response.code).to(eq('422'))
       end
 
       it 'returns an error message' do
         get :login, params: login_params, as: :json
         msg = response_json[:errors]
 
-        expect(msg).to eq(authorization_code: ['must be filled'])
+        expect(msg).to(eq(authorization_code: ['must be filled']))
       end
     end
   end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe RolesController, type: :controller do
+RSpec.describe(RolesController, type: :controller) do
   describe '#index' do
     let(:nb_roles) { 8 }
     before do
@@ -11,21 +11,21 @@ RSpec.describe RolesController, type: :controller do
       get :index
       body = JSON.parse(response.body, symbolize_names: true)
 
-      expect(response.code).to eq '200'
-      expect(body.size).to eq nb_roles
+      expect(response.code).to(eq('200'))
+      expect(body.size).to(eq(nb_roles))
     end
 
     it 'returns the right payload format' do
       get :index
       body = JSON.parse(response.body, symbolize_names: true)
-      expect(body).to be_an_instance_of Array
+      expect(body).to(be_an_instance_of(Array))
 
       role_raw = body.first
-      expect(role_raw).to be_an_instance_of Hash
-      expect(role_raw.size).to eq 3
-      expect(role_raw.key?(:id)).to be true
-      expect(role_raw.key?(:name)).to be true
-      expect(role_raw.key?(:code)).to be true
+      expect(role_raw).to(be_an_instance_of(Hash))
+      expect(role_raw.size).to(eq(3))
+      expect(role_raw.key?(:id)).to(be(true))
+      expect(role_raw.key?(:name)).to(be(true))
+      expect(role_raw.key?(:code)).to(be(true))
     end
 
     # TODO re-add authorizations for role index (login needed or OAuth application token)
@@ -48,13 +48,13 @@ RSpec.describe RolesController, type: :controller do
 
       context 'when data are valid' do
         it 'creates a valid role' do
-          expect { post :create, params: role_params }
-            .to change(Role, :count).by(1)
+          expect { post(:create, params: role_params) }
+            .to(change(Role, :count).by(1))
         end
 
         it 'returns code 201' do
           post :create, params: role_params
-          expect(response.code).to eq '201'
+          expect(response.code).to(eq('201'))
         end
       end
 
@@ -62,12 +62,12 @@ RSpec.describe RolesController, type: :controller do
         before { role_params[:name] = '' }
 
         it 'does not save the role' do
-          expect { post :create, params: role_params }.to_not change(Role, :count)
+          expect { post(:create, params: role_params) }.to_not(change(Role, :count))
         end
 
         it 'returns code 422' do
           post :create, params: role_params
-          expect(response.code).to eq '422'
+          expect(response.code).to(eq('422'))
         end
       end
     end
@@ -77,7 +77,7 @@ RSpec.describe RolesController, type: :controller do
       it_behaves_like 'client user unauthorized', :post, :create
 
       it 'does not save the role' do
-        expect { post :create, params: role_params }.to_not change(Role, :count)
+        expect { post(:create, params: role_params) }.to_not(change(Role, :count))
       end
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe UsersController, type: :controller do
+RSpec.describe(UsersController, type: :controller) do
   describe '#index' do
     before { create_list(:user, 5) }
 
@@ -11,30 +11,30 @@ RSpec.describe UsersController, type: :controller do
         before { get :index }
 
         it 'returns an HTTP code 200' do
-          expect(response.code).to eq('200')
+          expect(response.code).to(eq('200'))
         end
 
         it 'calls User::Operation::Index' do
-          expect(User::Operation::Index).to receive(:call)
-            .and_call_original
+          expect(User::Operation::Index).to(receive(:call)
+            .and_call_original)
 
           get :index
         end
 
         it 'returns all users from database' do
           # Pretty ugly... We have one more user than the 5 created: the admin
-          expect(response_json.size).to eq(6)
+          expect(response_json.size).to(eq(6))
         end
 
         it 'returns the correct payload format' do
-          expect(response_json).to all(match({
+          expect(response_json).to(all(match({
             id: a_kind_of(String),
             email: a_kind_of(String),
             context: a_kind_of(String),
             confirmed: be(true).or(be(false)),
             oauth_api_gouv_id: a_kind_of(String),
             created_at: a_kind_of(String),
-          }))
+          })))
         end
       end
 
@@ -43,9 +43,9 @@ RSpec.describe UsersController, type: :controller do
           User.take.update(email: 'random_query')
           get :index, params: { email: 'random_query' }, as: :json
 
-          expect(response_json).to contain_exactly(
+          expect(response_json).to(contain_exactly(
             a_hash_including(email: 'random_query')
-          )
+          ))
         end
       end
     end
@@ -68,8 +68,8 @@ RSpec.describe UsersController, type: :controller do
 
       it 'calls the operation to create a user' do
         expect(User::Operation::Create)
-          .to receive(:call)
-          .and_call_original
+          .to(receive(:call)
+          .and_call_original)
 
         post(:create, params: user_params, as: :json)
       end
@@ -84,14 +84,14 @@ RSpec.describe UsersController, type: :controller do
         end
 
         it 'returns code 422' do
-          expect(response.code).to eq('422')
+          expect(response.code).to(eq('422'))
         end
 
         it 'returns errors' do
-          expect(response_json).to match(
+          expect(response_json).to(match(
             errors: {
               email: a_collection_including(kind_of(String))
-            })
+            }))
         end
       end
 
@@ -101,19 +101,19 @@ RSpec.describe UsersController, type: :controller do
         # in the operation unit tests
         it 'saves the user into the database' do
           expect { post(:create, params: user_params, as: :json) }
-            .to change(User, :count).by(1)
+            .to(change(User, :count).by(1))
         end
 
         it 'returns code 201' do
           post(:create, params: user_params, as: :json)
 
-          expect(response.code).to eq('201')
+          expect(response.code).to(eq('201'))
         end
 
         it 'returns the created user' do
           post(:create, params: user_params, as: :json)
 
-          expect(response_json).to match({
+          expect(response_json).to(match({
             id: a_kind_of(String),
             email: a_kind_of(String),
             context: a_kind_of(String),
@@ -121,7 +121,7 @@ RSpec.describe UsersController, type: :controller do
             note: '',
             tokens: [],
             contacts: [],
-          })
+          }))
         end
       end
     end
@@ -147,7 +147,7 @@ RSpec.describe UsersController, type: :controller do
       it 'returns the user data' do
         get :show, params: { id: user.id }
 
-        expect(response_json).to include({
+        expect(response_json).to(include({
           id: a_kind_of(String),
           email: a_kind_of(String),
           context: a_kind_of(String),
@@ -175,7 +175,7 @@ RSpec.describe UsersController, type: :controller do
               contact_type: a_kind_of(String)
             )
           )
-        })
+        }))
       end
     end
 
@@ -186,7 +186,7 @@ RSpec.describe UsersController, type: :controller do
         it 'returns 404' do
           get :show, params: { id: 0 }
 
-          expect(response.code).to eq('404')
+          expect(response.code).to(eq('404'))
         end
       end
 
@@ -196,47 +196,47 @@ RSpec.describe UsersController, type: :controller do
         it 'shows blacklisted jwt' do
           get :show, params: { id: user.id }
 
-          expect(response_json).to include(
+          expect(response_json).to(include(
             tokens: a_collection_including(a_hash_including({
               blacklisted: true
             }))
-          )
+          ))
         end
 
         it 'shows archived jwt' do
           get :show, params: { id: user.id }
 
-          expect(response_json).to include(
+          expect(response_json).to(include(
             tokens: a_collection_including(a_hash_including({
               archived: true
             }))
-          )
+          ))
         end
 
         it 'returns the user note attribute' do
           get :show, params: { id: user.id }
 
-          expect(response_json).to include(:note)
+          expect(response_json).to(include(:note))
         end
 
         it 'shows contacts of archived JWT' do
           get :show, params: { id: user.id }
 
-          expect(response_json).to include(
+          expect(response_json).to(include(
             contacts: a_collection_including(a_hash_including({
               jwt_id: archived_jwt.id
             }))
-          )
+          ))
         end
 
         it 'shows contacts of blacklisted JWT' do
           get :show, params: { id: user.id }
 
-          expect(response_json).to include(
+          expect(response_json).to(include(
             contacts: a_collection_including(a_hash_including({
               jwt_id: blacklisted_jwt.id
             }))
-          )
+          ))
         end
 
         it 'returns the user\'s expired tokens' do
@@ -244,7 +244,7 @@ RSpec.describe UsersController, type: :controller do
           tokens_in_payload = response_json[:tokens]
           tokens_ids_in_payload = tokens_in_payload.map! { |t| t[:id] }
 
-          expect(tokens_ids_in_payload).to include(*expired_jwt.ids)
+          expect(tokens_ids_in_payload).to(include(*expired_jwt.ids))
         end
       end
     end
@@ -257,25 +257,25 @@ RSpec.describe UsersController, type: :controller do
       it 'responds with an HTTP code 200' do
         get :show, params: { id: user.id }
 
-        expect(response.code).to eq('200')
+        expect(response.code).to(eq('200'))
       end
 
       it 'does not return the user note attribute' do
         get :show, params: { id: user.id }
 
-        expect(response_json).to_not include(:note)
+        expect(response_json).to_not(include(:note))
       end
 
       it 'does not return the user blacklisted jwt' do
         get :show, params: { id: user.id }
 
-        expect(response_json[:tokens]).to all(include(blacklisted: false))
+        expect(response_json[:tokens]).to(all(include(blacklisted: false)))
       end
 
       it 'does not return the user archived jwt' do
         get :show, params: { id: user.id }
 
-        expect(response_json[:tokens]).to all(include(archived: false))
+        expect(response_json[:tokens]).to(all(include(archived: false)))
       end
 
       it 'does not return the user\'s expired tokens' do
@@ -283,27 +283,27 @@ RSpec.describe UsersController, type: :controller do
         tokens_in_payload = response_json[:tokens]
         tokens_ids_in_payload = tokens_in_payload.map! { |t| t[:id] }
 
-        expect(tokens_ids_in_payload).to_not include(*expired_jwt.ids)
+        expect(tokens_ids_in_payload).to_not(include(*expired_jwt.ids))
       end
 
       it 'denies access to other users data' do
         another_user = create(:user)
         get :show, params: { id: another_user.id }
 
-        expect(response.code).to eq('403')
+        expect(response.code).to(eq('403'))
       end
 
       describe 'associated contacts' do
         it 'does not return contacts for an archived token' do
           get :show, params: { id: user.id }
 
-          expect(response_json[:contacts]).to_not include(a_hash_including(jwt_id: archived_jwt.id))
+          expect(response_json[:contacts]).to_not(include(a_hash_including(jwt_id: archived_jwt.id)))
         end
 
         it 'does not return contacts for a blacklisted token' do
           get :show, params: { id: user.id }
 
-          expect(response_json[:contacts]).to_not include(a_hash_including(jwt_id: blacklisted_jwt.id))
+          expect(response_json[:contacts]).to_not(include(a_hash_including(jwt_id: blacklisted_jwt.id)))
         end
       end
     end
@@ -317,12 +317,12 @@ RSpec.describe UsersController, type: :controller do
         it 'returns 404' do
           delete :destroy, params: { id: 0 }
 
-          expect(response.code).to eq('404')
+          expect(response.code).to(eq('404'))
         end
 
         it 'does not change the database' do
-          expect { delete :destroy, params: { id: 0 } }
-            .to_not change(User, :count)
+          expect { delete(:destroy, params: { id: 0 }) }
+            .to_not(change(User, :count))
         end
       end
 
@@ -331,13 +331,13 @@ RSpec.describe UsersController, type: :controller do
           user = create(:user)
           delete :destroy, params: { id: user.id }
 
-          expect(response.code).to eq('204')
+          expect(response.code).to(eq('204'))
         end
 
         it 'deletes the user' do
           user = create(:user)
-          expect { delete :destroy, params: { id: user.id } }
-            .to change(User, :count).by(-1)
+          expect { delete(:destroy, params: { id: user.id }) }
+            .to(change(User, :count).by(-1))
         end
 
         pending 'it deletes associated tokens'
@@ -361,11 +361,11 @@ RSpec.describe UsersController, type: :controller do
       before { post :password_reset, params: pwd_reset_params }
 
       it 'returns an HTTP code 200' do
-        expect(response.code).to eq('200')
+        expect(response.code).to(eq('200'))
       end
 
       it 'returns a JWT token for the user to be logged in' do
-        expect(response_json).to include(access_token: a_kind_of(String))
+        expect(response_json).to(include(access_token: a_kind_of(String)))
       end
     end
 
@@ -376,11 +376,11 @@ RSpec.describe UsersController, type: :controller do
       end
 
       it 'returns a HTTP code 422' do
-        expect(response.code).to eq('422')
+        expect(response.code).to(eq('422'))
       end
 
       it 'returns an error message' do
-        expect(response_json).to match({ errors: { token: ['is missing']}})
+        expect(response_json).to(match({ errors: { token: ['is missing']}}))
       end
     end
   end
@@ -405,7 +405,7 @@ RSpec.describe UsersController, type: :controller do
         update_user!
         user.reload
 
-        expect(user.note).not_to eq('Test update')
+        expect(user.note).not_to(eq('Test update'))
       end
     end
 
@@ -416,17 +416,17 @@ RSpec.describe UsersController, type: :controller do
         it 'returns code 200' do
           update_user!
 
-          expect(response.code).to eq('200')
+          expect(response.code).to(eq('200'))
         end
 
         it 'updates the user' do
           update_user!
           user.reload
 
-          expect(user).to have_attributes({
+          expect(user).to(have_attributes({
             note: 'Test update',
             oauth_api_gouv_id: '9001'
-          })
+          }))
         end
       end
     end
@@ -443,13 +443,13 @@ RSpec.describe UsersController, type: :controller do
       it 'returns a HTTP code 422' do
         subject
 
-        expect(response.code).to eq('422')
+        expect(response.code).to(eq('422'))
       end
 
       it 'returns an error message' do
         subject
 
-        expect(response_json).to match({ errors: { email: ['must be filled'] } })
+        expect(response_json).to(match({ errors: { email: ['must be filled'] } }))
       end
     end
 
@@ -457,13 +457,13 @@ RSpec.describe UsersController, type: :controller do
       it 'returns a HTTP code 422' do
         subject
 
-        expect(response.code).to eq('422')
+        expect(response.code).to(eq('422'))
       end
 
       it 'returns an error message' do
         subject
 
-        expect(response_json).to match({ errors: { email: ['user with email "test_email" does not exist'] } })
+        expect(response_json).to(match({ errors: { email: ['user with email "test_email" does not exist'] } }))
       end
     end
 
@@ -476,17 +476,17 @@ RSpec.describe UsersController, type: :controller do
       it 'returns a HTTP code 200' do
         subject
 
-        expect(response.code).to eq('200')
+        expect(response.code).to(eq('200'))
       end
 
       it 'returns an empty payload' do
         subject
 
-        expect(response_json).to eq({})
+        expect(response_json).to(eq({}))
       end
 
       it 'sends an email' do
-        expect(UserMailer).to receive(:renew_account_password).and_call_original
+        expect(UserMailer).to(receive(:renew_account_password).and_call_original)
 
         subject
       end
@@ -506,24 +506,24 @@ RSpec.describe UsersController, type: :controller do
         it 'returns HTTP code 200' do
           call!
 
-          expect(response.status).to eq(200)
+          expect(response.status).to(eq(200))
         end
 
         it 'returns the current user payload without any JWT' do
           call!
 
-          expect(response_json).to include({
+          expect(response_json).to(include({
             id: old_owner.id,
             email: old_owner.email,
             context: old_owner.context,
             oauth_api_gouv_id: old_owner.oauth_api_gouv_id,
             contacts: [],
             tokens: []
-          })
+          }))
         end
 
         it 'calls the underlying operation' do
-          expect(User::Operation::TransferOwnership).to receive(:call).and_call_original
+          expect(User::Operation::TransferOwnership).to(receive(:call).and_call_original)
 
           call!
         end
@@ -535,15 +535,15 @@ RSpec.describe UsersController, type: :controller do
         it 'returns HTTP code 422' do
           call!
 
-          expect(response.status).to eq(422)
+          expect(response.status).to(eq(422))
         end
 
         it 'returns an error message' do
           call!
 
-          expect(response_json).to match({
+          expect(response_json).to(match({
             errors: { email: ['is in invalid format'] }
-          })
+          }))
         end
       end
     end
@@ -568,13 +568,13 @@ RSpec.describe UsersController, type: :controller do
       before { call! }
 
       it 'returns HTTP code 403' do
-        expect(response.status).to eq(403)
+        expect(response.status).to(eq(403))
       end
 
       it 'returns an error message' do
-        expect(response_json).to match({
+        expect(response_json).to(match({
           errors: 'Forbidden'
-        })
+        }))
       end
     end
   end

--- a/spec/jobs/access_request_satisfaction_survey_job_spec.rb
+++ b/spec/jobs/access_request_satisfaction_survey_job_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
-RSpec.describe AccessRequestSatisfactionSurveyJob do
+RSpec.describe(AccessRequestSatisfactionSurveyJob) do
   subject { described_class }
 
   it 'calls the operation' do
-    expect(JwtApiEntreprise::Operation::AccessRequestSatisfactionSurvey).to receive(:call)
+    expect(JwtApiEntreprise::Operation::AccessRequestSatisfactionSurvey).to(receive(:call))
     subject.perform_now
   end
 end

--- a/spec/jobs/jwt_api_entreprise_expiration_notice_job_spec.rb
+++ b/spec/jobs/jwt_api_entreprise_expiration_notice_job_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe JwtApiEntrepriseExpirationNoticeJob do
+RSpec.describe(JwtApiEntrepriseExpirationNoticeJob) do
   subject { described_class.perform_now }
 
   shared_examples 'sending expiration notices' do |nb_days|
@@ -10,7 +10,7 @@ RSpec.describe JwtApiEntrepriseExpirationNoticeJob do
 
       subject
 
-      expect(notifier_spy).to have_received(:call).with(expire_in: nb_days)
+      expect(notifier_spy).to(have_received(:call).with(expire_in: nb_days))
     end
   end
 

--- a/spec/lib/access_token_spec.rb
+++ b/spec/lib/access_token_spec.rb
@@ -1,21 +1,21 @@
 require 'rails_helper'
 
-RSpec.describe AccessToken do
+RSpec.describe(AccessToken) do
   context 'token encoding' do
     payload = { data: 'test', more_data: 'verytest' }
-    token = described_class.create payload
+    token = described_class.create(payload)
 
     it 'returns a token from a hash payload' do
-      expect(token).to be_a String
+      expect(token).to(be_a(String))
     end
 
     it 'decodes a valid token' do
-      expect(described_class.decode(token)).to include payload
+      expect(described_class.decode(token)).to(include(payload))
     end
 
     it 'raises error on invalid token' do
       expect { described_class.decode(token + 'a') }
-        .to raise_error JWT::VerificationError
+        .to(raise_error(JWT::VerificationError))
     end
   end
 end

--- a/spec/lib/account_access_token_spec.rb
+++ b/spec/lib/account_access_token_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 # TODO Replace "account" naming with "session"
 # JWT emited by doorkeeper on user login
-RSpec.describe 'JWT for account data access', type: :jwt do
+RSpec.describe('JWT for account data access', type: :jwt) do
   let(:user) { create(:user) }
   let(:token_payload) do
     # call JWTF the way Doorkeeper does
@@ -12,14 +12,14 @@ RSpec.describe 'JWT for account data access', type: :jwt do
   end
 
   it 'contains the user UUID' do
-    expect(token_payload[:uid]).to eq user.id
+    expect(token_payload[:uid]).to(eq(user.id))
   end
 
   it 'contains the creation date timestamp' do
     Timecop.freeze
     creation_timestamp = token_payload[:iat]
 
-    expect(creation_timestamp).to eq(Time.zone.now.to_i)
+    expect(creation_timestamp).to(eq(Time.zone.now.to_i))
     Timecop.return
   end
 
@@ -29,6 +29,6 @@ RSpec.describe 'JWT for account data access', type: :jwt do
 
     # giving the test 2 seconds lag security
     expect(expiration_timestamp)
-      .to be_within(2).of(creation_timestamp + (4*3600))
+      .to(be_within(2).of(creation_timestamp + (4*3600)))
   end
 end

--- a/spec/lib/jwt_user_spec.rb
+++ b/spec/lib/jwt_user_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe JwtUser, type: :jwt do
+RSpec.describe(JwtUser, type: :jwt) do
   let(:token_payload) do
     # call JWTF the way Doorkeeper does
     token = JWTF.generate(resource_owner_id: user_id)
@@ -15,6 +15,6 @@ RSpec.describe JwtUser, type: :jwt do
       admin.id
     end
 
-    its(:admin?) { is_expected.to eq(true) }
+    its(:admin?) { is_expected.to(eq(true)) }
   end
 end

--- a/spec/mailers/jwt_api_entreprise_mailer_spec.rb
+++ b/spec/mailers/jwt_api_entreprise_mailer_spec.rb
@@ -1,49 +1,49 @@
 require 'rails_helper'
 
-RSpec.describe JwtApiEntrepriseMailer, type: :mailer do
+RSpec.describe(JwtApiEntrepriseMailer, type: :mailer) do
   describe 'Expiration notices (old and new)' do
     let(:jwt) { create(:jwt_api_entreprise, :with_contacts) }
     let(:user) { jwt.user }
     let(:nb_days) { '4000' }
 
     shared_examples 'expiration notice' do
-      its(:subject) { is_expected.to eq("API Entreprise - Votre jeton expire dans #{nb_days} jours !") }
-      its(:from) { is_expected.to include(Rails.configuration.emails_sender_address) }
+      its(:subject) { is_expected.to(eq("API Entreprise - Votre jeton expire dans #{nb_days} jours !")) }
+      its(:from) { is_expected.to(include(Rails.configuration.emails_sender_address)) }
 
       describe 'notification recipients' do
         it 'sends the email to the account owner' do
           subject
 
-          expect(subject.to).to include(user.email)
+          expect(subject.to).to(include(user.email))
         end
 
         it 'sends the email to all jwt\'s contacts' do
           contacts_emails = jwt.contacts.pluck(:email).uniq
 
-          expect(subject.to).to include(*contacts_emails)
+          expect(subject.to).to(include(*contacts_emails))
         end
       end
 
       it 'contains the number of remaining days' do
         tested_corpus = "Un de vos jetons d'accès à API Entreprise expire dans moins de #{nb_days} jours."
 
-        expect(subject.html_part.decoded).to include(tested_corpus)
-        expect(subject.text_part.decoded).to include(tested_corpus)
+        expect(subject.html_part.decoded).to(include(tested_corpus))
+        expect(subject.text_part.decoded).to(include(tested_corpus))
       end
 
       it 'contains the JWT information' do
         jwt_info = "le jeton attribué dans le cadre d'utilisation \"#{jwt.subject}\" (id : #{jwt.id}) ne sera bientôt plus valide !"
 
-        expect(subject.html_part.decoded).to include(jwt_info)
-        expect(subject.text_part.decoded).to include(jwt_info)
+        expect(subject.html_part.decoded).to(include(jwt_info))
+        expect(subject.text_part.decoded).to(include(jwt_info))
       end
 
       it 'contains the exact expiration time of the JWT' do
         expiration_datetime = jwt.user_friendly_exp_date
         tested_corpus = "Passée la date du #{expiration_datetime} les appels à API Entreprise avec ce jeton seront rejetés."
 
-        expect(subject.html_part.decoded).to include(tested_corpus)
-        expect(subject.text_part.decoded).to include(tested_corpus)
+        expect(subject.html_part.decoded).to(include(tested_corpus))
+        expect(subject.text_part.decoded).to(include(tested_corpus))
       end
     end
 
@@ -55,22 +55,22 @@ RSpec.describe JwtApiEntrepriseMailer, type: :mailer do
       it 'contains the renewal process instructions' do
         instructions = "Le formulaire a été pré-rempli avec les données fournies lors de votre précédente demande d'accès, veuillez cependant vérifier que les informations sont à jour (notamment les coordonnées de contact) et les re-saisir dans le cas contraire. De plus, de nouvelles sources de données auxquelles vous auriez accès sont potentiellement disponibles depuis votre dernière demande !"
 
-        expect(subject.html_part.decoded).to include(instructions.unindent)
-        expect(subject.text_part.decoded).to include(instructions.unindent)
+        expect(subject.html_part.decoded).to(include(instructions.unindent))
+        expect(subject.text_part.decoded).to(include(instructions.unindent))
       end
 
       it 'contains the team email address' do
         renewal_process = "N'hésitez pas à contacter le support en répondant directement à cet email si vous avez la moindre question."
 
-        expect(subject.html_part.decoded).to include(renewal_process)
-        expect(subject.text_part.decoded).to include(renewal_process)
+        expect(subject.html_part.decoded).to(include(renewal_process))
+        expect(subject.text_part.decoded).to(include(renewal_process))
       end
 
       it 'contains the URL to the JWT\'s renewal request form' do
         renewal_url = "#{Rails.configuration.jwt_renewal_url}#{jwt.authorization_request_id}"
 
-        expect(subject.html_part.decoded).to include(renewal_url)
-        expect(subject.text_part.decoded).to include(renewal_url)
+        expect(subject.html_part.decoded).to(include(renewal_url))
+        expect(subject.text_part.decoded).to(include(renewal_url))
       end
     end
 
@@ -85,22 +85,22 @@ RSpec.describe JwtApiEntrepriseMailer, type: :mailer do
       it 'contains the dashboard URL' do
         url_part = 'dashboard.entreprise.api.gouv.fr/login'
 
-        expect(subject.html_part.decoded).to include(url_part)
-        expect(subject.text_part.decoded).to include(url_part)
+        expect(subject.html_part.decoded).to(include(url_part))
+        expect(subject.text_part.decoded).to(include(url_part))
       end
 
       it 'contains the renewal process' do
         instructions = 'Pour obtenir un nouveau jeton il vous faut faire une nouvelle demande d\'accès comme décrit ici : https://entreprise.api.gouv.fr/doc/#renouvellement-token'
 
-        expect(subject.html_part.decoded).to include(instructions)
-        expect(subject.text_part.decoded).to include(instructions)
+        expect(subject.html_part.decoded).to(include(instructions))
+        expect(subject.text_part.decoded).to(include(instructions))
       end
 
       it 'does not contain the URL to the renewal request form' do
         renewal_url = "#{Rails.configuration.jwt_renewal_url}#{jwt.authorization_request_id}"
 
-        expect(subject.html_part.decoded).to_not include(renewal_url)
-        expect(subject.text_part.decoded).to_not include(renewal_url)
+        expect(subject.html_part.decoded).to_not(include(renewal_url))
+        expect(subject.text_part.decoded).to_not(include(renewal_url))
       end
     end
   end
@@ -110,41 +110,41 @@ RSpec.describe JwtApiEntrepriseMailer, type: :mailer do
 
     subject { described_class.creation_notice(jwt) }
 
-    its(:subject) { is_expected.to eq 'API Entreprise - Création d\'un nouveau token' }
-    its(:from) { is_expected.to include(Rails.configuration.emails_sender_address) }
+    its(:subject) { is_expected.to(eq('API Entreprise - Création d\'un nouveau token')) }
+    its(:from) { is_expected.to(include(Rails.configuration.emails_sender_address)) }
 
     it 'sends the email to all contacts (including the account owner)' do
       account_owner_email = jwt.user.email
       jwt_contacts_emails = jwt.contacts.pluck(:email).uniq
 
-      expect(subject.to).to include(account_owner_email, *jwt_contacts_emails)
+      expect(subject.to).to(include(account_owner_email, *jwt_contacts_emails))
     end
 
     it 'contains the token_creation_notice' do
       notice = 'Un nouveau token est disponible dans votre espace client'
 
-      expect(subject.html_part.decoded).to include(notice)
-      expect(subject.text_part.decoded).to include(notice)
+      expect(subject.html_part.decoded).to(include(notice))
+      expect(subject.text_part.decoded).to(include(notice))
     end
 
     it 'contains the list of all roles' do
       jwt.roles.each do |role|
-        expect(subject.html_part.decoded).to include(role.name)
-        expect(subject.text_part.decoded).to include(role.name)
+        expect(subject.html_part.decoded).to(include(role.name))
+        expect(subject.text_part.decoded).to(include(role.name))
       end
     end
 
     it 'contains the link to the token' do
       token_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/me/tokens/'
-      expect(subject.html_part.decoded).to include(token_url)
-      expect(subject.text_part.decoded).to include(token_url)
+      expect(subject.html_part.decoded).to(include(token_url))
+      expect(subject.text_part.decoded).to(include(token_url))
     end
 
     it 'contains info regarding the current account access' do
       notice = "parmi les contacts pour le compte #{jwt.user.email}"
 
-      expect(subject.html_part.decoded).to include(notice)
-      expect(subject.text_part.decoded).to include(notice)
+      expect(subject.html_part.decoded).to(include(notice))
+      expect(subject.text_part.decoded).to(include(notice))
     end
   end
 
@@ -153,8 +153,8 @@ RSpec.describe JwtApiEntrepriseMailer, type: :mailer do
 
     let(:jwt_api_entreprise) { create(:jwt_api_entreprise) }
 
-    its(:subject) { is_expected.to eq('API Entreprise - Comment s\'est déroulée votre demande d\'accès ?') }
-    its(:from) { is_expected.to include(Rails.configuration.emails_sender_address) }
-    its(:to) { is_expected.to contain_exactly(jwt_api_entreprise.user.email) }
+    its(:subject) { is_expected.to(eq('API Entreprise - Comment s\'est déroulée votre demande d\'accès ?')) }
+    its(:from) { is_expected.to(include(Rails.configuration.emails_sender_address)) }
+    its(:to) { is_expected.to(contain_exactly(jwt_api_entreprise.user.email)) }
   end
 end

--- a/spec/mailers/user_spec.rb
+++ b/spec/mailers/user_spec.rb
@@ -1,28 +1,28 @@
 require 'rails_helper'
 
-RSpec.describe UserMailer, type: :mailer do
+RSpec.describe(UserMailer, type: :mailer) do
   describe '#renew_account_password' do
     let(:user) { create(:user, pwd_renewal_token: 'coucou') }
 
     subject { described_class.renew_account_password(user) }
 
-    its(:subject) { is_expected.to eq('API Entreprise - Mise à jour de votre mot de passe') }
-    its(:to) { is_expected.to eq([user.email]) }
-    its(:from) { is_expected.to include(Rails.configuration.emails_sender_address) }
+    its(:subject) { is_expected.to(eq('API Entreprise - Mise à jour de votre mot de passe')) }
+    its(:to) { is_expected.to(eq([user.email])) }
+    its(:from) { is_expected.to(include(Rails.configuration.emails_sender_address)) }
 
     describe 'body' do
       it 'contains the URL for a password update' do
         reset_pwd_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/account/password_reset?token=coucou'
 
-        expect(subject.html_part.decoded).to include(reset_pwd_url)
-        expect(subject.text_part.decoded).to include(reset_pwd_url)
+        expect(subject.html_part.decoded).to(include(reset_pwd_url))
+        expect(subject.text_part.decoded).to(include(reset_pwd_url))
       end
 
       it 'says the link will expire in 24h' do
         corpus = 'Le lien de renouvellement est valide pendant 24 heures.'
 
-        expect(subject.html_part.decoded).to include(corpus)
-        expect(subject.text_part.decoded).to include(corpus)
+        expect(subject.html_part.decoded).to(include(corpus))
+        expect(subject.text_part.decoded).to(include(corpus))
       end
     end
   end
@@ -33,29 +33,29 @@ RSpec.describe UserMailer, type: :mailer do
 
     subject { described_class.transfer_ownership(old_owner, new_owner) }
 
-    its(:subject) { is_expected.to eq('API Entreprise - Délégation d\'accès') }
-    its(:to) { is_expected.to eq([new_owner.email]) }
-    its(:from) { is_expected.to include(Rails.configuration.emails_sender_address) }
+    its(:subject) { is_expected.to(eq('API Entreprise - Délégation d\'accès')) }
+    its(:to) { is_expected.to(eq([new_owner.email])) }
+    its(:from) { is_expected.to(include(Rails.configuration.emails_sender_address)) }
 
     describe 'email body' do
       it 'contains the previous owner email address' do
-        expect(subject.html_part.decoded).to include(old_owner.email)
-        expect(subject.text_part.decoded).to include(old_owner.email)
+        expect(subject.html_part.decoded).to(include(old_owner.email))
+        expect(subject.text_part.decoded).to(include(old_owner.email))
       end
 
       it 'notifies the user to login to access his tokens' do
         signin_link = 'https://dashboard.entreprise.api.gouv.fr/login'
 
-        expect(subject.html_part.decoded).to include(signin_link)
-        expect(subject.text_part.decoded).to include(signin_link)
+        expect(subject.html_part.decoded).to(include(signin_link))
+        expect(subject.text_part.decoded).to(include(signin_link))
       end
 
       context 'when the new owner already has an API Gouv account' do
         before { new_owner.oauth_api_gouv_id = '12' }
 
         it 'informs the user he will need his API Gouv account' do
-          expect(subject.html_part.decoded).to include(new_owner.email)
-          expect(subject.text_part.decoded).to include(new_owner.email)
+          expect(subject.html_part.decoded).to(include(new_owner.email))
+          expect(subject.text_part.decoded).to(include(new_owner.email))
         end
       end
 
@@ -65,18 +65,18 @@ RSpec.describe UserMailer, type: :mailer do
         it 'informs an API Gouv account is needed' do
           signup_link = 'https://auth.api.gouv.fr/users/sign-up'
 
-          expect(subject.html_part.decoded).to include(signup_link)
-          expect(subject.text_part.decoded).to include(signup_link)
+          expect(subject.html_part.decoded).to(include(signup_link))
+          expect(subject.text_part.decoded).to(include(signup_link))
         end
 
         it 'informs to use the same email address' do
-          expect(subject.html_part.decoded).to include(new_owner.email)
-          expect(subject.text_part.decoded).to include(new_owner.email)
+          expect(subject.html_part.decoded).to(include(new_owner.email))
+          expect(subject.text_part.decoded).to(include(new_owner.email))
         end
 
         it 'informs to use the same siret' do
-          expect(subject.html_part.decoded).to include(new_owner.context)
-          expect(subject.text_part.decoded).to include(new_owner.context)
+          expect(subject.html_part.decoded).to(include(new_owner.context))
+          expect(subject.text_part.decoded).to(include(new_owner.context))
         end
       end
     end
@@ -87,26 +87,26 @@ RSpec.describe UserMailer, type: :mailer do
 
     subject { described_class.notify_datapass_for_data_reconciliation(user) }
 
-    its(:subject) { is_expected.to eq('API Entreprise - Réconciliation de demandes d\'accès à un nouvel usager') }
-    its(:to) { is_expected.to eq(['contact@api.gouv.fr']) }
-    its(:from) { is_expected.to include(Rails.configuration.emails_sender_address) }
+    its(:subject) { is_expected.to(eq('API Entreprise - Réconciliation de demandes d\'accès à un nouvel usager')) }
+    its(:to) { is_expected.to(eq(['contact@api.gouv.fr'])) }
+    its(:from) { is_expected.to(include(Rails.configuration.emails_sender_address)) }
 
     it 'contains the user email address' do
-      expect(subject.html_part.decoded).to include(user.email)
-      expect(subject.text_part.decoded).to include(user.email)
+      expect(subject.html_part.decoded).to(include(user.email))
+      expect(subject.text_part.decoded).to(include(user.email))
     end
 
     it 'contains the user API Gouv ID' do
-      expect(subject.html_part.decoded).to include(user.oauth_api_gouv_id.to_s)
-      expect(subject.text_part.decoded).to include(user.oauth_api_gouv_id.to_s)
+      expect(subject.html_part.decoded).to(include(user.oauth_api_gouv_id.to_s))
+      expect(subject.text_part.decoded).to(include(user.oauth_api_gouv_id.to_s))
     end
 
     it 'contains the user\'s JWT requests ID' do
       authorization_requests_ids = user.jwt_api_entreprise.pluck(:authorization_request_id)
       authorization_requests_ids.map!(&:to_i)
 
-      expect(subject.html_part.decoded).to include(authorization_requests_ids.to_s)
-      expect(subject.text_part.decoded).to include(authorization_requests_ids.to_s)
+      expect(subject.html_part.decoded).to(include(authorization_requests_ids.to_s))
+      expect(subject.text_part.decoded).to(include(authorization_requests_ids.to_s))
     end
   end
 end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,16 +1,16 @@
 require 'rails_helper'
 
-RSpec.describe Contact do
+RSpec.describe(Contact) do
   describe 'db columns' do
-    it { is_expected.to have_db_column(:id).of_type(:uuid) }
-    it { is_expected.to have_db_column(:email).of_type(:string) }
-    it { is_expected.to have_db_column(:phone_number).of_type(:string) }
-    it { is_expected.to have_db_column(:contact_type).of_type(:string) }
-    it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
-    it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
+    it { is_expected.to(have_db_column(:id).of_type(:uuid)) }
+    it { is_expected.to(have_db_column(:email).of_type(:string)) }
+    it { is_expected.to(have_db_column(:phone_number).of_type(:string)) }
+    it { is_expected.to(have_db_column(:contact_type).of_type(:string)) }
+    it { is_expected.to(have_db_column(:created_at).of_type(:datetime)) }
+    it { is_expected.to(have_db_column(:updated_at).of_type(:datetime)) }
   end
 
   describe 'relationships' do
-    it { is_expected.to belong_to(:jwt_api_entreprise) }
+    it { is_expected.to(belong_to(:jwt_api_entreprise)) }
   end
 end

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -1,34 +1,34 @@
 require 'rails_helper'
 
-RSpec.describe JwtApiEntreprise, type: :model do
+RSpec.describe(JwtApiEntreprise, type: :model) do
   let(:jwt) { create(:jwt_api_entreprise) }
 
   describe 'db_columns' do
-    it { is_expected.to have_db_column(:id).of_type(:uuid) }
-    it { is_expected.to have_db_column(:subject).of_type(:string) }
-    it { is_expected.to have_db_column(:iat).of_type(:integer) }
-    it { is_expected.to have_db_column(:user_id).of_type(:uuid) }
-    it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
-    it { is_expected.to have_db_column(:updated_at).of_type(:datetime) }
-    it { is_expected.to have_db_column(:exp).of_type(:integer) }
-    it { is_expected.to have_db_column(:version).of_type(:string) }
-    it { is_expected.to have_db_column(:blacklisted).of_type(:boolean).with_options(default: false) }
-    it { is_expected.to have_db_column(:archived).of_type(:boolean).with_options(default: false) }
-    it { is_expected.to have_db_column(:days_left_notification_sent).of_type(:json).with_options(default: []) }
-    it { is_expected.to have_db_column(:authorization_request_id).of_type(:string) }
-    it { is_expected.to have_db_column(:access_request_survey_sent).of_type(:boolean).with_options(default: false, null: false) }
+    it { is_expected.to(have_db_column(:id).of_type(:uuid)) }
+    it { is_expected.to(have_db_column(:subject).of_type(:string)) }
+    it { is_expected.to(have_db_column(:iat).of_type(:integer)) }
+    it { is_expected.to(have_db_column(:user_id).of_type(:uuid)) }
+    it { is_expected.to(have_db_column(:created_at).of_type(:datetime)) }
+    it { is_expected.to(have_db_column(:updated_at).of_type(:datetime)) }
+    it { is_expected.to(have_db_column(:exp).of_type(:integer)) }
+    it { is_expected.to(have_db_column(:version).of_type(:string)) }
+    it { is_expected.to(have_db_column(:blacklisted).of_type(:boolean).with_options(default: false)) }
+    it { is_expected.to(have_db_column(:archived).of_type(:boolean).with_options(default: false)) }
+    it { is_expected.to(have_db_column(:days_left_notification_sent).of_type(:json).with_options(default: [])) }
+    it { is_expected.to(have_db_column(:authorization_request_id).of_type(:string)) }
+    it { is_expected.to(have_db_column(:access_request_survey_sent).of_type(:boolean).with_options(default: false, null: false)) }
   end
 
   describe 'db_indexes' do
-    it { is_expected.to have_db_index(:created_at) }
-    it { is_expected.to have_db_index(:iat) }
-    it { is_expected.to have_db_index(:access_request_survey_sent) }
+    it { is_expected.to(have_db_index(:created_at)) }
+    it { is_expected.to(have_db_index(:iat)) }
+    it { is_expected.to(have_db_index(:access_request_survey_sent)) }
   end
 
   describe 'relationships' do
-    it { is_expected.to belong_to(:user) }
-    it { is_expected.to have_many(:contacts).dependent(:delete_all) }
-    it { is_expected.to have_and_belong_to_many(:roles) }
+    it { is_expected.to(belong_to(:user)) }
+    it { is_expected.to(have_many(:contacts).dependent(:delete_all)) }
+    it { is_expected.to(have_and_belong_to_many(:roles)) }
   end
 
   describe '#mark_access_request_survey_sent!' do
@@ -41,7 +41,7 @@ RSpec.describe JwtApiEntreprise, type: :model do
         expect {
           instance.mark_access_request_survey_sent!
           instance.reload
-        }.to change(instance, :access_request_survey_sent?).from(false).to(true)
+        }.to(change(instance, :access_request_survey_sent?).from(false).to(true))
       end
     end
 
@@ -52,7 +52,7 @@ RSpec.describe JwtApiEntreprise, type: :model do
         expect {
           instance.mark_access_request_survey_sent!
           instance.reload
-        }.not_to change(instance, :access_request_survey_sent?)
+        }.not_to(change(instance, :access_request_survey_sent?))
       end
     end
   end
@@ -65,13 +65,13 @@ RSpec.describe JwtApiEntreprise, type: :model do
     context 'when the token was issued up to maximum 6 days ago' do
       let(:datetime_of_issue) { :less_than_seven_days_ago }
 
-      its(:issued_in_last_seven_days) { is_expected.not_to be_exist token.id }
+      its(:issued_in_last_seven_days) { is_expected.not_to(be_exist(token.id)) }
     end
 
     context 'when the token was issued since at least 7 days ago' do
       let(:datetime_of_issue) { :seven_days_ago }
 
-      its(:issued_in_last_seven_days) { is_expected.to be_exist token.id }
+      its(:issued_in_last_seven_days) { is_expected.to(be_exist(token.id)) }
     end
   end
 
@@ -83,13 +83,13 @@ RSpec.describe JwtApiEntreprise, type: :model do
     context 'when the access request survey was not sent' do
       let(:sent_state) { :access_request_survey_not_sent }
 
-      its(:access_request_survey_not_sent) { is_expected.to be_exist token.id }
+      its(:access_request_survey_not_sent) { is_expected.to(be_exist(token.id)) }
     end
 
     context 'when the access request survey was sent' do
       let(:sent_state) { :access_request_survey_sent }
 
-      its(:access_request_survey_not_sent) { is_expected.not_to be_exist token.id }
+      its(:access_request_survey_not_sent) { is_expected.not_to(be_exist(token.id)) }
     end
   end
 
@@ -100,7 +100,7 @@ RSpec.describe JwtApiEntreprise, type: :model do
       datetime = DateTime.new(1998, 3, 17, 15, 28, 49, '+1')
       jwt.exp = datetime.to_i
 
-      expect(jwt.user_friendly_exp_date).to eq('17/03/1998 à 15h28 (heure de Paris)')
+      expect(jwt.user_friendly_exp_date).to(eq('17/03/1998 à 15h28 (heure de Paris)'))
     end
   end
 
@@ -111,11 +111,11 @@ RSpec.describe JwtApiEntreprise, type: :model do
     let!(:unexpired_jwt) { create_list(:jwt_api_entreprise, 2) }
 
     it 'returns unexpired tokens' do
-      expect(subject).to include(*unexpired_jwt)
+      expect(subject).to(include(*unexpired_jwt))
     end
 
     it 'does not return expired tokens' do
-      expect(subject).to_not include(*expired_jwt)
+      expect(subject).to_not(include(*expired_jwt))
     end
   end
 
@@ -123,50 +123,50 @@ RSpec.describe JwtApiEntreprise, type: :model do
     let(:token) { jwt.rehash }
 
     it 'returns a jwt' do
-      expect(token).to match(/\A([a-zA-Z0-9_-]+\.){2}([a-zA-Z0-9_-]+)?\z/)
+      expect(token).to(match(/\A([a-zA-Z0-9_-]+\.){2}([a-zA-Z0-9_-]+)?\z/))
     end
 
     describe 'generated JWT payload' do
       let(:payload) { extract_payload_from(token) }
 
       it 'contains its owner user id into the "uid" key' do
-        expect(payload.fetch(:uid)).to eq(jwt.user_id)
+        expect(payload.fetch(:uid)).to(eq(jwt.user_id))
       end
 
       it 'contains its id into the "jti" key' do
-        expect(payload.fetch(:jti)).to eq(jwt.id)
+        expect(payload.fetch(:jti)).to(eq(jwt.id))
       end
 
       it 'contains its subject into the "sub" key' do
-        expect(payload.fetch(:sub)).to eq(jwt.subject)
+        expect(payload.fetch(:sub)).to(eq(jwt.subject))
       end
 
       it 'contains its creation timestamp into the "iat" key' do
-        expect(payload.fetch(:iat)).to eq(jwt.iat)
+        expect(payload.fetch(:iat)).to(eq(jwt.iat))
       end
 
       it 'contains all its access roles into the "roles" key' do
         jwt_roles = jwt.roles.pluck(:code)
 
-        expect(payload.fetch(:roles)).to eq(jwt_roles)
+        expect(payload.fetch(:roles)).to(eq(jwt_roles))
       end
 
       describe 'expiration date' do
         it 'contains its expiration date into the "exp" key when not nil' do
-          expect(payload.fetch(:exp)).to eq(jwt.exp)
+          expect(payload.fetch(:exp)).to(eq(jwt.exp))
         end
 
         # ex: Watchdoge JWT for ping has no expiration date
         it 'does not set exp field when expiration date is nil' do
           jwt.exp = nil
 
-          expect(payload).to_not have_key(:exp)
+          expect(payload).to_not(have_key(:exp))
         end
       end
 
       it 'contains the payload version' do
-        expect(payload.fetch(:version)).to_not be_nil
-        expect(payload.fetch(:version)).to eq(jwt.version)
+        expect(payload.fetch(:version)).to_not(be_nil)
+        expect(payload.fetch(:version)).to(eq(jwt.version))
       end
     end
   end
@@ -176,7 +176,7 @@ RSpec.describe JwtApiEntreprise, type: :model do
       j = create(:jwt_api_entreprise, subject: 'coucou subject', authorization_request_id: '42')
       url = Rails.configuration.jwt_renewal_url + '42'
 
-      expect(j.renewal_url).to eq(url)
+      expect(j.renewal_url).to(eq(url))
     end
   end
 
@@ -187,13 +187,13 @@ RSpec.describe JwtApiEntreprise, type: :model do
     it 'returns the #subject value if #temp_use_case is nil' do
       j = create(:jwt_api_entreprise, subject: 'coucou subject', temp_use_case: nil)
 
-      expect(j.displayed_subject).to eq('coucou subject')
+      expect(j.displayed_subject).to(eq('coucou subject'))
     end
 
     it 'returns #temp_use_case value if it is not nil' do
       j = create(:jwt_api_entreprise, subject: 'coucou subject', temp_use_case: 'coucou use case')
 
-      expect(j.displayed_subject).to eq('coucou use case')
+      expect(j.displayed_subject).to(eq('coucou use case'))
     end
   end
 
@@ -205,13 +205,13 @@ RSpec.describe JwtApiEntreprise, type: :model do
     it 'contains the jwt owner\'s email (account owner)' do
       user_email = jwt.user.email
 
-      expect(subject).to include(user_email)
+      expect(subject).to(include(user_email))
     end
 
     it 'contains all jwt\'s contacts email' do
       contacts_emails = jwt.contacts.pluck(:email).uniq
 
-      expect(subject).to include(*contacts_emails)
+      expect(subject).to(include(*contacts_emails))
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,24 +1,24 @@
 require 'rails_helper'
 
-RSpec.describe User do
+RSpec.describe(User) do
   let(:user) { create :user, :with_jwt }
 
   describe 'db_columns' do
-    it { is_expected.to have_db_column(:id).of_type(:uuid) }
-    it { is_expected.to have_db_column(:email).of_type(:string) }
-    it { is_expected.to have_db_column(:oauth_api_gouv_id).of_type(:string) }
-    it { is_expected.to have_db_column(:context).of_type(:string) }
-    it { is_expected.to have_db_column(:password_digest).of_type(:string) }
-    it { is_expected.to have_db_column(:cgu_agreement_date).of_type(:datetime) }
-    it { is_expected.to have_db_column(:note).of_type(:text).with_options(default: '') }
-    it { is_expected.to have_db_column(:pwd_renewal_token).of_type(:string).with_options(default: nil) }
-    it { is_expected.to have_db_column(:admin).of_type(:boolean).with_options(default: false) }
-    it { is_expected.to have_db_column(:tokens_newly_transfered).of_type(:boolean).with_options(default: false) }
+    it { is_expected.to(have_db_column(:id).of_type(:uuid)) }
+    it { is_expected.to(have_db_column(:email).of_type(:string)) }
+    it { is_expected.to(have_db_column(:oauth_api_gouv_id).of_type(:string)) }
+    it { is_expected.to(have_db_column(:context).of_type(:string)) }
+    it { is_expected.to(have_db_column(:password_digest).of_type(:string)) }
+    it { is_expected.to(have_db_column(:cgu_agreement_date).of_type(:datetime)) }
+    it { is_expected.to(have_db_column(:note).of_type(:text).with_options(default: '')) }
+    it { is_expected.to(have_db_column(:pwd_renewal_token).of_type(:string).with_options(default: nil)) }
+    it { is_expected.to(have_db_column(:admin).of_type(:boolean).with_options(default: false)) }
+    it { is_expected.to(have_db_column(:tokens_newly_transfered).of_type(:boolean).with_options(default: false)) }
   end
 
   describe 'relationships' do
-    it { is_expected.to have_many(:jwt_api_entreprise).dependent(:nullify) }
-    it { is_expected.to have_many(:contacts).through(:jwt_api_entreprise) }
+    it { is_expected.to(have_many(:jwt_api_entreprise).dependent(:nullify)) }
+    it { is_expected.to(have_many(:contacts).through(:jwt_api_entreprise)) }
   end
 
   describe '#generate_pwd_renewal_token' do
@@ -27,7 +27,7 @@ RSpec.describe User do
       user.generate_pwd_renewal_token
       user.reload
 
-      expect(user.pwd_renewal_token).to match(/\A[0-9a-f]{20}\z/)
+      expect(user.pwd_renewal_token).to(match(/\A[0-9a-f]{20}\z/))
     end
   end
 
@@ -36,12 +36,12 @@ RSpec.describe User do
 
     context 'when the user has an API Gouv ID' do
       before { user.oauth_api_gouv_id = '12' }
-      it { is_expected.to eq(true) }
+      it { is_expected.to(eq(true)) }
     end
 
     context 'when the user does not have an API Gouv ID' do
       before { user.oauth_api_gouv_id = nil }
-      it { is_expected.to eq(false) }
+      it { is_expected.to(eq(false)) }
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -59,22 +59,22 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
 
   # Include factory_bot methods into test suite
-  config.include FactoryBot::Syntax::Methods
+  config.include(FactoryBot::Syntax::Methods)
 
   # Include helpers / support accurately for each spec type
-  config.include AuthenticationHelper, type: :controller
-  config.include JWTHelper, type: :jwt
-  config.include JWTHelper, type: :model
-  config.include JWTHelper, type: :request
-  config.include ResponseHelper, type: :controller
+  config.include(AuthenticationHelper, type: :controller)
+  config.include(JWTHelper, type: :jwt)
+  config.include(JWTHelper, type: :model)
+  config.include(JWTHelper, type: :request)
+  config.include(ResponseHelper, type: :controller)
 
   # Include fixtures tokens to test OAuth API Gouv interaction
-  config.include OAuthApiGouv
+  config.include(OAuthApiGouv)
 end
 
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
-    with.test_framework :rspec
-    with.library :rails
+    with.test_framework(:rspec)
+    with.library(:rails)
   end
 end

--- a/spec/request_authentication_spec.rb
+++ b/spec/request_authentication_spec.rb
@@ -1,11 +1,11 @@
 require 'rails_helper'
 
-RSpec.describe 'Request authentication', type: :controller do
+RSpec.describe('Request authentication', type: :controller) do
   # Use of anonymous controller with random action which inherits from
   # ApplicationController to test authentication callback genericity
   controller(ApplicationController) do
     def random_action
-      render json: { very: 'random' }, status: 200
+      render(json: { very: 'random' }, status: 200)
     end
   end
 
@@ -17,8 +17,8 @@ RSpec.describe 'Request authentication', type: :controller do
     it 'returns 401' do
       get :random_action
 
-      expect(response.code).to eq '401'
-      expect(response.body).to eq '{"error":"Unauthorized"}'
+      expect(response.code).to(eq('401'))
+      expect(response.body).to(eq('{"error":"Unauthorized"}'))
     end
   end
 
@@ -30,24 +30,24 @@ RSpec.describe 'Request authentication', type: :controller do
       request.headers['Authorization'] = "Bearer #{valid_token}"
       get :random_action
 
-      expect(response.code).to eq '200'
-      expect(response.body).to eq '{"very":"random"}'
+      expect(response.code).to(eq('200'))
+      expect(response.body).to(eq('{"very":"random"}'))
     end
 
     it 'denies invalid header format' do
       request.headers['Authorization'] = "FuBearer : #{valid_token}"
       get :random_action
 
-      expect(response.code).to eq '401'
-      expect(response.body).to eq '{"error":"Unauthorized"}'
+      expect(response.code).to(eq('401'))
+      expect(response.body).to(eq('{"error":"Unauthorized"}'))
     end
 
     it 'denies invalid tokens' do
       request.headers['Authorization'] = 'Bearer invalid_token'
       get :random_action
 
-      expect(response.code).to eq '401'
-      expect(response.body).to eq '{"error":"Unauthorized"}'
+      expect(response.code).to(eq('401'))
+      expect(response.body).to(eq('{"error":"Unauthorized"}'))
     end
 
     pending 'denies unwell-signed tokens'
@@ -66,8 +66,8 @@ RSpec.describe 'Request authentication', type: :controller do
       }
       post '/api/admin/users/login', params: login_params
 
-      expect(response.code).to eq '200'
-      expect(response.body).to include 'access_token'
+      expect(response.code).to(eq('200'))
+      expect(response.body).to(include('access_token'))
     end
 
     context 'when admin logs in' do
@@ -83,8 +83,8 @@ RSpec.describe 'Request authentication', type: :controller do
         body = JSON.parse(response.body, symbolize_names: true)
         jwt = body.fetch(:access_token)
 
-        expect(response.code).to eq '200'
-        expect(extract_payload_from(jwt).fetch(:admin)).to eq true
+        expect(response.code).to(eq('200'))
+        expect(extract_payload_from(jwt).fetch(:admin)).to(eq(true))
       end
     end
   end

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -1,38 +1,38 @@
 require 'rails_helper'
 
-RSpec.describe 'Application routes' do
+RSpec.describe('Application routes') do
   describe 'incidents' do
     it 'has an index route' do
       expect(get('api/admin/incidents'))
-        .to route_to(controller: 'incidents', action: 'index')
+        .to(route_to(controller: 'incidents', action: 'index'))
     end
 
     it 'has a create route' do
       expect(post('api/admin/incidents'))
-        .to route_to(controller: 'incidents', action: 'create')
+        .to(route_to(controller: 'incidents', action: 'create'))
     end
     it 'has an update route' do
       expect(put('api/admin/incidents/very_id'))
-        .to route_to(controller: 'incidents', action: 'update', id: 'very_id')
+        .to(route_to(controller: 'incidents', action: 'update', id: 'very_id'))
     end
   end
 
   describe 'roles' do
     it 'has an index route' do
       expect(get('api/admin/roles'))
-        .to route_to(controller: 'roles', action: 'index')
+        .to(route_to(controller: 'roles', action: 'index'))
     end
 
     it 'has a create route' do
       expect(post('api/admin/roles'))
-        .to route_to(controller: 'roles', action: 'create')
+        .to(route_to(controller: 'roles', action: 'create'))
     end
   end
 
   describe 'oauth_api_gouv' do
     it 'has a route to login with an authorization code' do
       expect(get('api/admin/oauth_api_gouv/login?authorization_code=very_code'))
-        .to route_to(controller: 'oauth_api_gouv', action: 'login', authorization_code: 'very_code')
+        .to(route_to(controller: 'oauth_api_gouv', action: 'login', authorization_code: 'very_code'))
     end
 
   end
@@ -40,59 +40,59 @@ RSpec.describe 'Application routes' do
   describe 'users' do
     it 'has an index route' do
       expect(get('api/admin/users'))
-        .to route_to(controller: 'users', action: 'index')
+        .to(route_to(controller: 'users', action: 'index'))
     end
 
     it 'has a create route' do
       expect(post('api/admin/users'))
-        .to route_to(controller: 'users', action: 'create')
+        .to(route_to(controller: 'users', action: 'create'))
     end
 
     it 'has a show route' do
       expect(get('api/admin/users/very_id'))
-        .to route_to(controller: 'users', action: 'show', id: 'very_id')
+        .to(route_to(controller: 'users', action: 'show', id: 'very_id'))
     end
 
     it 'has an update route' do
       expect(patch('api/admin/users/very_id'))
-        .to route_to(controller: 'users', action: 'update', id: 'very_id')
+        .to(route_to(controller: 'users', action: 'update', id: 'very_id'))
     end
 
     it 'has a delete route' do
       expect(delete('api/admin/users/very_id'))
-        .to route_to(controller: 'users', action: 'destroy', id: 'very_id')
+        .to(route_to(controller: 'users', action: 'destroy', id: 'very_id'))
     end
 
     it 'has a login route' do
       expect(post('api/admin/users/login'))
-        .to route_to(controller: 'doorkeeper/tokens', action: 'create')
+        .to(route_to(controller: 'doorkeeper/tokens', action: 'create'))
     end
 
     it 'has an account tranfer route' do
       expect(post('api/admin/users/much_id/transfer_ownership'))
-        .to route_to(controller: 'users', action: 'transfer_ownership', id: 'much_id')
+        .to(route_to(controller: 'users', action: 'transfer_ownership', id: 'much_id'))
     end
 
     it 'has a password_renewal route' do
       expect(post('api/admin/users/password_renewal'))
-        .to route_to(controller: 'users', action: 'password_renewal')
+        .to(route_to(controller: 'users', action: 'password_renewal'))
     end
 
     it 'has a password_reset route' do
       expect(post('api/admin/users/password_reset'))
-        .to route_to(controller: 'users', action: 'password_reset')
+        .to(route_to(controller: 'users', action: 'password_reset'))
     end
   end
 
   describe 'jwt_api_entreprise' do
     it 'has a create route' do
       expect(post('api/admin/users/very_user_id/jwt_api_entreprise'))
-        .to route_to(controller: 'jwt_api_entreprise', action: 'create', user_id: 'very_user_id')
+        .to(route_to(controller: 'jwt_api_entreprise', action: 'create', user_id: 'very_user_id'))
     end
 
     it 'has an update route' do
       expect(patch('api/admin/jwt_api_entreprise/very_id'))
-        .to route_to(controller: 'jwt_api_entreprise', action: 'update', id: 'very_id')
+        .to(route_to(controller: 'jwt_api_entreprise', action: 'update', id: 'very_id'))
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ if ARGV.grep(/spec\.rb/).empty? && !defined?(Spring)
     ]
   )
 
-  SimpleCov.start 'rails' do
+  SimpleCov.start('rails') do
     add_filter 'app/channels/'
     add_filter 'app/jobs/application_job.rb'
     add_filter 'app/mailers/application_mailer.rb'
@@ -41,7 +41,7 @@ RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
-  config.expect_with :rspec do |expectations|
+  config.expect_with(:rspec) do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods
     # defined using `chain`, e.g.:
@@ -54,7 +54,7 @@ RSpec.configure do |config|
 
   # rspec-mocks config goes here. You can use an alternate test double
   # library (such as bogus or mocha) by changing the `mock_with` option here.
-  config.mock_with :rspec do |mocks|
+  config.mock_with(:rspec) do |mocks|
     # Prevents you from mocking or stubbing a method that does not exist on
     # a real object. This is generally recommended, and will default to
     # `true` in RSpec 4.
@@ -116,5 +116,5 @@ RSpec.configure do |config|
   # Setting this allows you to use `--seed` to deterministically reproduce
   # test failures related to randomization by passing the same `--seed` value
   # as the one that triggered the failure.
-  Kernel.srand config.seed
+  Kernel.srand(config.seed)
 end

--- a/spec/support/shared_context.rb
+++ b/spec/support/shared_context.rb
@@ -1,17 +1,17 @@
-RSpec.shared_context 'admin request' do
+RSpec.shared_context('admin request') do
   before do
     fill_request_headers_with_admin_jwt
   end
 end
 
-RSpec.shared_context 'user request' do
+RSpec.shared_context('user request') do
   before do
     user = create(:user)
     fill_request_headers_with_user_jwt(user.id)
   end
 end
 
-RSpec.shared_context 'oauth api gouv fresh token' do
+RSpec.shared_context('oauth api gouv fresh token') do
   # Time when the recorded ID Token hasn't expired yet
   let(:id_token_alive_time) { Time.at(1589460000) }
 

--- a/spec/support/shared_example.rb
+++ b/spec/support/shared_example.rb
@@ -1,18 +1,18 @@
-RSpec.shared_examples 'client user unauthorized' do |req_verb, action, req_params = {}|
+RSpec.shared_examples('client user unauthorized') do |req_verb, action, req_params = {}|
   include_context 'user request'
   before { self.send(req_verb, action, params: req_params) }
 
   it 'returns 403' do
-    expect(response.code).to eq '403'
+    expect(response.code).to(eq('403'))
   end
 
   it 'returns "Forbidden" message' do
     body = JSON.parse(response.body, symbolize_names: true)
-    expect(body[:errors]).to eq 'Forbidden'
+    expect(body[:errors]).to(eq('Forbidden'))
   end
 end
 
-RSpec.shared_examples :password_renewal_contract do
+RSpec.shared_examples(:password_renewal_contract) do
   let(:op_params) do
     {
       password: 'couCOU23',
@@ -29,37 +29,37 @@ RSpec.shared_examples :password_renewal_contract do
     op_params[:password_confirmation] = 'coucou23'
     subject
 
-    expect(subject).to be_failure
-    expect(errors[:password_confirmation]).to include('must be equal to password')
+    expect(subject).to(be_failure)
+    expect(errors[:password_confirmation]).to(include('must be equal to password'))
   end
 
   it 'is min 8 characters long' do
     op_params[:password] = op_params[:password_confirmation] = 'a' * 7
 
-    expect(errors[:password]).to include('size cannot be less than 8')
+    expect(errors[:password]).to(include('size cannot be less than 8'))
   end
 
   it 'contains a lowercase letter' do
     op_params[:password] = op_params[:password_confirmation] = 'AAAAAAAAA3'
 
-    expect(errors[:password]).to include(format_error_message)
+    expect(errors[:password]).to(include(format_error_message))
   end
 
   it 'contains an uppercase letter' do
     op_params[:password] = op_params[:password_confirmation] = 'aaaaaaaaa3'
 
-    expect(errors[:password]).to include(format_error_message)
+    expect(errors[:password]).to(include(format_error_message))
   end
 
   it 'contains a number' do
     op_params[:password] = op_params[:password_confirmation] = 'AAAAAAAAAa'
 
-    expect(errors[:password]).to include(format_error_message)
+    expect(errors[:password]).to(include(format_error_message))
   end
 
   it 'accepts special characters' do
     op_params[:password] = op_params[:password_confirmation] = 'Cou-cou!123?'
 
-    expect(errors[:password]).to be_nil
+    expect(errors[:password]).to(be_nil)
   end
 end

--- a/spec/vcr_helper.rb
+++ b/spec/vcr_helper.rb
@@ -2,7 +2,7 @@ require 'vcr'
 
 VCR.configure do |c|
   c.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
-  c.hook_into :webmock
+  c.hook_into(:webmock)
   c.configure_rspec_metadata!
 
   c.filter_sensitive_data('<OAUTH_API_GOUV_CLIENT_SECRET>' ) { "#{Rails.application.credentials.oauth_api_gouv_client_secret}" }

--- a/spec/views/jwt_api_entreprise_mailer/satisfaction_survey.html.erb_spec.rb
+++ b/spec/views/jwt_api_entreprise_mailer/satisfaction_survey.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'rendering the mail template' do
+RSpec.describe('rendering the mail template') do
   let(:jwt) { build(:jwt_api_entreprise) }
 
   before do
@@ -13,6 +13,6 @@ RSpec.describe 'rendering the mail template' do
   end
 
   it 'renders the JWT authorization request id' do
-    expect(subject).to match "n°#{jwt.authorization_request_id}"
+    expect(subject).to(match("n°#{jwt.authorization_request_id}"))
   end
 end

--- a/spec/views/jwt_api_entreprise_mailer/satisfaction_survey.text.erb_spec.rb
+++ b/spec/views/jwt_api_entreprise_mailer/satisfaction_survey.text.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'rendering the mail template' do
+RSpec.describe('rendering the mail template') do
   before do
     assign(:jwt, jwt)
     render template: 'jwt_api_entreprise_mailer/satisfaction_survey', formats: [:text]
@@ -27,6 +27,6 @@ RSpec.describe 'rendering the mail template' do
   end
 
   it 'renders the message' do
-    expect(subject).to match full_message
+    expect(subject).to(match(full_message))
   end
 end


### PR DESCRIPTION
Cette PR propose d'harmoniser toute la base de code sur cette règle RuboCop :

```yaml
Style/MethodCallWithArgsParentheses:
  EnforcedStyle: require_parentheses
  IgnoreMacros: true
  AllowParenthesesInMultilineCall: true
  AllowParenthesesInCamelCaseMethod: true
  AllowParenthesesInStringInterpolation: true
```

Commande utilisée :

```sh
bundle exec rubocop --auto-correct --only Style/MethodCallWithArgsParentheses
```