### PR TITLE
Magic Link for JWT

### DIFF
--- a/app/concepts/jwt_api_entreprise/contract/create_magic_link.rb
+++ b/app/concepts/jwt_api_entreprise/contract/create_magic_link.rb
@@ -1,0 +1,6 @@
+module JwtApiEntreprise::Contract
+  CreateMagicLink = Dry::Validation.Schema do
+    required(:id).filled(:str?)
+    required(:email).filled(format?: ParamsValidation::EmailRegex)
+  end
+end

--- a/app/concepts/jwt_api_entreprise/operation/create_magic_link.rb
+++ b/app/concepts/jwt_api_entreprise/operation/create_magic_link.rb
@@ -1,6 +1,9 @@
 module JwtApiEntreprise::Operation
   class CreateMagicLink < Trailblazer::Operation
-    step Model(JwtApiEntreprise, :find_by), Output(:failure) => End(:not_found)
+    step Model(JwtApiEntreprise, :find_by),
+      Output(:failure) => End(:not_found)
+    step Policy::Pundit(JwtApiEntreprisePolicy, :magic_link?),
+      Output(:failure) => End(:unauthorized)
     step self::Contract::Validate(constant: JwtApiEntreprise::Contract::CreateMagicLink),
       Output(:failure) => End(:invalid_params), fail_fast: true
     step :generate_magic_link_token

--- a/app/concepts/jwt_api_entreprise/operation/create_magic_link.rb
+++ b/app/concepts/jwt_api_entreprise/operation/create_magic_link.rb
@@ -1,0 +1,17 @@
+module JwtApiEntreprise::Operation
+  class CreateMagicLink < Trailblazer::Operation
+    step Model(JwtApiEntreprise, :find_by), Output(:failure) => End(:not_found)
+    step self::Contract::Validate(constant: JwtApiEntreprise::Contract::CreateMagicLink),
+      Output(:failure) => End(:invalid_params), fail_fast: true
+    step :generate_magic_link_token
+    step :send_magic_link
+
+    def generate_magic_link_token(ctx, model:, **)
+      model.generate_magic_link_token
+    end
+
+    def send_magic_link(ctx, model:, params:, **)
+      JwtApiEntrepriseMailer.magic_link(params[:email], model).deliver_later
+    end
+  end
+end

--- a/app/concepts/jwt_api_entreprise/operation/retrieve_from_magic_link.rb
+++ b/app/concepts/jwt_api_entreprise/operation/retrieve_from_magic_link.rb
@@ -1,0 +1,15 @@
+module JwtApiEntreprise::Operation
+  class RetrieveFromMagicLink < Trailblazer::Operation
+    step :retrieve_from_magic_link_token
+    step :magic_link_token_valid?
+
+    def retrieve_from_magic_link_token(ctx, params:, **)
+      ctx[:jwt] = JwtApiEntreprise.find_by_magic_link_token(params[:token])
+    end
+
+    def magic_link_token_valid?(ctx, jwt:, **)
+      expiration_time = jwt.magic_link_issuance_date + 4.hours
+      Time.zone.now < expiration_time
+    end
+  end
+end

--- a/app/controllers/jwt_api_entreprise_controller.rb
+++ b/app/controllers/jwt_api_entreprise_controller.rb
@@ -1,4 +1,6 @@
 class JwtApiEntrepriseController < ApplicationController
+  skip_before_action :jwt_authenticate!, only: [:show_magic_link]
+
   def index
     authorize :admin, :admin?
 
@@ -50,6 +52,16 @@ class JwtApiEntrepriseController < ApplicationController
       elsif state == :unauthorized
         render json: { errors: 'Unauthorized' }, status: 403
       end
+    end
+  end
+
+  def show_magic_link
+    result = JwtApiEntreprise::Operation::RetrieveFromMagicLink.call(params: params)
+
+    if result.success?
+      render json: result[:jwt], serializer: JwtApiEntrepriseShowSerializer, status: 200
+    else
+      render json: { errors: { token: ['not a valid token'] } }, status: 404
     end
   end
 

--- a/app/controllers/jwt_api_entreprise_controller.rb
+++ b/app/controllers/jwt_api_entreprise_controller.rb
@@ -33,7 +33,7 @@ class JwtApiEntrepriseController < ApplicationController
     end
   end
 
