### PR TITLE
fix(db): enforce unique email addresses for users

### DIFF
--- a/db/migrate/20210608091146_add_unique_email_constraint_to_users.rb
+++ b/db/migrate/20210608091146_add_unique_email_constraint_to_users.rb
@@ -1,0 +1,5 @@
+class AddUniqueEmailConstraintToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_index :users, :email, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_29_125933) do
+ActiveRecord::Schema.define(version: 2021_06_08_091146) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -118,6 +118,7 @@ ActiveRecord::Schema.define(version: 2021_03_29_125933) do
     t.string "oauth_api_gouv_id"
     t.boolean "admin", default: false
     t.boolean "tokens_newly_transfered", default: false
+    t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["pwd_renewal_token"], name: "index_users_on_pwd_renewal_token"
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe User do
     it { is_expected.to have_db_column(:tokens_newly_transfered).of_type(:boolean).with_options(default: false) }
   end
 
+  describe 'db_indexes' do
+    it { is_expected.to have_db_index(:email).unique(true) }
+  end
+
   describe 'relationships' do
     it { is_expected.to have_many(:jwt_api_entreprise).dependent(:nullify) }
     it { is_expected.to have_many(:roles).through(:jwt_api_entreprise) }


### PR DESCRIPTION
# Pourquoi cette PR

Il est actuellement possible d'avoir plusieurs fois une même adresse email sur des comptes utilisateurs différents.

Exemple :

![email](https://user-images.githubusercontent.com/20987/121160204-293f0e00-c84c-11eb-9e89-833292f45796.png)

# Que fait cette PR

Cette PR ajoute une contrainte d'unicité sur le champ `email` de la table `users`.

# Pourquoi fait-on ça

Pour rendre impossible le fait d'avoir plusieurs adresses emails identiques.