### PR TITLE
refactor(factory): remove callback from jwt_api_entreprises

### DIFF
--- a/factories/jwt_api_entreprises.rb
+++ b/factories/jwt_api_entreprises.rb
@@ -8,10 +8,6 @@ FactoryBot.define do
     version { '1.0' }
     days_left_notification_sent { [] }
     user
-
-    after(:create) do |jwt|
-      create_list(:role, 4, jwt_api_entreprise: [jwt])
-    end
   end
 
   factory :token_without_roles, class: JwtApiEntreprise do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -130,6 +130,12 @@ RSpec.describe UsersController, type: :controller do
   end
 
   describe '#show' do
+    before do
+      user.jwt_api_entreprise.find_each do |jwt|
+        create_list(:role, 4, jwt_api_entreprise: [jwt])
+      end
+    end
+
     let(:user) do
       create(:user,
              :with_jwt,


### PR DESCRIPTION
# Proposition

Supprimer un callback dans la factory du token

# Intérêt

Ne pas forcément entraîner la création de 4 rôles lors de la création de token, notamment pour faciliter le contrôle des données générées dans le cadre de tests unitaires.

# Note

Dans l'éventualité où plus d'un cas de test pourrait bénéficier de ce genre de création de rôle automatique, nous pourrions par la suite réintégrer un tel callback activable via un trait pour ne pas polluer les autres tests qui n'en auraient pas besoin.