-  def magic_link
+  def create_magic_link
     result = JwtApiEntreprise::Operation::CreateMagicLink.call(
       params: params,
       current_user: pundit_user,

--- a/app/mailers/jwt_api_entreprise_mailer.rb
+++ b/app/mailers/jwt_api_entreprise_mailer.rb
@@ -33,4 +33,8 @@ class JwtApiEntrepriseMailer < ApplicationMailer
 
     mail(to: recipient, subject: 'API Entreprise - Comment s\'est déroulée votre demande d\'accès ?')
   end
+
+  def magic_link(recipient, jwt)
+
+  end
 end

--- a/app/mailers/jwt_api_entreprise_mailer.rb
+++ b/app/mailers/jwt_api_entreprise_mailer.rb
@@ -35,6 +35,10 @@ class JwtApiEntrepriseMailer < ApplicationMailer
   end
 
   def magic_link(recipient, jwt)
+    @jwt = jwt
+    @magic_link_url = "#{Rails.configuration.jwt_magic_link_url}?token=#{jwt.magic_link_token}"
+    subject = 'API Entreprise - Lien d\'accès à votre jeton !'
 
+    mail(to: recipient, subject: subject)
   end
 end

--- a/app/models/concerns/random_token.rb
+++ b/app/models/concerns/random_token.rb
@@ -1,0 +1,12 @@
+module RandomToken
+  private
+
+  def random_token_for(attr)
+    constraint = {}
+    loop do
+      token = SecureRandom.hex(10)
+      constraint[attr] = token
+      return token unless self.class.find_by(constraint)
+    end
+  end
+end

--- a/app/models/jwt_api_entreprise.rb
+++ b/app/models/jwt_api_entreprise.rb
@@ -1,4 +1,6 @@
 class JwtApiEntreprise < ApplicationRecord
+  include RandomToken
+
   belongs_to :user
   has_many :contacts, dependent: :delete_all
   has_and_belongs_to_many :roles
@@ -30,6 +32,14 @@ class JwtApiEntreprise < ApplicationRecord
 
   def user_and_contacts_email
     Set[*contacts.pluck(:email)] << user.email
+  end
+
+  def generate_magic_link_token
+    token = random_token_for(:magic_link_token)
+    update(
+      magic_link_token: token,
+      magic_link_issuance_date: Time.zone.now
+    )
   end
 
   # TODO XXX This is temporary, the real "subject" of a JWT is set into the

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  include RandomToken
+
   has_many :jwt_api_entreprise, dependent: :nullify
   has_many :contacts, through: :jwt_api_entreprise
 
@@ -15,16 +17,5 @@ class User < ApplicationRecord
 
   def generate_pwd_renewal_token
     update(pwd_renewal_token: random_token_for(:pwd_renewal_token))
-  end
-
-  private
-
-  def random_token_for(attr)
-    constraint = {}
-    loop do
-      token = SecureRandom.hex(10)
-      constraint[attr] = token
-      return token unless User.find_by(constraint)
-    end
   end
 end

--- a/app/policies/jwt_api_entreprise_policy.rb
+++ b/app/policies/jwt_api_entreprise_policy.rb
@@ -1,0 +1,22 @@
+class JwtApiEntreprisePolicy < ApplicationPolicy
+  attr_reader :jwt_user
+
+  def initialize(jwt_user, jwt_record)
+    @jwt_user = jwt_user
+    @jwt_record = jwt_record
+  end
+
+  def magic_link?
+    admin? || current_user_owns_jwt?
+  end
+
+  private
+
+  def admin?
+    jwt_user.admin?
+  end
+
+  def current_user_owns_jwt?
+    jwt_user.id == @jwt_record.user.id
+  end
+end

--- a/app/views/jwt_api_entreprise_mailer/magic_link.html.erb
+++ b/app/views/jwt_api_entreprise_mailer/magic_link.html.erb
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Bonjour,</p>
+
+    <p>Un lien vers le jeton d'accès à API Entreprise, cas d'usage "<%= @jwt.subject %>", vient d'être généré pour vous. Vous pouvez accéder à ce jeton via le lien <%= link_to('suivant', @magic_link_url) %></p>
+
+    <p>Ce lien est temporaire il n'est valable que pour une durée de 4 heures seulement.</p>
+    <p>Cordialement,</p>
+    <p>L'équipe API Entreprise</p>
+  </body>
+</html>

--- a/app/views/jwt_api_entreprise_mailer/magic_link.text.erb
+++ b/app/views/jwt_api_entreprise_mailer/magic_link.text.erb
@@ -1,0 +1,10 @@
+Bonjour,
+
+Un lien vers le jeton d'accès à API Entreprise, cas d'usage "<%= @jwt.subject %>", vient d'être généré pour vous. Vous pouvez accéder à ce jeton via le lien suivant :
+
+<%= @magic_link_url %>
+
+Ce lien est temporaire il n'est valable que pour une durée de 4 heures seulement.
+
+Cordialement,
+L'équipe API Entreprise

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -62,6 +62,7 @@ Rails.application.configure do
   config.renew_password_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/account/password_reset'
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/me/tokens/'
   config.jwt_renewal_url  = 'https://signup-staging.api.gouv.fr/copy-authorization-request/'
+  config.jwt_magic_link_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/magic_link'
 
   config.redis_database = 'redis://localhost:6379/0'
   config.emails_sender_address = 'support@entreprise.api.gouv.fr'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -60,6 +60,7 @@ Rails.application.configure do
   config.renew_password_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/account/password_reset'
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/me/tokens/'
   config.jwt_renewal_url  = 'https://signup-staging.api.gouv.fr/copy-authorization-request/'
+  config.jwt_magic_link_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/magic_link'
 
   config.redis_database = 'redis://localhost:6379/0'
   config.emails_sender_address = 'support@entreprise.api.gouv.fr'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,10 +30,10 @@ Rails.application.routes.draw do
     post   '/users/:id/transfer_ownership'     => 'users#transfer_ownership'
 
     # jwt_api_entreprise
-    get   '/jwt_api_entreprise'                  => 'jwt_api_entreprise#index'
-    post  '/users/:user_id/jwt_api_entreprise'   => 'jwt_api_entreprise#create'
-    patch '/jwt_api_entreprise/:id'              => 'jwt_api_entreprise#update'
-    post  '/jwt_api_entreprise/:id/magic_link'   => 'jwt_api_entreprise#magic_link'
-    get   '/jwt_api_entreprise/show_magic_link'  => 'jwt_api_entreprise#show_magic_link'
+    get   '/jwt_api_entreprise'                       => 'jwt_api_entreprise#index'
+    post  '/users/:user_id/jwt_api_entreprise'        => 'jwt_api_entreprise#create'
+    patch '/jwt_api_entreprise/:id'                   => 'jwt_api_entreprise#update'
+    post  '/jwt_api_entreprise/:id/create_magic_link' => 'jwt_api_entreprise#create_magic_link'
+    get   '/jwt_api_entreprise/show_magic_link'       => 'jwt_api_entreprise#show_magic_link'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,5 +34,6 @@ Rails.application.routes.draw do
     post  '/users/:user_id/jwt_api_entreprise'   => 'jwt_api_entreprise#create'
     patch '/jwt_api_entreprise/:id'              => 'jwt_api_entreprise#update'
     post  '/jwt_api_entreprise/:id/magic_link'   => 'jwt_api_entreprise#magic_link'
+    get   '/jwt_api_entreprise/show_magic_link'  => 'jwt_api_entreprise#show_magic_link'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,8 +30,9 @@ Rails.application.routes.draw do
     post   '/users/:id/transfer_ownership'     => 'users#transfer_ownership'
 
     # jwt_api_entreprise
-    get   '/jwt_api_entreprise'                => 'jwt_api_entreprise#index'
-    post  '/users/:user_id/jwt_api_entreprise' => 'jwt_api_entreprise#create'
-    patch '/jwt_api_entreprise/:id'            => 'jwt_api_entreprise#update'
+    get   '/jwt_api_entreprise'                  => 'jwt_api_entreprise#index'
+    post  '/users/:user_id/jwt_api_entreprise'   => 'jwt_api_entreprise#create'
+    patch '/jwt_api_entreprise/:id'              => 'jwt_api_entreprise#update'
+    post  '/jwt_api_entreprise/:id/magic_link'   => 'jwt_api_entreprise#magic_link'
   end
 end

--- a/db/migrate/20210428134253_add_magic_links_to_jwt_api_entreprise.rb
+++ b/db/migrate/20210428134253_add_magic_links_to_jwt_api_entreprise.rb
@@ -1,0 +1,8 @@
+class AddMagicLinksToJwtApiEntreprise < ActiveRecord::Migration[6.1]
+  def change
+    add_column :jwt_api_entreprises, :magic_link_token, :string, default: nil
+    add_column :jwt_api_entreprises, :magic_link_issuance_date, :datetime, default: nil
+
+    add_index :jwt_api_entreprises, :magic_link_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_29_125933) do
+ActiveRecord::Schema.define(version: 2021_04_28_134253) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -48,9 +48,12 @@ ActiveRecord::Schema.define(version: 2021_03_29_125933) do
     t.string "temp_use_case"
     t.string "authorization_request_id"
     t.boolean "access_request_survey_sent", default: false, null: false
+    t.string "magic_link_token"
+    t.datetime "magic_link_issuance_date"
     t.index ["access_request_survey_sent"], name: "index_jwt_api_entreprises_on_access_request_survey_sent"
     t.index ["created_at"], name: "index_jwt_api_entreprises_on_created_at"
     t.index ["iat"], name: "index_jwt_api_entreprises_on_iat"
+    t.index ["magic_link_token"], name: "index_jwt_api_entreprises_on_magic_link_token", unique: true
     t.index ["user_id"], name: "index_jwt_api_entreprises_on_user_id"
   end
 

--- a/factories/jwt_api_entreprises.rb
+++ b/factories/jwt_api_entreprises.rb
@@ -77,4 +77,9 @@ FactoryBot.define do
   trait :expired do
     exp { Faker::Time.between(from: 20.months.ago, to:19.months.ago).to_i }
   end
+
+  trait :with_magic_link do
+    magic_link_token { 'mUchmaGicWOW' }
+    magic_link_issuance_date { Time.zone.now }
+  end
 end

--- a/spec/concepts/jwt_api_entreprise/operation/create_magic_link_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/create_magic_link_spec.rb
@@ -1,0 +1,81 @@
+require 'rails_helper'
+
+RSpec.describe JwtApiEntreprise::Operation::CreateMagicLink do
+  subject { described_class.call(params: op_params) }
+
+  let(:op_params) do
+    {
+      id: jwt_id,
+      email: email_address,
+    }
+  end
+
+  let(:end_state) { subject.event.to_h[:semantic] }
+
+  context 'when the JwtApiEntreprise record does not exist' do
+    let(:email_address) { 'whatever' }
+    let(:jwt_id) { '0' }
+
+    it { is_expected.to be_failure }
+
+    it 'ends in :not_found state' do
+      expect(end_state).to eq(:not_found)
+    end
+
+    it 'does not queue any email' do
+      expect { subject }
+        .to_not have_enqueued_mail(JwtApiEntrepriseMailer, :magic_link)
+    end
+  end
+
+  context 'when the JwtApiEntreprise record exists' do
+    let!(:jwt) { create(:jwt_api_entreprise) }
+    let(:jwt_id) { jwt.id }
+
+    context 'with a valid email address' do
+      let(:email_address) { 'valid@email.com' }
+
+      it { is_expected.to be_success }
+
+      it 'queues the magic link email' do
+        expect { subject }
+          .to have_enqueued_mail(JwtApiEntrepriseMailer, :magic_link)
+          .with(args: [email_address, jwt])
+      end
+
+      describe 'the token record' do
+        it 'saves a magic token' do
+          subject
+          jwt.reload
+
+          expect(jwt.magic_link_token).to match(/\A[0-9a-f]{20}\z/)
+        end
+
+        it 'saves the issuance date of the magic token' do
+          creation_time = Time.zone.now
+          Timecop.freeze(creation_time) do
+            subject
+            jwt.reload
+
+            expect(jwt.magic_link_issuance_date).to eq(creation_time)
+          end
+        end
+      end
+    end
+
+    context 'with an invalid email address' do
+      let(:email_address) { 'not an email' }
+
+      it { is_expected.to be_failure }
+
+      it 'ends in :invalid_params state' do
+        expect(end_state).to eq(:invalid_params)
+      end
+
+      it 'does not queue any email' do
+        expect { subject }
+          .to_not have_enqueued_mail(JwtApiEntrepriseMailer, :magic_link)
+      end
+    end
+  end
+end

--- a/spec/concepts/jwt_api_entreprise/operation/retrieve_from_magic_link_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/retrieve_from_magic_link_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe JwtApiEntreprise::Operation::RetrieveFromMagicLink do
+  subject { described_class.call(params: params) }
+
+  let(:params) do
+    { token: token }
+  end
+
+  let!(:jwt) { create(:jwt_api_entreprise, :with_magic_link) }
+  let(:token) { jwt.magic_link_token }
+
+  context 'when the magic token does not exist' do
+    let(:token) { 'not a magic link token' }
+
+    it { is_expected.to be_a_failure }
+  end
+
+  context 'when the magic token exists but is expired' do
+    it 'is a failure' do
+      Timecop.freeze(Time.zone.now + 4.hours) do
+        expect(subject).to be_a_failure
+      end
+    end
+  end
+
+  context 'when the magic token is valid' do
+    it { is_expected.to be_a_success }
+
+    its([:jwt]) { is_expected.to eq(jwt) }
+  end
+end

--- a/spec/controllers/jwt_api_entreprise_controller_spec.rb
+++ b/spec/controllers/jwt_api_entreprise_controller_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe JwtApiEntrepriseController, type: :controller do
 
   describe '#magic_link' do
     subject(:call!) do
-      post :magic_link, params: { id: jwt_id, email: email }
+      post :create_magic_link, params: { id: jwt_id, email: email }
     end
 
     shared_examples :magic_links do

--- a/spec/mailers/jwt_api_entreprise_mailer_spec.rb
+++ b/spec/mailers/jwt_api_entreprise_mailer_spec.rb
@@ -157,4 +157,23 @@ RSpec.describe JwtApiEntrepriseMailer, type: :mailer do
     its(:from) { is_expected.to include(Rails.configuration.emails_sender_address) }
     its(:to) { is_expected.to contain_exactly(jwt_api_entreprise.user.email) }
   end
+
+  describe '#magic_link' do
+    subject(:mailer) { described_class.magic_link(email, jwt) }
+
+    let(:email) { 'muchemail@wow.com' }
+    let(:jwt) { create(:jwt_api_entreprise, :with_magic_link) }
+
+    its(:subject) { is_expected.to eq('API Entreprise - Lien d\'accès à votre jeton !') }
+    its(:from) { is_expected.to include(Rails.configuration.emails_sender_address) }
+    its(:to) { is_expected.to contain_exactly(email) }
+
+    it 'contains the magic link to the jwt' do
+      magic_link_path = Rails.configuration.jwt_magic_link_url
+      magic_link_url = "#{magic_link_path}?token=#{jwt.magic_link_token}"
+
+      expect(subject.html_part.decoded).to include(magic_link_url)
+      expect(subject.text_part.decoded).to include(magic_link_url)
+    end
+  end
 end

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -17,12 +17,15 @@ RSpec.describe JwtApiEntreprise, type: :model do
     it { is_expected.to have_db_column(:days_left_notification_sent).of_type(:json).with_options(default: []) }
     it { is_expected.to have_db_column(:authorization_request_id).of_type(:string) }
     it { is_expected.to have_db_column(:access_request_survey_sent).of_type(:boolean).with_options(default: false, null: false) }
+    it { is_expected.to have_db_column(:magic_link_token).of_type(:string).with_options(default: nil) }
+    it { is_expected.to have_db_column(:magic_link_issuance_date).of_type(:datetime).with_options(default: nil) }
   end
 
   describe 'db_indexes' do
     it { is_expected.to have_db_index(:created_at) }
     it { is_expected.to have_db_index(:iat) }
     it { is_expected.to have_db_index(:access_request_survey_sent) }
+    it { is_expected.to have_db_index(:magic_link_token) }
   end
 
   describe 'relationships' do

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -60,6 +60,28 @@ RSpec.describe JwtApiEntreprise, type: :model do
     end
   end
 
+  describe '#generate_magic_link_token' do
+    let(:jwt) { create(:jwt_api_entreprise) }
+
+    it 'generates a random string for the :magic_link_token attribute' do
+      jwt.update(magic_link_token: nil)
+      jwt.generate_magic_link_token
+      jwt.reload
+
+      expect(jwt.magic_link_token).to match(/\A[0-9a-f]{20}\z/)
+    end
+
+    it 'saves the issuance date of the token' do
+      creation_time = Time.zone.now
+      Timecop.freeze(creation_time) do
+        jwt.generate_magic_link_token
+        jwt.reload
+
+        expect(jwt.magic_link_issuance_date).to eq(creation_time)
+      end
+    end
+  end
+
   describe '.issued_in_last_seven_days' do
     subject { described_class }
 

--- a/spec/routing/route_spec.rb
+++ b/spec/routing/route_spec.rb
@@ -94,5 +94,15 @@ RSpec.describe 'Application routes' do
       expect(patch('api/admin/jwt_api_entreprise/very_id'))
         .to route_to(controller: 'jwt_api_entreprise', action: 'update', id: 'very_id')
     end
+
+    it 'has a route to create a magic link' do
+      expect(post('api/admin/jwt_api_entreprise/very_id/create_magic_link'))
+        .to route_to(controller: 'jwt_api_entreprise', action: 'create_magic_link', id: 'very_id')
+    end
+
+    it 'has an update route' do
+      expect(get('api/admin/jwt_api_entreprise/show_magic_link?token=very_token'))
+        .to route_to(controller: 'jwt_api_entreprise', action: 'show_magic_link', token: 'very_token')
+    end
   end
 end


### PR DESCRIPTION
### Contenu de la PR

* Génération de Magic Link envoyé par email pour partager un WT précis. 
* Récupération du JWT à partir d'un magic link. 

Les magic links sont valables pour une durée de 4h (j'ai arbitrairement choisi la durée d'expiration des sessions au dashboard, on peut en discuter/changer ici). 

@Haelle @skelz0r @cyril @hugolepetit 