### PR TITLE
Introduce webhooks for Datapass 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,8 @@ gem 'chartkick'
 gem 'bootsnap', '>= 1.4.4', require: false
 gem 'logstasher'
 
+gem 'interactor'
+
 gem 'sentry-ruby'
 gem 'sentry-rails'
 

--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem 'logstasher'
 
 gem 'interactor'
 
+gem 'chronic'
+
 gem 'sentry-ruby'
 gem 'sentry-rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     case_transform (0.2)
       activesupport
     chartkick (4.0.5)
+    chronic (0.10.2)
     coderay (1.1.3)
     colorize (0.8.1)
     concurrent-ruby (1.1.9)
@@ -502,6 +503,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.4)
   capybara (>= 3.26)
   chartkick
+  chronic
   colorize
   doorkeeper (~> 4.4.0)
   dry-validation (~> 0.11.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,6 +215,7 @@ GEM
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     inflecto (0.0.2)
+    interactor (3.1.2)
     jsonapi-renderer (0.2.2)
     jwt (2.2.2)
     jwtf (0.2.0)
@@ -508,6 +509,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   guard-rspec
+  interactor
   jwt
   jwtf (= 0.2.0)
   listen

--- a/README.md
+++ b/README.md
@@ -160,3 +160,7 @@ sur les machines de production.
 - `config/credentials/production.key`
 - `config/environments/rails_env.rb`
 - `config/initializers/cors.rb`
+
+## Gestion des webhooks DataPass
+
+Se référer à [docs/webhooks.md](docs/webhooks.md)

--- a/app/concepts/authorization_request/contract/create_from_jwt.rb
+++ b/app/concepts/authorization_request/contract/create_from_jwt.rb
@@ -1,0 +1,28 @@
+module AuthorizationRequest::Contract
+  class CreateFromJwt < Reform::Form
+    property :user_id
+    property :external_id
+
+    validation do
+      configure do
+        config.messages_file = Rails.root
+          .join('config/dry_validation_errors.yml').to_s
+
+        def user_exists?(uid)
+          User.exists?(uid)
+        end
+      end
+
+      required(:user_id).filled(:str?, :user_exists?)
+      required(:external_id).filled(:str?)
+
+      # TODO Add a high level validation rule here to ensure at least one
+      # business and one tech contact is provided in the payload
+      required(:contacts).filled
+    end
+
+    collection :contacts,
+      form: Contact::Contract::Upsert,
+      populate_if_empty: Contact
+  end
+end

--- a/app/concepts/authorization_request/operation/find_or_create_from_jwt.rb
+++ b/app/concepts/authorization_request/operation/find_or_create_from_jwt.rb
@@ -1,0 +1,8 @@
+module AuthorizationRequest::Operation
+  class FindOrCreateFromJwt < Trailblazer::Operation
+    step Model(AuthorizationRequest, :find_or_initialize_by, [:user_id, :authorization_id])
+    step self::Contract::Build(constant: AuthorizationRequest::Contract::CreateFromJwt)
+    step self::Contract::Validate()
+    step self::Contract::Persist()
+  end
+end

--- a/app/concepts/jwt_api_entreprise/contract/create.rb
+++ b/app/concepts/jwt_api_entreprise/contract/create.rb
@@ -1,6 +1,6 @@
 module JwtApiEntreprise::Contract
   class Create < Reform::Form
-    property :user_id
+    property :authorization_request
     property :authorization_request_id
     property :subject
 
@@ -14,22 +14,15 @@ module JwtApiEntreprise::Contract
         end
       end
 
-      required(:user_id).filled(:str?, :user_exists?)
-      required(:subject).filled(:str?)
+      required(:authorization_request)
       required(:authorization_request_id).filled(:str?)
 
-      # TODO Add a high level validation rule here to ensure at least one
-      # business and one tech contact is provided in the payload
-      required(:contacts).filled
+      required(:subject).filled(:str?)
 
       # TODO Add a rule to validate the format of the :roles data to ensure
       # the populator won't fail (format should be [{ code: '...' }, { ... }])
       required(:roles).filled
     end
-
-    collection :contacts,
-      form: Contact::Contract::Upsert,
-      populate_if_empty: Contact
 
     collection :roles, populate_if_empty: :populate_roles_from_code do
       property :code
@@ -47,7 +40,6 @@ module JwtApiEntreprise::Contract
         required(:code).filled(:role_exists?)
       end
     end
-
 
     def populate_roles_from_code(options)
       Role.find_by_code(options[:fragment][:code]) || Role.new

--- a/app/concepts/jwt_api_entreprise/operation/create.rb
+++ b/app/concepts/jwt_api_entreprise/operation/create.rb
@@ -40,9 +40,7 @@ module JwtApiEntreprise::Operation
 
     def set_token_defaults(options, model:, **)
       model.update(
-        iat: Time.zone.now.to_i,
-        version: '1.0',
-        exp: 18.months.from_now.to_i
+        JwtApiEntreprise.default_create_params
       )
     end
 

--- a/app/concepts/jwt_api_entreprise/operation/create.rb
+++ b/app/concepts/jwt_api_entreprise/operation/create.rb
@@ -1,11 +1,42 @@
 module JwtApiEntreprise::Operation
   class Create < Trailblazer::Operation
+    step Subprocess(AuthorizationRequest::Operation::FindOrCreateFromJwt),
+      input: :input_for_authorization_request_retrieval,
+      output: :set_authorization_id
+
+    fail :invalid_authorization_request_params
+
     step Model(JwtApiEntreprise, :new)
     step self::Contract::Build(constant: JwtApiEntreprise::Contract::Create)
     step self::Contract::Validate()
     step self::Contract::Persist()
     step :set_token_defaults
     step :send_creation_notices
+
+    def input_for_authorization_request_retrieval(ctx, params:)
+      @original_params = params
+
+      {
+        params: {
+          user_id: params[:user_id],
+          external_id: params[:authorization_request_id],
+          contacts: params[:contacts],
+        }
+      }
+    end
+
+    def set_authorization_id(scoped_ctx, params:, model:, **)
+      {
+        params: @original_params.merge(
+          authorization_request: model,
+          authorization_request_operation_contract: scoped_ctx['result.contract.default'],
+        ),
+      }
+    end
+
+    def invalid_authorization_request_params(ctx, params:)
+      ctx['result.contract.default'] = params[:authorization_request_operation_contract]
+    end
 
     def set_token_defaults(options, model:, **)
       model.update(

--- a/app/concepts/user/operation/transfer_ownership.rb
+++ b/app/concepts/user/operation/transfer_ownership.rb
@@ -19,8 +19,8 @@ module User::Operation
     end
 
     def transfer_tokens(ctx, model:, new_owner:, **)
-      new_owner.jwt_api_entreprise << model.jwt_api_entreprise
-      model.jwt_api_entreprise.clear
+      new_owner.authorization_requests << model.authorization_requests
+      model.authorization_requests.clear
     end
 
     def send_email_notification(ctx, model:, new_owner:, **)

--- a/app/controllers/datapass_webhooks_controller.rb
+++ b/app/controllers/datapass_webhooks_controller.rb
@@ -6,6 +6,16 @@ class DatapassWebhooksController < ApplicationController
   def create
     result = DatapassWebhook.call(**datapass_webhook_params)
 
+    if result.success?
+      handle_success(result)
+    else
+      render json: {}, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def handle_success(result)
     if event == 'validate_application'
       render json: {
         token_id: result.token_id
@@ -14,8 +24,6 @@ class DatapassWebhooksController < ApplicationController
       render json: {}
     end
   end
-
-  private
 
   def datapass_webhook_params
     params.permit(

--- a/app/controllers/datapass_webhooks_controller.rb
+++ b/app/controllers/datapass_webhooks_controller.rb
@@ -1,5 +1,7 @@
 class DatapassWebhooksController < ApplicationController
   skip_before_action :jwt_authenticate!
+  skip_before_action :verify_authenticity_token
+
   before_action :track_payload_through_sentry
   before_action :verify_hub_signature!
 

--- a/app/interactors/application_interactor.rb
+++ b/app/interactors/application_interactor.rb
@@ -1,0 +1,3 @@
+class ApplicationInteractor
+  include Interactor
+end

--- a/app/interactors/application_interactor.rb
+++ b/app/interactors/application_interactor.rb
@@ -1,3 +1,21 @@
 class ApplicationInteractor
   include Interactor
+
+  def fail!(message, level, attributes={})
+    if attributes.any?
+      Sentry.set_context(
+        'Error context',
+        attributes
+      )
+    end
+
+    Sentry.capture_message(
+      message,
+      {
+        level: level,
+      }
+    )
+
+    context.fail!(message: message, attributes: attributes)
+  end
 end

--- a/app/interactors/datapass_webhook/create_jwt_token.rb
+++ b/app/interactors/datapass_webhook/create_jwt_token.rb
@@ -1,0 +1,45 @@
+class DatapassWebhook::CreateJwtToken < ApplicationInteractor
+  def call
+    return if context.event != 'validate_application'
+    return if token_already_exists?
+
+    token = create_jwt_token
+
+    if token.persisted?
+      affect_roles(token)
+      context.token_id = token.id
+    else
+      context.fail!(message: 'Fail to create token')
+    end
+  end
+
+  private
+
+  def create_jwt_token
+    authorization_request.create_jwt_api_entreprise(
+      subject: authorization_request.intitule,
+      authorization_request_id: authorization_request.external_id,
+      iat: Time.zone.now.to_i,
+      version: '1.0',
+      exp: 18.months.from_now.to_i
+    )
+  end
+
+  def affect_roles(token)
+    token.roles = Role.where(code: roles)
+  end
+
+  def token_already_exists?
+    context.authorization_request.jwt_api_entreprise.present?
+  end
+
+  def roles
+    context.data['pass']['scopes'].map do |code, bool|
+      code if bool
+    end.compact
+  end
+
+  def authorization_request
+    context.authorization_request
+  end
+end

--- a/app/interactors/datapass_webhook/create_jwt_token.rb
+++ b/app/interactors/datapass_webhook/create_jwt_token.rb
@@ -17,11 +17,10 @@ class DatapassWebhook::CreateJwtToken < ApplicationInteractor
 
   def create_jwt_token
     authorization_request.create_jwt_api_entreprise(
-      subject: authorization_request.intitule,
-      authorization_request_id: authorization_request.external_id,
-      iat: Time.zone.now.to_i,
-      version: '1.0',
-      exp: 18.months.from_now.to_i
+      JwtApiEntreprise.default_create_params.merge(
+        subject: authorization_request.intitule,
+        authorization_request_id: authorization_request.external_id,
+      )
     )
   end
 

--- a/app/interactors/datapass_webhook/extract_mailjet_variables.rb
+++ b/app/interactors/datapass_webhook/extract_mailjet_variables.rb
@@ -1,0 +1,74 @@
+class DatapassWebhook::ExtractMailjetVariables < ApplicationInteractor
+  def call
+    context.mailjet_variables = build_common_mailjet_variables
+
+    add_instructors_variables if event_from_instructor?
+    add_token_roles if token_present?
+  end
+
+  private
+
+  def build_common_mailjet_variables
+    {
+      'authorization_request_id'          => authorization_request.external_id,
+      'authorization_request_intitule'    => authorization_request.intitule,
+      'authorization_request_description' => authorization_request.description,
+    }
+  end
+
+  def add_instructors_variables
+    instructor_payload = latest_authorization_request_event['user']
+
+    context.mailjet_variables['instructor_first_name'] = instructor_payload['given_name']
+    context.mailjet_variables['instructor_last_name'] = instructor_payload['family_name']
+  end
+
+  def latest_authorization_request_event
+    context.data['pass']['events'].sort do |event1, event2|
+      DateTime.parse(event2['created_at']).to_i <=> DateTime.parse(event1['created_at']).to_i
+    end.first
+  end
+
+  def event_from_instructor?
+    events_from_instructor.include?(context.event)
+  end
+
+  def add_token_roles
+    context.mailjet_variables['token_roles'] ||= {}
+
+    available_roles.each do |role|
+      context.mailjet_variables['token_roles']["role_#{role}"] = token_roles.include?(role)
+    end
+  end
+
+  def token_present?
+    authorization_request.jwt_api_entreprise.present?
+  end
+
+  def token_roles
+    @token_roles ||= authorization_request.jwt_api_entreprise.roles.pluck(:code)
+  end
+
+  def events_from_instructor
+    %w[
+      refuse_application
+      review_application
+      validate_application
+      notify
+    ].freeze
+  end
+
+  def authorization_request
+    context.authorization_request
+  end
+
+  def available_roles
+    ::Role.where.not(code: excluded_roles).pluck(:code)
+  end
+
+  def excluded_roles
+    %w[
+      uptime
+    ].freeze
+  end
+end

--- a/app/interactors/datapass_webhook/extract_mailjet_variables.rb
+++ b/app/interactors/datapass_webhook/extract_mailjet_variables.rb
@@ -34,10 +34,8 @@ class DatapassWebhook::ExtractMailjetVariables < ApplicationInteractor
   end
 
   def add_token_roles
-    context.mailjet_variables['token_roles'] ||= {}
-
     available_role_codes.each do |role|
-      context.mailjet_variables['token_roles']["role_#{role}"] = token_roles.include?(role)
+      context.mailjet_variables["token_role_#{role}"] = token_roles.include?(role).to_s
     end
   end
 

--- a/app/interactors/datapass_webhook/extract_mailjet_variables.rb
+++ b/app/interactors/datapass_webhook/extract_mailjet_variables.rb
@@ -13,6 +13,25 @@ class DatapassWebhook::ExtractMailjetVariables < ApplicationInteractor
       'authorization_request_id'          => authorization_request.external_id,
       'authorization_request_intitule'    => authorization_request.intitule,
       'authorization_request_description' => authorization_request.description,
+    }.merge(
+      build_contact_payload(:user),
+    ).merge(
+      build_contact_payload(:contact_metier),
+    ).merge(
+      build_contact_payload(:contact_technique),
+    )
+  end
+
+  def build_contact_payload(contact_kind)
+    model = authorization_request.public_send(contact_kind)
+    key = contact_kind == :user ? :demandeur : contact_kind
+
+    return {} if model.blank?
+
+    {
+      "#{key}_first_name" => model.first_name,
+      "#{key}_last_name" => model.last_name,
+      "#{key}_email" => model.email,
     }
   end
 

--- a/app/interactors/datapass_webhook/extract_mailjet_variables.rb
+++ b/app/interactors/datapass_webhook/extract_mailjet_variables.rb
@@ -36,7 +36,7 @@ class DatapassWebhook::ExtractMailjetVariables < ApplicationInteractor
   def add_token_roles
     context.mailjet_variables['token_roles'] ||= {}
 
-    available_roles.each do |role|
+    available_role_codes.each do |role|
       context.mailjet_variables['token_roles']["role_#{role}"] = token_roles.include?(role)
     end
   end
@@ -62,8 +62,8 @@ class DatapassWebhook::ExtractMailjetVariables < ApplicationInteractor
     context.authorization_request
   end
 
-  def available_roles
-    ::Role.where.not(code: excluded_roles).pluck(:code)
+  def available_role_codes
+    ::Role.available.pluck(:code)
   end
 
   def excluded_roles

--- a/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
+++ b/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
@@ -14,13 +14,13 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
   private
 
   def create_or_update_contacts
-    create_or_update_contact(:technique)
-    create_or_update_contact(:metier)
+    create_or_update_contact(:responsable_technique, :technique)
+    create_or_update_contact(:contact_metier, :metier)
   end
 
-  def create_or_update_contact(kind)
-    contact = context.authorization_request.public_send("contact_#{kind}") || context.authorization_request.public_send("build_contact_#{kind}")
-    contact_payload = contact_payload_for(kind)
+  def create_or_update_contact(from_kind, to_kind)
+    contact = context.authorization_request.public_send("contact_#{to_kind}") || context.authorization_request.public_send("build_contact_#{to_kind}")
+    contact_payload = contact_payload_for(from_kind)
 
     contact.assign_attributes(
       last_name: contact_payload['family_name'],
@@ -62,8 +62,8 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
   end
 
   def contact_payload_for(kind)
-    context.data['pass']['contacts'].find do |contact_payload|
-      contact_payload['id'] == kind.to_s
+    context.data['pass']['team_members'].find do |contact_payload|
+      contact_payload['type'] == kind.to_s
     end
   end
 

--- a/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
+++ b/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
@@ -36,6 +36,7 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
     context.data['pass'].slice(
       'intitule',
       'description',
+      'status',
     ).merge(authorization_request_attributes_for_current_event).merge(
       'last_update' => fired_at_as_datetime,
     )

--- a/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
+++ b/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
@@ -8,7 +8,7 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
 
     return if context.authorization_request.save
 
-    context.fail!(message: 'Authorization request not valid')
+    fail!('Authorization request not valid', 'error', context.authorization_request.errors.to_h)
   end
 
   private

--- a/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
+++ b/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
@@ -1,0 +1,72 @@
+class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
+  def call
+    context.authorization_request = AuthorizationRequest.find_or_initialize_by(external_id: context.data['pass']['id'])
+    context.authorization_request.assign_attributes(authorization_request_attributes)
+
+    context.authorization_request.user = context.user
+    create_or_update_contacts
+
+    return if context.authorization_request.save
+
+    context.fail!(message: 'Authorization request not valid')
+  end
+
+  private
+
+  def create_or_update_contacts
+    create_or_update_contact(:technique)
+    create_or_update_contact(:metier)
+  end
+
+  def create_or_update_contact(kind)
+    contact = context.authorization_request.public_send("contact_#{kind}") || context.authorization_request.public_send("build_contact_#{kind}")
+    contact_payload = contact_payload_for(kind)
+
+    contact.assign_attributes(
+      last_name: contact_payload['family_name'],
+      first_name: contact_payload['given_name'],
+      email: contact_payload['email'],
+      phone_number: contact_payload['phone_number'],
+    )
+
+    contact.save
+  end
+
+  def authorization_request_attributes
+    context.data['pass'].slice(
+      'intitule',
+      'description',
+    ).merge(authorization_request_attributes_for_current_event).merge(
+      'last_update' => fired_at_as_datetime,
+    )
+  end
+
+  def authorization_request_attributes_for_current_event
+    case context.event
+    when 'send_application'
+      if context.authorization_request.first_submitted_at.nil?
+        {
+          'first_submitted_at' => fired_at_as_datetime,
+        }
+      else
+        {}
+      end
+    when 'validate_application'
+      {
+        'validated_at' => fired_at_as_datetime,
+      }
+    else
+      {}
+    end
+  end
+
+  def contact_payload_for(kind)
+    context.data['pass']['contacts'].find do |contact_payload|
+      contact_payload['id'] == kind.to_s
+    end
+  end
+
+  def fired_at_as_datetime
+    @fired_at_as_datetime ||= Time.at(context.fired_at).to_datetime
+  end
+end

--- a/app/interactors/datapass_webhook/find_or_create_user.rb
+++ b/app/interactors/datapass_webhook/find_or_create_user.rb
@@ -19,6 +19,8 @@ class DatapassWebhook::FindOrCreateUser < ApplicationInteractor
   end
 
   def user_attributes
-    context.data['pass']['user']
+    context.data['pass']['team_members'].find do |team_member|
+      team_member['type'] == 'demandeur'
+    end
   end
 end

--- a/app/interactors/datapass_webhook/find_or_create_user.rb
+++ b/app/interactors/datapass_webhook/find_or_create_user.rb
@@ -1,0 +1,24 @@
+class DatapassWebhook::FindOrCreateUser < ApplicationInteractor
+  def call
+    context.user = User.find_or_initialize_by(email: user_attributes['email'])
+    context.user.assign_attributes(user_attributes_to_assign)
+
+    return if context.user.save
+
+    context.fail!(message: 'User not valid')
+  end
+
+  private
+
+  def user_attributes_to_assign
+    {
+      'first_name' => user_attributes['given_name'],
+      'last_name' => user_attributes['family_name'],
+      'oauth_api_gouv_id' => user_attributes['uid']
+    }
+  end
+
+  def user_attributes
+    context.data['pass']['user']
+  end
+end

--- a/app/interactors/datapass_webhook/find_or_create_user.rb
+++ b/app/interactors/datapass_webhook/find_or_create_user.rb
@@ -5,7 +5,7 @@ class DatapassWebhook::FindOrCreateUser < ApplicationInteractor
 
     return if context.user.save
 
-    context.fail!(message: 'User not valid')
+    fail!('User not valid', 'error', context.user.errors.to_h)
   end
 
   private

--- a/app/interactors/datapass_webhook/schedule_authorization_request_emails.rb
+++ b/app/interactors/datapass_webhook/schedule_authorization_request_emails.rb
@@ -34,7 +34,7 @@ class DatapassWebhook::ScheduleAuthorizationRequestEmails < ApplicationInteracto
 
   def recipients_payload(email_config)
     {
-      to: recipient_payload(email_config['to'] || ['authorization_request.user']),
+      to: recipient_payload(email_config['to'] || default_recipients),
       cc: recipient_payload(email_config['cc']),
     }.compact
   end
@@ -52,6 +52,12 @@ class DatapassWebhook::ScheduleAuthorizationRequestEmails < ApplicationInteracto
         'full_name' => contact.full_name,
       }
     end
+  end
+
+  def default_recipients
+    [
+      'authorization_request.user',
+    ]
   end
 
   def extract_when_time(when_time)

--- a/app/interactors/datapass_webhook/schedule_authorization_request_emails.rb
+++ b/app/interactors/datapass_webhook/schedule_authorization_request_emails.rb
@@ -10,7 +10,7 @@ class DatapassWebhook::ScheduleAuthorizationRequestEmails < ApplicationInteracto
   private
 
   def schedule_email(email_config)
-    return unless condition_met?(email_config['condition'])
+    return unless condition_on_authorization_met?(email_config['condition_on_authorization'])
 
     ScheduleAuthorizationRequestMailjetEmailJob.set(wait_until: extract_when_time(email_config['when'])).perform_later(
       context.authorization_request.id,
@@ -19,10 +19,10 @@ class DatapassWebhook::ScheduleAuthorizationRequestEmails < ApplicationInteracto
     )
   end
 
-  def condition_met?(condition)
-    return true if condition.nil?
+  def condition_on_authorization_met?(condition_on_authorization)
+    return true if condition_on_authorization.nil?
 
-    SafeEval.new(condition, context.authorization_request).perform
+    AuthorizationRequestConditionFacade.new(context.authorization_request).public_send(condition_on_authorization)
   end
 
   def build_mailjet_attributes(email_config)

--- a/app/interactors/datapass_webhook/schedule_authorization_request_emails.rb
+++ b/app/interactors/datapass_webhook/schedule_authorization_request_emails.rb
@@ -1,0 +1,68 @@
+class DatapassWebhook::ScheduleAuthorizationRequestEmails < ApplicationInteractor
+  def call
+    (datapass_webhooks_config_for_event[:emails] || []).each do |email_config|
+      schedule_email(
+        email_config.stringify_keys,
+      )
+    end
+  end
+
+  private
+
+  def schedule_email(email_config)
+    return unless condition_met?(email_config['condition'])
+
+    ScheduleAuthorizationRequestMailjetEmailJob.set(wait_until: extract_when_time(email_config['when'])).perform_later(
+      context.authorization_request.id,
+      context.authorization_request.status,
+      build_mailjet_attributes(email_config),
+    )
+  end
+
+  def condition_met?(condition)
+    return true if condition.nil?
+
+    SafeEval.new(condition, context.authorization_request).perform
+  end
+
+  def build_mailjet_attributes(email_config)
+    {
+      template_id: email_config['id'],
+      vars: context.mailjet_variables,
+    }.merge(recipients_payload(email_config))
+  end
+
+  def recipients_payload(email_config)
+    {
+      to: recipient_payload(email_config['to'] || ['authorization_request.user']),
+      cc: recipient_payload(email_config['cc']),
+    }.compact
+  end
+
+  def recipient_payload(user_strings_to_eval)
+    return if user_strings_to_eval.blank?
+
+    user_strings_to_eval.map do |user_string_to_eval|
+      contact = user_string_to_eval.split('.').reduce(context) do |object, method|
+        object = object.public_send(method)
+      end
+
+      {
+        'email' => contact.email,
+        'full_name' => contact.full_name,
+      }
+    end
+  end
+
+  def extract_when_time(when_time)
+    Chronic.parse(when_time) || Time.now
+  end
+
+  def datapass_webhooks_config_for_event
+    datapass_webhooks_config[context.event.to_sym] || { emails: [] }
+  end
+
+  def datapass_webhooks_config
+    @datapass_webhooks_config ||= Rails.application.config_for('datapass_webhooks')
+  end
+end

--- a/app/interactors/datapass_webhook/update_mailjet_contacts.rb
+++ b/app/interactors/datapass_webhook/update_mailjet_contacts.rb
@@ -1,0 +1,43 @@
+class DatapassWebhook::UpdateMailjetContacts < ApplicationInteractor
+  def call
+    Mailjet::Contactslist_managemanycontacts.create(
+      id: ::Rails.application.credentials.mj_list_id!,
+      action: 'addnoforce',
+      contacts: mailjet_contact_payloads
+    )
+  end
+
+  private
+
+  def mailjet_contact_payloads
+    [
+      mailjet_payload_for(:user),
+      mailjet_payload_for(:contact_metier),
+      mailjet_payload_for(:contact_technique),
+    ].compact.uniq do |mailjet_contact_payload|
+      mailjet_contact_payload[:email]
+    end
+  end
+
+  def mailjet_payload_for(kind)
+    contact = authorization_request.send(kind)
+
+    return if contact.nil?
+    return if contact.email.nil?
+
+    {
+      email: contact.email,
+      properties: {
+        'prénom' => contact.first_name,
+        'nom' => contact.last_name,
+        'contact_demandeur' => contact.email == authorization_request.user.try(:email),
+        'contact_métier' => contact.email == authorization_request.contact_metier.try(:email),
+        'contact_technique' => contact.email == authorization_request.contact_technique.try(:email),
+      }
+    }
+  end
+
+  def authorization_request
+    context.authorization_request
+  end
+end

--- a/app/jobs/schedule_authorization_request_mailjet_email_job.rb
+++ b/app/jobs/schedule_authorization_request_mailjet_email_job.rb
@@ -1,4 +1,6 @@
 class ScheduleAuthorizationRequestMailjetEmailJob < ApplicationJob
+  queue_as :default
+
   attr_reader :authorization_request
 
   def perform(authorization_request_id, authorization_request_status, mailjet_attributes)

--- a/app/jobs/schedule_authorization_request_mailjet_email_job.rb
+++ b/app/jobs/schedule_authorization_request_mailjet_email_job.rb
@@ -1,0 +1,65 @@
+class ScheduleAuthorizationRequestMailjetEmailJob < ApplicationJob
+  attr_reader :authorization_request
+
+  def perform(authorization_request_id, authorization_request_status, mailjet_attributes)
+    @authorization_request = AuthorizationRequest.find_by(id: authorization_request_id)
+
+    return if authorization_request.blank?
+    return if authorization_request.status != authorization_request_status
+
+    deliver_mailjet_email(
+      build_message(mailjet_attributes.stringify_keys)
+    )
+  rescue Mailjet::ApiError => e
+    set_mailjet_context_for_sentry(e)
+    raise
+  end
+
+  def deliver_mailjet_email(message)
+    Mailjet::Send.create(
+      messages: [
+        message,
+      ]
+    )
+  end
+
+  def build_message(mailjet_attributes)
+    {
+      'From' => {
+        'Email' => Rails.configuration.emails_sender_address,
+      },
+      'To' => build_recipient_attributes(mailjet_attributes['to']),
+      'Cc' => build_recipient_attributes(mailjet_attributes['cc']),
+      'Variables' => mailjet_attributes['vars'],
+      'TemplateLanguage' => true,
+      'TemplateID' => mailjet_attributes['template_id'],
+    }.compact
+  end
+
+  def build_recipient_attributes(recipient_payloads)
+    return if recipient_payloads.nil?
+
+    recipient_payloads.map do |recipient_payload|
+      recipient_payload.stringify_keys!
+
+      {
+        'Name' => recipient_payload['full_name'],
+        'Email' => recipient_payload['email'],
+      }
+    end
+  end
+
+  def set_mailjet_context_for_sentry(mailjet_exception)
+    Sentry.set_context(
+      'mailjet error',
+      build_mailjet_error_context(mailjet_exception)
+    )
+  end
+
+  def build_mailjet_error_context(mailjet_exception)
+    {
+      mailjet_error_code: mailjet_exception.code,
+      mailjet_error_reason: mailjet_exception.reason,
+    }
+  end
+end

--- a/app/jobs/schedule_authorization_request_mailjet_email_job.rb
+++ b/app/jobs/schedule_authorization_request_mailjet_email_job.rb
@@ -17,22 +17,19 @@ class ScheduleAuthorizationRequestMailjetEmailJob < ApplicationJob
 
   def deliver_mailjet_email(message)
     Mailjet::Send.create(
-      messages: [
-        message,
-      ]
+      message,
     )
   end
 
   def build_message(mailjet_attributes)
     {
-      'From' => {
-        'Email' => Rails.configuration.emails_sender_address,
-      },
-      'To' => build_recipient_attributes(mailjet_attributes['to']),
-      'Cc' => build_recipient_attributes(mailjet_attributes['cc']),
-      'Variables' => mailjet_attributes['vars'],
-      'TemplateLanguage' => true,
-      'TemplateID' => mailjet_attributes['template_id'],
+      from_name: 'API Entreprise',
+      from_email: Rails.configuration.emails_sender_address,
+      to: build_recipient_attributes(mailjet_attributes['to']),
+      cc: build_recipient_attributes(mailjet_attributes['cc']),
+      vars: mailjet_attributes['vars'],
+      'Mj-TemplateLanguage' => true,
+      'Mj-TemplateID' => mailjet_attributes['template_id'],
     }.compact
   end
 
@@ -42,11 +39,8 @@ class ScheduleAuthorizationRequestMailjetEmailJob < ApplicationJob
     recipient_payloads.map do |recipient_payload|
       recipient_payload.stringify_keys!
 
-      {
-        'Name' => recipient_payload['full_name'],
-        'Email' => recipient_payload['email'],
-      }
-    end
+      "#{recipient_payload['full_name']} <#{recipient_payload['email']}>"
+    end.join(', ')
   end
 
   def set_mailjet_context_for_sentry(mailjet_exception)

--- a/app/lib/authorization_request_condition_facade.rb
+++ b/app/lib/authorization_request_condition_facade.rb
@@ -14,4 +14,14 @@ class AuthorizationRequestConditionFacade < SimpleDelegator
       contact_metier.email,
     ].uniq.count == 1
   end
+
+  def user_is_contact_technique_and_not_contact_metier?
+    user.email == contact_technique.email &&
+      user.email != contact_metier.email
+  end
+
+  def user_is_contact_metier_and_not_contact_technique?
+    user.email == contact_metier.email &&
+      user.email != contact_technique.email
+  end
 end

--- a/app/lib/authorization_request_condition_facade.rb
+++ b/app/lib/authorization_request_condition_facade.rb
@@ -1,0 +1,17 @@
+class AuthorizationRequestConditionFacade < SimpleDelegator
+  def all_contacts_have_different_emails?
+    [
+      user.email,
+      contact_technique.email,
+      contact_metier.email,
+    ].uniq.count == 3
+  end
+
+  def all_contacts_have_the_same_email?
+    [
+      user.email,
+      contact_technique.email,
+      contact_metier.email,
+    ].uniq.count == 1
+  end
+end

--- a/app/lib/datapass_webhook.rb
+++ b/app/lib/datapass_webhook.rb
@@ -1,5 +1,10 @@
 class DatapassWebhook
-  def self.call(...)
-    OpenStruct.new(token_id: nil)
-  end
+  include ::Interactor::Organizer
+
+  organize ::DatapassWebhook::FindOrCreateUser,
+           ::DatapassWebhook::FindOrCreateAuthorizationRequest,
+           ::DatapassWebhook::CreateJwtToken,
+           ::DatapassWebhook::UpdateMailjetContacts,
+           ::DatapassWebhook::ExtractMailjetVariables,
+           ::DatapassWebhook::ScheduleAuthorizationRequestEmails
 end

--- a/app/lib/mailjet/contact_properties_adapter.rb
+++ b/app/lib/mailjet/contact_properties_adapter.rb
@@ -24,19 +24,13 @@ module Mailjet
     private
 
     def role_properties
-      available_roles.inject({}) do |properties, role|
+      available_role_codes.inject({}) do |properties, role|
         properties.merge("role_#{role}".to_sym => roles.include?(role))
       end
     end
 
-    def available_roles
-      ::Role.where.not(code: excluded_roles).map(&:code)
-    end
-
-    def excluded_roles
-      %w[
-        uptime
-      ]
+    def available_role_codes
+      ::Role.available.map(&:code)
     end
   end
 end

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -8,20 +8,4 @@ class AuthorizationRequest < ApplicationRecord
 
   has_one :contact_technique, -> { where(contact_type: 'tech') }, class_name: 'Contact'
   has_one :contact_metier, -> { where(contact_type: 'admin') }, class_name: 'Contact'
-
-  def all_contacts_have_different_emails?
-    [
-      user.email,
-      contact_technique.email,
-      contact_metier.email,
-    ].uniq.count == 3
-  end
-
-  def all_contacts_have_the_same_email?
-    [
-      user.email,
-      contact_technique.email,
-      contact_metier.email,
-    ].uniq.count == 1
-  end
 end

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -8,4 +8,20 @@ class AuthorizationRequest < ApplicationRecord
 
   has_one :contact_technique, -> { where(contact_type: 'tech') }, class_name: 'Contact'
   has_one :contact_metier, -> { where(contact_type: 'admin') }, class_name: 'Contact'
+
+  def all_contacts_have_different_emails?
+    [
+      user.email,
+      contact_technique.email,
+      contact_metier.email,
+    ].uniq.count == 3
+  end
+
+  def all_contacts_have_the_same_email?
+    [
+      user.email,
+      contact_technique.email,
+      contact_metier.email,
+    ].uniq.count == 1
+  end
 end

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -1,3 +1,11 @@
 class AuthorizationRequest < ApplicationRecord
   validates :user, presence: true
+
+  belongs_to :user
+  has_one :jwt_api_entreprise, required: false, foreign_key: 'authorization_request_model_id'
+
+  has_many :contacts, dependent: :delete_all
+
+  has_one :contact_technique, -> { where(contact_type: 'tech') }, class_name: 'Contact'
+  has_one :contact_metier, -> { where(contact_type: 'admin') }, class_name: 'Contact'
 end

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -4,6 +4,8 @@ class AuthorizationRequest < ApplicationRecord
   belongs_to :user
   has_one :jwt_api_entreprise, required: false, foreign_key: 'authorization_request_model_id'
 
+  validates :external_id, uniqueness: true, allow_blank: true
+
   has_many :contacts, dependent: :delete_all
 
   has_one :contact_technique, -> { where(contact_type: 'tech') }, class_name: 'Contact'

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -1,0 +1,3 @@
+class AuthorizationRequest < ApplicationRecord
+  validates :user, presence: true
+end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,4 +1,8 @@
 class Contact < ApplicationRecord
   belongs_to :jwt_api_entreprise
   scope :not_expired, -> { where(jwt_api_entreprises: { blacklisted: false, archived: false } ) }
+
+  def full_name
+    "#{last_name} #{first_name}"
+  end
 end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -3,7 +3,7 @@ class Contact < ApplicationRecord
   has_one :jwt_api_entreprise, through: :authorization_request
 
   def full_name
-    "#{last_name} #{first_name}"
+    "#{last_name.try(:upcase)} #{first_name}"
   end
 
   scope :not_expired, lambda {

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -1,8 +1,21 @@
 class Contact < ApplicationRecord
-  belongs_to :jwt_api_entreprise
-  scope :not_expired, -> { where(jwt_api_entreprises: { blacklisted: false, archived: false } ) }
+  belongs_to :authorization_request
+  has_one :jwt_api_entreprise, through: :authorization_request
 
   def full_name
     "#{last_name} #{first_name}"
   end
+
+  scope :not_expired, lambda {
+    joins(
+      :jwt_api_entreprise,
+    ).where(
+      authorization_request: {
+        jwt_api_entreprises: {
+          blacklisted: false,
+          archived: false
+        }
+      }
+    )
+  }
 end

--- a/app/models/jwt_api_entreprise.rb
+++ b/app/models/jwt_api_entreprise.rb
@@ -1,8 +1,9 @@
 class JwtApiEntreprise < ApplicationRecord
   include RandomToken
 
-  belongs_to :user
-  has_many :contacts, dependent: :delete_all
+  belongs_to :authorization_request, foreign_key: 'authorization_request_model_id', required: false
+  has_one :user, through: :authorization_request
+  has_many :contacts, through: :authorization_request
   has_and_belongs_to_many :roles
 
   scope :access_request_survey_not_sent, -> { where(access_request_survey_sent: false) }
@@ -27,7 +28,7 @@ class JwtApiEntreprise < ApplicationRecord
   end
 
   def renewal_url
-    "#{Rails.configuration.jwt_renewal_url}#{authorization_request_id}"
+    "#{Rails.configuration.jwt_renewal_url}#{authorization_request.external_id}"
   end
 
   def user_and_contacts_email

--- a/app/models/jwt_api_entreprise.rb
+++ b/app/models/jwt_api_entreprise.rb
@@ -50,6 +50,14 @@ class JwtApiEntreprise < ApplicationRecord
     temp_use_case || subject
   end
 
+  def self.default_create_params
+    {
+      iat: Time.zone.now.to_i,
+      version: '1.0',
+      exp: 18.months.from_now.to_i,
+    }
+  end
+
   private
 
   def token_payload

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,3 +1,11 @@
 class Role < ApplicationRecord
   has_and_belongs_to_many :jwt_api_entreprise
+
+  scope :available, -> { where.not(code: Role.internal_role_codes) }
+
+  def self.internal_role_codes
+    %w[
+      uptime
+    ]
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@ class User < ApplicationRecord
   end
 
   def full_name
-    "#{last_name} #{first_name}"
+    "#{last_name.try(:upcase)} #{first_name}"
   end
 
   def tokens_newly_transfered?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,10 @@ class User < ApplicationRecord
     !!oauth_api_gouv_id
   end
 
+  def full_name
+    "#{last_name} #{first_name}"
+  end
+
   def tokens_newly_transfered?
     tokens_newly_transfered
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,9 @@
 class User < ApplicationRecord
   include RandomToken
 
-  has_many :jwt_api_entreprise, dependent: :nullify
-  has_many :contacts, through: :jwt_api_entreprise
+  has_many :authorization_requests, dependent: :nullify
+  has_many :jwt_api_entreprise, through: :authorization_requests
+  has_many :contacts, through: :authorization_requests
   has_many :roles, through: :jwt_api_entreprise
 
   scope :added_since_yesterday, -> { where('created_at > ?', 1.day.ago) }

--- a/app/serializers/jwt_api_entreprise_index_serializer.rb
+++ b/app/serializers/jwt_api_entreprise_index_serializer.rb
@@ -6,4 +6,8 @@ class JwtApiEntrepriseIndexSerializer < ActiveModel::Serializer
   def subject
     object.displayed_subject
   end
+
+  def user_id
+    object.authorization_request.try(:user_id)
+  end
 end

--- a/config/datapass_webhooks.yml
+++ b/config/datapass_webhooks.yml
@@ -1,0 +1,67 @@
+# Check https://github.com/betagouv/signup-back/tree/master/docs/webhooks.md for all events and their details
+---
+development: &development
+  created: {}
+  updated: {}
+  owner_updated: {}
+  rgpd_contact_updated: {}
+  send_application:
+    emails:
+      - id: '11'
+      - id: '12'
+        when: 'in 14 days'
+  notify: {}
+  review_application: {}
+  refuse_application: {}
+  validate_application:
+    emails:
+      - id: '51'
+        condition: 'authorization_request.user.first_name == "run"'
+      - id: '52'
+        condition: 'authorization_request.user.last_name == "run"'
+        to:
+          - 'authorization_request.contact_metier'
+        cc:
+          - 'authorization_request.contact_technique'
+          - 'authorization_request.user'
+test: *development
+
+production: &production
+  created:
+    emails:
+      - id: '3098115'
+      - id: '3098214'
+        when: 'in 14 days'
+  updated: {}
+  owner_updated: {}
+  rgpd_contact_updated: {}
+  sent_application:
+    emails:
+      - id: '3098391'
+      - id: '3098436'
+        when: 'in 14 days'
+  notify: {}
+  review_application:
+    emails:
+      - id: '3098236'
+      - id: '3098155'
+        when: 'in 14 days'
+  refuse_application:
+    emails:
+      - id: '3084277'
+  # FIXME
+  validate_application:
+    emails:
+      - id: '51'
+        condition: 'authorization_request.all_contacts_have_the_same_email?'
+      - id: '52'
+        condition: 'authorization_request.all_contacts_have_different_emails?'
+        to:
+          - 'authorization_request.user'
+        cc:
+          - 'authorization_request.contact_metier'
+          - 'authorization_request.contact_technique'
+
+
+sandbox: *production
+staging: *production

--- a/config/datapass_webhooks.yml
+++ b/config/datapass_webhooks.yml
@@ -12,18 +12,18 @@ development: &development
         when: 'in 14 days'
   notify: {}
   review_application: {}
-  refuse_application: {}
-  validate_application:
+  refuse_application:
     emails:
       - id: '51'
-        condition: 'authorization_request.user.first_name == "run"'
+        condition_on_authorization: 'user_first_name_is_run?'
       - id: '52'
-        condition: 'authorization_request.user.last_name == "run"'
+        condition_on_authorization: 'user_last_name_is_run?'
         to:
           - 'authorization_request.contact_metier'
         cc:
           - 'authorization_request.contact_technique'
           - 'authorization_request.user'
+  validate_application: {}
 test: *development
 
 production: &production
@@ -53,9 +53,9 @@ production: &production
   validate_application:
     emails:
       - id: '51'
-        condition: 'authorization_request.all_contacts_have_the_same_email?'
+        condition_on_authorization: 'all_contacts_have_the_same_email?'
       - id: '52'
-        condition: 'authorization_request.all_contacts_have_different_emails?'
+        condition_on_authorization: 'all_contacts_have_different_emails?'
         to:
           - 'authorization_request.user'
         cc:

--- a/config/datapass_webhooks.yml
+++ b/config/datapass_webhooks.yml
@@ -35,7 +35,7 @@ production: &production
   updated: {}
   owner_updated: {}
   rgpd_contact_updated: {}
-  sent_application:
+  send_application:
     emails:
       - id: '3098391'
       - id: '3098436'
@@ -49,19 +49,53 @@ production: &production
   refuse_application:
     emails:
       - id: '3084277'
-  # FIXME
   validate_application:
     emails:
-      - id: '51'
+      - id: '3090261'
         condition_on_authorization: 'all_contacts_have_the_same_email?'
-      - id: '52'
+
+
+      - id: '3090303'
         condition_on_authorization: 'all_contacts_have_different_emails?'
         to:
           - 'authorization_request.user'
+      - id: '3090321'
+        condition_on_authorization: 'all_contacts_have_different_emails?'
+        to:
+          - 'authorization_request.contact_technique'
         cc:
+          - 'authorization_request.user'
+      - id: '3084241'
+        condition_on_authorization: 'all_contacts_have_different_emails?'
+        to:
           - 'authorization_request.contact_metier'
+        cc:
+          - 'authorization_request.user'
           - 'authorization_request.contact_technique'
 
+
+      - id: '3090303'
+        condition_on_authorization: 'user_is_contact_metier_and_not_contact_technique?'
+        to:
+          - 'authorization_request.user'
+      - id: '3090321'
+        condition_on_authorization: 'user_is_contact_metier_and_not_contact_technique?'
+        to:
+          - 'authorization_request.contact_technique'
+        cc:
+          - 'authorization_request.user'
+
+
+      - id: '3090261'
+        condition_on_authorization: 'user_is_contact_technique_and_not_contact_metier?'
+        to:
+          - 'authorization_request.user'
+      - id: '3084241'
+        condition_on_authorization: 'user_is_contact_technique_and_not_contact_metier?'
+        to:
+          - 'authorization_request.contact_metier'
+        cc:
+          - 'authorization_request.user'
 
 sandbox: *production
 staging: *production

--- a/db/migrate/20210811142038_create_authorization_requests.rb
+++ b/db/migrate/20210811142038_create_authorization_requests.rb
@@ -16,7 +16,7 @@ class CreateAuthorizationRequests < ActiveRecord::Migration[6.1]
     add_column :contacts, :authorization_request_id, :uuid
     add_column :jwt_api_entreprises, :authorization_request_model_id, :uuid
 
-    JwtApiEntreprise.includes(:contacts).where.not(authorization_request_id: nil).find_each do |jwt_api_entreprise|
+    JwtApiEntreprise.where.not(authorization_request_id: nil).find_each do |jwt_api_entreprise|
       authorization_request = AuthorizationRequest.create!(
         intitule: jwt_api_entreprise.subject,
         external_id: jwt_api_entreprise.authorization_request_id,
@@ -26,7 +26,7 @@ class CreateAuthorizationRequests < ActiveRecord::Migration[6.1]
         user_id: jwt_api_entreprise.user_id,
       )
 
-      jwt_api_entreprise.contacts.each do |contact|
+      Contact.where(jwt_api_entreprise_id: jwt_api_entreprise.id).each do |contact|
         contact.update!(
           authorization_request_id: authorization_request.id,
         )

--- a/db/migrate/20210811142038_create_authorization_requests.rb
+++ b/db/migrate/20210811142038_create_authorization_requests.rb
@@ -1,0 +1,47 @@
+class CreateAuthorizationRequests < ActiveRecord::Migration[6.1]
+  def up
+    create_table :authorization_requests, id: :uuid do |t|
+      t.string :intitule
+      t.string :description
+      t.string :external_id
+      t.string :status
+      t.datetime :last_update
+      t.datetime :first_submitted_at
+      t.datetime :validated_at
+      t.datetime :created_at
+
+      t.uuid :user_id, null: false
+    end
+
+    add_column :contacts, :authorization_request_id, :uuid
+    add_column :jwt_api_entreprises, :authorization_request_model_id, :uuid
+
+    JwtApiEntreprise.includes(:contacts).where.not(authorization_request_id: nil).find_each do |jwt_api_entreprise|
+      authorization_request = AuthorizationRequest.create!(
+        intitule: jwt_api_entreprise.subject,
+        external_id: jwt_api_entreprise.authorization_request_id,
+        status: 'validate_application',
+        last_update: jwt_api_entreprise.created_at,
+        validated_at: jwt_api_entreprise.created_at,
+        user_id: jwt_api_entreprise.user_id,
+      )
+
+      jwt_api_entreprise.contacts.each do |contact|
+        contact.update!(
+          authorization_request_id: authorization_request.id,
+        )
+      end
+
+      jwt_api_entreprise.update!(
+        authorization_request_model_id: authorization_request.id,
+      )
+    end
+  end
+
+  def down
+    drop_table :authorization_requests
+
+    remove_column :contacts, :authorization_request_id, :uuid
+    remove_column :jwt_api_entreprises, :authorization_request_model_id, :uuid
+  end
+end

--- a/db/migrate/20210813124603_add_full_name_to_users.rb
+++ b/db/migrate/20210813124603_add_full_name_to_users.rb
@@ -1,0 +1,6 @@
+class AddFullNameToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :first_name, :string
+    add_column :users, :last_name, :string
+  end
+end

--- a/db/migrate/20210820102431_add_full_name_to_contacts.rb
+++ b/db/migrate/20210820102431_add_full_name_to_contacts.rb
@@ -1,0 +1,6 @@
+class AddFullNameToContacts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :contacts, :first_name, :string
+    add_column :contacts, :last_name, :string
+  end
+end

--- a/db/migrate/20210830072250_add_unique_index_if_not_null_on_external_id_to_authorization_requests.rb
+++ b/db/migrate/20210830072250_add_unique_index_if_not_null_on_external_id_to_authorization_requests.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexIfNotNullOnExternalIdToAuthorizationRequests < ActiveRecord::Migration[6.1]
+  def change
+    add_index :authorization_requests, :external_id, unique: true, where: 'external_id IS NOT NULL'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_20_102431) do
+ActiveRecord::Schema.define(version: 2021_08_30_072250) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2021_08_20_102431) do
     t.datetime "validated_at"
     t.datetime "created_at"
     t.uuid "user_id", null: false
+    t.index ["external_id"], name: "index_authorization_requests_on_external_id", unique: true, where: "(external_id IS NOT NULL)"
   end
 
   create_table "contacts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_13_124603) do
+ActiveRecord::Schema.define(version: 2021_08_20_102431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2021_08_13_124603) do
     t.uuid "jwt_api_entreprise_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "first_name"
+    t.string "last_name"
     t.index ["created_at"], name: "index_contacts_on_created_at"
     t.index ["jwt_api_entreprise_id"], name: "index_contacts_on_jwt_api_entreprise_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_23_080558) do
+ActiveRecord::Schema.define(version: 2021_08_13_124603) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -129,6 +130,8 @@ ActiveRecord::Schema.define(version: 2021_06_23_080558) do
     t.string "oauth_api_gouv_id"
     t.boolean "admin", default: false
     t.boolean "tokens_newly_transfered", default: false
+    t.string "first_name"
+    t.string "last_name"
     t.index ["created_at"], name: "index_users_on_created_at"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["pwd_renewal_token"], name: "index_users_on_pwd_renewal_token"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,18 @@ ActiveRecord::Schema.define(version: 2021_08_20_102431) do
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
+  create_table "authorization_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "intitule"
+    t.string "description"
+    t.string "external_id"
+    t.string "status"
+    t.datetime "last_update"
+    t.datetime "first_submitted_at"
+    t.datetime "validated_at"
+    t.datetime "created_at"
+    t.uuid "user_id", null: false
+  end
+
   create_table "contacts", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "email"
     t.string "phone_number"
@@ -25,6 +37,7 @@ ActiveRecord::Schema.define(version: 2021_08_20_102431) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "first_name"
     t.string "last_name"
+    t.uuid "authorization_request_id"
     t.index ["created_at"], name: "index_contacts_on_created_at"
     t.index ["jwt_api_entreprise_id"], name: "index_contacts_on_jwt_api_entreprise_id"
   end
@@ -54,6 +67,7 @@ ActiveRecord::Schema.define(version: 2021_08_20_102431) do
     t.boolean "access_request_survey_sent", default: false, null: false
     t.string "magic_link_token"
     t.datetime "magic_link_issuance_date"
+    t.uuid "authorization_request_model_id"
     t.index ["access_request_survey_sent"], name: "index_jwt_api_entreprises_on_access_request_survey_sent"
     t.index ["archived"], name: "index_jwt_api_entreprises_on_archived"
     t.index ["blacklisted"], name: "index_jwt_api_entreprises_on_blacklisted"

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -71,11 +71,11 @@ production:
   validate_application:
     emails:
       - id: "51"
-        # La clé 'condition' permet d'appliquer une condition sur l'envoi de l'email. Cette condition est évaluée au moment de la réception du webhook et non lors de l'envoi. Cette condition doit
+        # La clé 'condition_on_authorization' permet d'appliquer une condition sur l'envoi de l'email. Cette condition est évaluée au moment de la réception du webhook et non lors de l'envoi. Cette condition doit être une méthode définie sur la classe AuthorizationRequestConditionFacade
         # Par défaut condition est évalué à true
-        condition: "authorization_request.all_contacts_have_the_same_email?"
+        condition_on_authorization: "all_contacts_have_the_same_email?"
       - id: "52"
-        condition: "authorization_request.all_contacts_have_different_emails?"
+        condition_on_authorization: "all_contacts_have_different_emails?"
         # Tableau des destinataires, doit être soit un modèle User soit un modèle Contact
         to:
           - "authorization_request.contact_metier"
@@ -88,9 +88,8 @@ production:
 Un test d'acceptance vérifie le format du fichier: si il y a une typo les tests
 ne passeront pas.
 
-A noter de même que les conditions sont évalués dans un environnement sécurisé
-un minimum, mais il faut vérifier tout de même qu'aucune action dangereuse
-n'est présente (à priori il s'agit de simple vérifications d'attributs).
+Pour les conditions évaluées, vous trouverez le fichier ici:
+[AuthorizationRequestConditionFacade](../app/lib/authorization_request_condition_facade.rb)
 
 ## Variables d'environnement disponibles lors de l'envoi via Mailjet
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,136 @@
+# Gestion des webhooks DataPass
+
+## Introduction / contexte
+
+DataPass intègre un système de webhooks qui envoie des payloads à une URL cible
+en fonction du service, ceci à chaque changement d'état d'une demande associé à
+ce dit service. Dans le cadre d'API Entreprise, ceux-ci nous servent à gérer
+intégralement la communication envoyée aux utilisateurs, ainsi que la création
+du jeton associé en cas de validation.
+
+Pour le contexte, les emails étaient précédemment géré par DataPass, tandis que
+la création du jeton était géré par un " bridge " custom côté DataPass.
+
+A noter que certains emails (relatifs aux contacts RGPD) sont encore gérés côté
+DataPass.
+
+Pour plus d'infos sur les webhooks:
+
+- [Documentation DataPass sur les
+  webhooks](https://github.com/betagouv/signup-back/blob/master/docs/webhooks.md)
+- [Implémentation technique pour API
+  Entreprise](https://github.com/betagouv/signup-back/blob/master/app/notifiers/api_entreprise_notifier.rb)
+
+## Implémentation technique
+
+L'intégralité du traitement s'effectue à travers le controller
+`DatapassWebhooksController`, où l'organizer `DatapassWebhook` est appelé.
+
+Celui-ci effectue les tâches suivantes de manière séquentielle:
+
+1. Trouve ou crée l'utilisateur (le demandeur)
+1. Trouve ou crée la demande, en affectant les dernières valeurs (intitule,
+   contacts etc...)
+1. Si l'événement est une validation, crée le jeton associé
+1. Mets à jour les contacts (demandeur, technique et métier) sur Mailjet
+1. Construit la liste des variables Mailjet
+1. Planifie l'ensemble des emails associés à la demande, en fonction de
+   l'événement
+
+Cette dernière étape s'appuie sur un fichier de configuration, expliqué
+ci-dessous.
+
+## Fichier de configuration
+
+Le fichier de configuration se situe dans
+[`config/datapass_webhooks.yml`](./config/datapass_webhooks.yml) et permet de
+planifier les emails aux divers contacts associés à la demande.
+
+Ci-dessous un exemple avec les explications de chaque entrée:
+
+```yaml
+# L'environnement associé à la configuration
+production:
+  # Chaque clé à ce niveau correspond à un événement associé à la demande. La liste exhaustive se trouve dans la documentation DataPass
+  # Une clé vide ou absente n'effectue aucun envoi d'email.
+  created: {}
+  send_application:
+    emails:
+      # Chaque entrée correspond à un email. Le champ 'id' correspond à l'ID technique d'un template transactionnel sur Mailjet, et doit être présent (il s'agit du seul champ obligatoire)
+      - id: "11"
+      - id: "12"
+        # La clé 'when' permet de planifier un email dans le future, dans le cadre des relances. Point iportant: si la demande a changé d'état au moment de l'envoi, l'email n'est pas envoyé.
+        # Par défaut l'email est envoyé sans délai.
+        when: "in 14 days"
+  review_application:
+    emails:
+      - id: "22"
+  refuse_application:
+    emails:
+      - id: "32"
+  validate_application:
+    emails:
+      - id: "51"
+        # La clé 'condition' permet d'appliquer une condition sur l'envoi de l'email. Cette condition est évaluée au moment de la réception du webhook et non lors de l'envoi. Cette condition doit
+        # Par défaut condition est évalué à true
+        condition: "authorization_request.all_contacts_have_the_same_email?"
+      - id: "52"
+        condition: "authorization_request.all_contacts_have_different_emails?"
+        # Tableau des destinataires, doit être soit un modèle User soit un modèle Contact
+        to:
+          - "authorization_request.contact_metier"
+        # Tableau des destinataires en copie
+        cc:
+          - "authorization_request.contact_technique"
+          - "authorization_request.user"
+```
+
+Un test d'acceptance vérifie le format du fichier: si il y a une typo les tests
+ne passeront pas.
+
+A noter de même que les conditions sont évalués dans un environnement sécurisé
+un minimum, mais il faut vérifier tout de même qu'aucune action dangereuse
+n'est présente (à priori il s'agit de simple vérifications d'attributs).
+
+## Variables d'environnement disponibles lors de l'envoi via Mailjet
+
+Les variables ci-dessous sont disponibles quelque soit l'état de la demande:
+
+1. `authorization_request_id`, `integer`, l'ID de la demande DataPass
+1. `authorization_request_intitule`, `string`, l'intitulé de la demande DataPass
+1. `authorization_request_description`, `string`, la description de la demande DataPass
+
+Si l'événement est initié par un instructeur (`refuse_application`,
+`review_application`, `validate_application`, `review`), les variables suivantes
+sont disponibles:
+
+1. `instructor_first_name`, `string`, prénom de l'instructeur
+1. `instructor_last_name`, `string`, nom de l'instructeur
+
+A noter qu'il s'agit de variables d'environnements. Les attributs des contacts
+sont mis à jour avant l'envoi des emails, et décrit ci-dessous.
+
+Si un jeton est associé à la demande (théoriquement seulement dans le cas de la
+validation), les variables suivantes sont disponibles:
+
+1. `token_roles`, hash de configuration des authorizations associé à la demande.
+   Le format est le suivant:
+   ```json
+   {
+     "role_entreprise": true,
+     "role_exercices": false
+   }
+   ```
+
+## Mise à jour des attributs des contacts
+
+A chaque réception d'un webhook, les informations de contacts sont mis à jour
+sur Mailjet. Les contacts regroupent le demandeur, le contact technique et le
+contact métier. Les informations mises à jour sont les suivantes:
+
+1. `prénom`, `string`, le prénom du contact
+1. `nom`, `string`, le nom du contact
+1. `contact_demandeur`, `boolean`, indique si le contact est le demandeur
+1. `contact_métier`, `boolean`, indique si le contact est le contact métier
+1. `contact_technique`, `boolean`, indique si le contact est le contact
+   technique

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -98,6 +98,17 @@ Les variables ci-dessous sont disponibles quelque soit l'état de la demande:
 1. `authorization_request_id`, `integer`, l'ID de la demande DataPass
 1. `authorization_request_intitule`, `string`, l'intitulé de la demande DataPass
 1. `authorization_request_description`, `string`, la description de la demande DataPass
+1. `demandeur_first_name`, `string`, le prénom du demandeur
+1. `demandeur_last_name`, `string`, le nom du demandeur
+1. `demandeur_email`, `string`, l'email du demandeur
+1. `contact_metier_first_name`, `string`, le prénom du contact métier
+1. `contact_metier_last_name`, `string`, le nom du contact métier
+1. `contact_metier_email`, `string`, l'email du contact métier
+1. `contact_technique_first_name`, `string`, le prénom du contact technique
+1. `contact_technique_last_name`, `string`, le nom du contact technique
+1. `contact_technique_email`, `string`, l'email du contact technique
+
+A noter que les variables associées aux contacts peuvent être vides.
 
 Si l'événement est initié par un instructeur (`refuse_application`,
 `review_application`, `validate_application`, `review`), les variables suivantes

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -112,14 +112,8 @@ sont mis à jour avant l'envoi des emails, et décrit ci-dessous.
 Si un jeton est associé à la demande (théoriquement seulement dans le cas de la
 validation), les variables suivantes sont disponibles:
 
-1. `token_roles`, hash de configuration des authorizations associé à la demande.
-   Le format est le suivant:
-   ```json
-   {
-     "role_entreprise": true,
-     "role_exercices": false
-   }
-   ```
+1. `token_role_ROLE`, `boolean`, détermine si ROLE est associé au jeton. La
+   liste des rôles est celle en base de données.
 
 ## Mise à jour des attributs des contacts
 

--- a/spec/acceptances/datapass_webhooks_config_format_spec.rb
+++ b/spec/acceptances/datapass_webhooks_config_format_spec.rb
@@ -36,6 +36,21 @@ RSpec.describe 'Datapass webhook config format', type: :acceptance do
             expect(date).to be_future, "[#{env}] #{event} emails ##{index+1} has an invalid date for 'when', which is not in the future: #{email_config['when']}"
           end
 
+          %w[to cc].each do |kind|
+            if email_config[kind].present?
+              expect(email_config[kind]).to be_an_instance_of(Array), "[#{env}] #{event} emails ##{index+1} has an invalid '#{kind}': not an array"
+
+              email_config[kind].each do |to_recipient|
+                contact = to_recipient.split('.').reduce(OpenStruct.new(authorization_request: dummy_authorization_request)) do |object, method|
+                  object = object.public_send(method)
+                end
+
+                expect(contact).to respond_to(:email)
+                expect(contact).to respond_to(:full_name)
+              end
+            end
+          end
+
           if email_config['condition_on_authorization'].present?
             next if %w[development test].include?(env)
 

--- a/spec/acceptances/datapass_webhooks_config_format_spec.rb
+++ b/spec/acceptances/datapass_webhooks_config_format_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+require 'yaml'
+
+RSpec.describe 'Datapass webhook config format', type: :acceptance do
+  let(:file) { Rails.root.join('./config/datapass_webhooks.yml') }
+  let(:dummy_authorization_request) { create(:authorization_request, :with_contacts)}
+
+  it 'is a valid file' do
+    expect {
+      YAML.load_file(file)
+    }.not_to raise_error
+  end
+
+  it 'has valid format for each event' do
+    yaml_config = YAML.load_file(file)
+
+    %w[
+      development
+      test
+      production
+      sandbox
+      staging
+    ].each do |env|
+      yaml_config[env].each do |event, config|
+        next if config['emails'].blank?
+
+        expect(config['emails']).to be_a(Array), "[#{env}] #{event} has an emails key which is not an array"
+
+        config['emails'].each_with_index do |email_config, index|
+          expect(email_config['id']).to be_present, "[#{env}] #{event} emails ##{index+1} has no id key"
+
+          if email_config['when'].present?
+            date = Chronic.parse(email_config['when'])
+
+            expect(date).to be_present, "[#{env}] #{event} emails ##{index+1} has an invalid date for 'when', which is not parsable: #{email_config['when']}"
+            expect(date).to be_future, "[#{env}] #{event} emails ##{index+1} has an invalid date for 'when', which is not in the future: #{email_config['when']}"
+          end
+
+          if email_config['condition'].present?
+            result = SafeEval.new(email_config['condition'], dummy_authorization_request).perform
+
+            expect(result).to be_an_instance_of(TrueClass).or be_an_instance_of(FalseClass)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/concepts/jwt_api_entreprise/operation/create_spec.rb
+++ b/spec/concepts/jwt_api_entreprise/operation/create_spec.rb
@@ -141,8 +141,8 @@ RSpec.describe JwtApiEntreprise::Operation::Create do
       end
     end
 
-    describe ':authorization_request_id' do
-      let(:errors) { subject['result.contract.default'].errors[:authorization_request_id] }
+    describe ':authorization_request_id (which is renamed external_id)' do
+      let(:errors) { subject['result.contract.default'].errors[:external_id] }
 
       it 'is required' do
         token_params.delete(:authorization_request_id)
@@ -183,7 +183,7 @@ RSpec.describe JwtApiEntreprise::Operation::Create do
         token_params.delete(:contacts)
 
         expect(subject).to be_failure
-        expect(errors).to include('must be filled')
+        expect(errors).to include('is missing')
       end
 
       pending 'business and tech contacts are required'

--- a/spec/concepts/mailjet_contacts/operation/create_spec.rb
+++ b/spec/concepts/mailjet_contacts/operation/create_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe MailjetContacts::Operation::Create do
   end
 
   context 'when a user with a tech contact is present in the DB' do
-    let(:user) { create(:contact, :tech).jwt_api_entreprise.user }
+    let(:user) { create(:contact, :tech).authorization_request.user }
 
     context 'when he was added a long time ago' do
       let(:creation_period) { Faker::Time.between(from: 10.years.ago, to: 1.day.ago) }

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  sequence(:external_authorization_request_id) { |n| "#{n}" }
+
+  factory :authorization_request do
+    user
+
+    trait :with_external_id do
+      external_id { generate(:external_authorization_request_id) }
+    end
+  end
+end

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -2,10 +2,19 @@ FactoryBot.define do
   sequence(:external_authorization_request_id) { |n| "#{n}" }
 
   factory :authorization_request do
-    user
+    user { build(:user, :with_full_name) }
 
     trait :with_external_id do
       external_id { generate(:external_authorization_request_id) }
+    end
+
+    trait :with_contacts do
+      contacts do
+        [
+          build(:contact, :with_full_name, :business),
+          build(:contact, :with_full_name, :tech),
+        ]
+      end
     end
   end
 end

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -3,7 +3,18 @@ FactoryBot.define do
     sequence(:email) { |n| "contact_#{n}@example.org" }
     phone_number { '0256743256' }
     contact_type { 'other' }
-    jwt_api_entreprise
+    authorization_request
+
+    transient do
+      jwt_api_entreprise { nil }
+    end
+
+    after(:build) do |contact, evaluator|
+      if evaluator.jwt_api_entreprise
+        contact.authorization_request = evaluator.jwt_api_entreprise.authorization_request
+        contact.authorization_request.user = evaluator.jwt_api_entreprise.user
+      end
+    end
 
     trait :with_full_name do
       first_name { 'Jean-Marc' }

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -5,6 +5,11 @@ FactoryBot.define do
     contact_type { 'other' }
     jwt_api_entreprise
 
+    trait :with_full_name do
+      first_name { 'Jean-Marc' }
+      last_name { 'Gigot' }
+    end
+
     trait :business do
       contact_type { 'admin' }
     end

--- a/spec/factories/datapass_webhooks.rb
+++ b/spec/factories/datapass_webhooks.rb
@@ -33,6 +33,7 @@ FactoryBot.define do
     sequence(:id) { |n| "#{n}" }
     intitule { 'intitule from webhook' }
     description { 'description from webhook' }
+    status { 'sent' }
 
     user { build(:datapass_webhook_user_model) }
 

--- a/spec/factories/datapass_webhooks.rb
+++ b/spec/factories/datapass_webhooks.rb
@@ -1,0 +1,95 @@
+FactoryBot.define do
+  factory :datapass_webhook, class: Hash do
+    initialize_with { attributes.stringify_keys }
+
+    event { 'refuse_application' }
+    model_type { 'Pass' }
+    fired_at { Time.now.to_i }
+    data do
+      {
+        'pass' => build(:datapass_webhook_pass_model),
+      }
+    end
+
+    transient do
+      user_attributes { nil }
+      authorization_request_attributes { nil }
+    end
+
+    after(:build) do |datapass_webhook, evaluator|
+      if evaluator.authorization_request_attributes
+        datapass_webhook['data']['pass'] = build(:datapass_webhook_pass_model, evaluator.authorization_request_attributes)
+      end
+
+      if evaluator.user_attributes
+        datapass_webhook['data']['pass']['user'] = build(:datapass_webhook_user_model, evaluator.user_attributes)
+      end
+    end
+  end
+
+  factory :datapass_webhook_pass_model, class: Hash do
+    initialize_with { attributes.stringify_keys }
+
+    sequence(:id) { |n| "#{n}" }
+    intitule { 'intitule from webhook' }
+    description { 'description from webhook' }
+
+    user { build(:datapass_webhook_user_model) }
+
+    events { build_list(:datapass_webhook_event_model, 2) }
+
+    contacts do
+      [
+        build(:datapass_webhook_contact_model, id: 'metier'),
+        build(:datapass_webhook_contact_model, id: 'technique'),
+      ]
+    end
+
+    scopes do
+      {
+        'associations' => true,
+        'entreprises' => true,
+        'exercices' => false,
+      }
+    end
+  end
+
+  factory :datapass_webhook_user_model, class: Hash do
+    initialize_with { attributes.stringify_keys }
+
+    sequence(:id) { |n| "#{n}" }
+    sequence(:uid) { |n| "uid#{n}" }
+    given_name { 'John' }
+    family_name { 'Doe' }
+    sequence(:email) { |n| "john.doe.#{n}@service.api.gouv.fr" }
+  end
+
+  factory :datapass_webhook_contact_model, class: Hash do
+    initialize_with { attributes.stringify_keys }
+
+    id { 'random' }
+    phone_number { '0256743256' }
+
+    after(:build) do |contact_model|
+      contact_model['family_name'] = "#{contact_model['id']} last name"
+      contact_model['given_name'] = "#{contact_model['id']} first name"
+      contact_model['email'] = "#{contact_model['id']}#{rand(9001)}@service.gouv.fr"
+    end
+  end
+
+  factory :datapass_webhook_event_model, class: Hash do
+    initialize_with { attributes.stringify_keys }
+
+    sequence(:id) { |n| "#{n}" }
+    name { 'notify' }
+    comment { 'comment' }
+    created_at { rand(1..9001).seconds.ago.to_datetime.strftime("%Y-%m-%d %H:%M:%S UTC") }
+    user do
+      {
+        'family_name' => 'Instructor last name',
+        'given_name' => 'Instructor first name',
+        'email' => 'instructor@service.gouv.fr',
+      }
+    end
+  end
+end

--- a/spec/factories/jwt_api_entreprises.rb
+++ b/spec/factories/jwt_api_entreprises.rb
@@ -1,81 +1,96 @@
 FactoryBot.define do
   factory :jwt_api_entreprise do
     subject { 'Humm testy' }
-    sequence(:authorization_request_id) { |n| "1234#{n}" }
     iat { Time.zone.now.to_i }
     exp { 18.months.from_now.to_i }
     archived { false }
     version { '1.0' }
     days_left_notification_sent { [] }
-    user
-  end
 
-  factory :token_without_roles, class: JwtApiEntreprise do
-    subject { 'Humm no roles' }
-    user
-  end
+    sequence(:authorization_request_id) { |n| "1234#{n}" }
 
-  trait :access_request_survey_not_sent do
-    access_request_survey_sent { false }
-  end
-
-  trait :access_request_survey_sent do
-    access_request_survey_sent { true }
-  end
-
-  trait :less_than_seven_days_ago do
-    created_at { Faker::Time.backward(days: 6) }
-  end
-
-  trait :seven_days_ago do
-    created_at { 7.days.ago }
-  end
-
-  trait :expiring_within_3_month do
-    exp { Faker::Time.forward(days: 88) }
-  end
-
-  trait :expiring_in_1_year do
-    exp { 1.year.from_now }
-  end
-
-  trait :not_blacklisted do
-    blacklisted { false }
-  end
-
-  trait :blacklisted do
-    blacklisted { true }
-
-    after(:create) do |jwt|
-      create(:contact, :business, jwt_api_entreprise: jwt)
-      create(:contact, :tech, jwt_api_entreprise: jwt)
+    transient do
+      user { nil }
     end
-  end
 
-  trait :archived do
-    archived { true }
+    after(:build) do |jwt_api_entreprise, evaluator|
+      if jwt_api_entreprise.authorization_request_id && jwt_api_entreprise.authorization_request.nil?
+        jwt_api_entreprise.authorization_request = build(:authorization_request, jwt_api_entreprise: jwt_api_entreprise)
+      elsif jwt_api_entreprise.authorization_request_id
+        jwt_api_entreprise.authorization_request.external_id = jwt_api_entreprise.authorization_request_id
+      end
 
-    after(:create) do |jwt|
-      create(:contact, :business, jwt_api_entreprise: jwt)
-      create(:contact, :tech, jwt_api_entreprise: jwt)
+      if evaluator.user
+        jwt_api_entreprise.authorization_request.user = evaluator.user
+      end
     end
-  end
 
-  trait :with_contacts do
-    after(:create) do |jwt|
-      create(:contact, :business, jwt_api_entreprise: jwt)
-      create(:contact, :business, jwt_api_entreprise: jwt)
-      create(:contact, :tech, jwt_api_entreprise: jwt)
-      create(:contact, :other, jwt_api_entreprise: jwt)
+    trait :without_authorization_request_id do
+      authorization_request_id { nil }
     end
-  end
 
-  trait :expired do
-    exp { Faker::Time.between(from: 20.months.ago, to:19.months.ago).to_i }
-  end
+    trait :access_request_survey_not_sent do
+      access_request_survey_sent { false }
+    end
 
-  trait :with_magic_link do
-    magic_link_token { 'mUchmaGicWOW' }
-    magic_link_issuance_date { Time.zone.now }
+    trait :access_request_survey_sent do
+      access_request_survey_sent { true }
+    end
+
+    trait :less_than_seven_days_ago do
+      created_at { Faker::Time.backward(days: 6) }
+    end
+
+    trait :seven_days_ago do
+      created_at { 7.days.ago }
+    end
+
+    trait :expiring_within_3_month do
+      exp { Faker::Time.forward(days: 88) }
+    end
+
+    trait :expiring_in_1_year do
+      exp { 1.year.from_now }
+    end
+
+    trait :not_blacklisted do
+      blacklisted { false }
+    end
+
+    trait :blacklisted do
+      blacklisted { true }
+
+      after(:create) do |jwt|
+        create(:contact, :business, authorization_request: jwt.authorization_request)
+        create(:contact, :tech, authorization_request: jwt.authorization_request)
+      end
+    end
+
+    trait :archived do
+      archived { true }
+
+      after(:create) do |jwt|
+        create(:contact, :business, authorization_request: jwt.authorization_request)
+        create(:contact, :tech, authorization_request: jwt.authorization_request)
+      end
+    end
+
+    trait :with_contacts do
+      after(:create) do |jwt|
+        create(:contact, :business, authorization_request: jwt.authorization_request)
+        create(:contact, :business, authorization_request: jwt.authorization_request)
+        create(:contact, :tech, authorization_request: jwt.authorization_request)
+        create(:contact, :other, authorization_request: jwt.authorization_request)
+      end
+    end
+
+    trait :expired do
+      exp { Faker::Time.between(from: 20.months.ago, to:19.months.ago).to_i }
+    end
+
+    trait :with_magic_link do
+      magic_link_token { 'mUchmaGicWOW' }
+      magic_link_issuance_date { Time.zone.now }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,6 +9,11 @@ FactoryBot.define do
     password { 'Coucou123' }
     tokens_newly_transfered { false }
 
+    trait :with_full_name do
+      first_name { 'Jean-Marie' }
+      last_name { 'Gigot' }
+    end
+
     trait :admin do
       admin { true }
       password { AuthenticationHelper::ADMIN_PWD }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
+  sequence(:email) { |n| "user_#{n}@example.org" }
+
   factory :user do
-    sequence(:email) { |n| "user_#{n}@example.org" }
+    email
     sequence(:oauth_api_gouv_id) { |n| "#{n}" }
     context { 'VERY_DEVELOPMENT' }
     cgu_agreement_date { Time.zone.now }

--- a/spec/interactors/datapass_webhook/create_jwt_token_spec.rb
+++ b/spec/interactors/datapass_webhook/create_jwt_token_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatapassWebhook::CreateJwtToken, type: :interactor do
+  subject { described_class.call(datapass_webhook_params.merge(authorization_request: authorization_request)) }
+
+  let(:authorization_request) { create(:authorization_request) }
+  let(:datapass_webhook_params) { build(:datapass_webhook, event: event) }
+  let(:roles) { build(:datapass_webhook_pass_model)['scopes'].keys }
+
+  before do
+    Timecop.freeze
+
+    roles.each do |role|
+      create(:role, code: role)
+    end
+  end
+
+  after do
+    Timecop.return
+  end
+
+  context 'when event is not validate_application' do
+    let(:event) { 'whatever' }
+
+    it { is_expected.to be_a_success }
+
+    it 'does not create a new jwt token' do
+      expect {
+        subject
+      }.not_to change { JwtApiEntreprise.count }
+    end
+  end
+
+  context 'when event is validate_application' do
+    let(:event) { 'validate_application' }
+
+    it { is_expected.to be_a_success }
+
+    it { expect(subject.token_id).to be_present }
+
+    it 'creates a new jwt token with valid attributes and roles' do
+      expect {
+        subject
+      }.to change { JwtApiEntreprise.count }
+
+      token = JwtApiEntreprise.last
+
+      expect(token.authorization_request).to eq(authorization_request)
+      expect(token.exp).to eq(18.month.from_now.to_i)
+      expect(token.iat).to eq(Time.zone.now.to_i)
+
+      expect(token.roles.pluck(:code).sort).to eq(%w[associations entreprises])
+    end
+  end
+end

--- a/spec/interactors/datapass_webhook/extract_mailjet_variables_spec.rb
+++ b/spec/interactors/datapass_webhook/extract_mailjet_variables_spec.rb
@@ -56,13 +56,11 @@ RSpec.describe DatapassWebhook::ExtractMailjetVariables, type: :interactor do
     end
 
     it 'sets token_roles with these values, excluding uptime' do
-      expect(subject.mailjet_variables['token_roles']).to be_present
+      expect(subject.mailjet_variables['token_role_uptime']).to be_nil
+      expect(subject.mailjet_variables['token_role_entreprise']).to eq 'true'
+      expect(subject.mailjet_variables['token_role_liasse_fiscale']).to eq 'true'
 
-      expect(subject.mailjet_variables['token_roles']['role_uptime']).to be_nil
-      expect(subject.mailjet_variables['token_roles']['role_entreprise']).to eq true
-      expect(subject.mailjet_variables['token_roles']['role_liasse_fiscale']).to eq true
-
-      expect(subject.mailjet_variables['token_roles']['role_etablissement']).to eq false
+      expect(subject.mailjet_variables['token_role_etablissement']).to eq 'false'
     end
   end
 end

--- a/spec/interactors/datapass_webhook/extract_mailjet_variables_spec.rb
+++ b/spec/interactors/datapass_webhook/extract_mailjet_variables_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe DatapassWebhook::ExtractMailjetVariables, type: :interactor do
     expect(subject.mailjet_variables['authorization_request_intitule']).to eq(authorization_request.intitule)
     expect(subject.mailjet_variables['authorization_request_description']).to eq(authorization_request.description)
 
+    expect(subject.mailjet_variables['demandeur_first_name']).to eq(authorization_request.user.first_name)
+    expect(subject.mailjet_variables['demandeur_last_name']).to eq(authorization_request.user.last_name)
+    expect(subject.mailjet_variables['demandeur_email']).to eq(authorization_request.user.email)
+
     expect(subject.mailjet_variables['token_roles']).to be_nil
   end
 
@@ -61,6 +65,21 @@ RSpec.describe DatapassWebhook::ExtractMailjetVariables, type: :interactor do
       expect(subject.mailjet_variables['token_role_liasse_fiscale']).to eq 'true'
 
       expect(subject.mailjet_variables['token_role_etablissement']).to eq 'false'
+    end
+  end
+
+  context 'when authorization request has contacts' do
+    let(:authorization_request) { create(:authorization_request, :with_contacts) }
+
+    it 'adds contact metier and technique first, last name and email' do
+      %w[
+        technique
+        metier
+      ].each do |contact_kind|
+        expect(subject.mailjet_variables["contact_#{contact_kind}_first_name"]).to be_present
+        expect(subject.mailjet_variables["contact_#{contact_kind}_last_name"]).to be_present
+        expect(subject.mailjet_variables["contact_#{contact_kind}_email"]).to be_present
+      end
     end
   end
 end

--- a/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interac
       }.to change { authorization_request.reload.intitule }.to(datapass_webhook_params['data']['pass']['intitule'])
 
       expect(authorization_request.last_update.to_i).to eq(fired_at)
+      expect(authorization_request.status).to eq('sent')
     end
 
     it 'updates contacts associated to authorization request' do

--- a/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interactor do
+  subject { described_class.call(datapass_webhook_params.merge(user: user)) }
+
+  let(:datapass_webhook_params) { build(:datapass_webhook, fired_at: fired_at, authorization_request_attributes: { id: authorization_id }) }
+  let(:user) { create(:user) }
+  let(:authorization_id) { rand(1..9001) }
+  let(:fired_at) { 2.minutes.ago.to_i }
+
+  context 'when authorization request already exists' do
+    let!(:authorization_request) { create(:authorization_request, :with_contacts, external_id: authorization_id) }
+
+    it { is_expected.to be_a_success }
+    it { expect(subject.authorization_request).to eq(authorization_request) }
+
+    it 'updates attributes on existing authorization request' do
+      expect {
+        subject
+      }.to change { authorization_request.reload.intitule }.to(datapass_webhook_params['data']['pass']['intitule'])
+
+      expect(authorization_request.last_update.to_i).to eq(fired_at)
+    end
+
+    it 'updates contacts associated to authorization request' do
+      expect(authorization_request.contact_metier.full_name).not_to eq("metier last name metier first name")
+      expect(authorization_request.contact_technique.full_name).not_to eq("technique last name technique first name")
+
+      expect(authorization_request.contact_technique.email).not_to match(/technique\d+@/)
+      expect(authorization_request.contact_metier.email).not_to match(/metier\d+@/)
+
+      expect {
+        subject
+      }.not_to change { authorization_request.reload.contacts.count }
+
+      expect(authorization_request.contact_technique.email).to match(/technique\d+@/)
+      expect(authorization_request.contact_metier.email).to match(/metier\d+@/)
+
+      expect(authorization_request.contact_metier.full_name).to eq("metier last name metier first name")
+      expect(authorization_request.contact_technique.full_name).to eq("technique last name technique first name")
+    end
+
+    context 'when it is the same user' do
+      let!(:authorization_request) { create(:authorization_request, external_id: authorization_id, user: user) }
+
+      it 'does not update user' do
+        expect {
+          subject
+        }.not_to change { authorization_request.reload.user }
+      end
+    end
+
+    context 'when it is not the same user' do
+      let!(:authorization_request) { create(:authorization_request, external_id: authorization_id) }
+
+      it 'updates user' do
+        expect {
+          subject
+        }.to change { authorization_request.reload.user }.to(user)
+      end
+    end
+  end
+
+  context 'when authorization request does not exist' do
+    it { is_expected.to be_a_success }
+    it { expect(subject.authorization_request).to an_instance_of(AuthorizationRequest) }
+
+    it 'creates a new authorization request with attributes, contacts and linked to user' do
+      expect {
+        subject
+      }.to change { user.reload.authorization_requests.count }.by(1)
+
+      authorization_request = user.authorization_requests.last
+
+      expect(authorization_request.intitule).to eq(datapass_webhook_params['data']['pass']['intitule'])
+      expect(authorization_request.contacts.count).to eq(2)
+      expect(authorization_request.contact_technique.email).to match(/technique\d+@/)
+      expect(authorization_request.contact_metier.email).to match(/metier\d+@/)
+    end
+  end
+
+  context 'when event is send_application' do
+    let(:datapass_webhook_params) { build(:datapass_webhook, event: 'send_application', fired_at: fired_at, authorization_request_attributes: { id: authorization_id }) }
+
+    let!(:authorization_request) { create(:authorization_request, :with_contacts, external_id: authorization_id, first_submitted_at: first_submitted_at) }
+
+    context 'when first_submitted_at is nil' do
+      let(:first_submitted_at) { nil }
+
+      it 'updates it' do
+        expect {
+          subject
+        }.to change { authorization_request.reload.first_submitted_at.to_i }.to(fired_at)
+      end
+    end
+
+    context 'when first_submitted_at is present' do
+      let(:first_submitted_at) { 3.days.ago }
+
+      it 'does not update it' do
+        expect {
+          subject
+        }.not_to change { authorization_request.reload.first_submitted_at.to_i }
+      end
+    end
+  end
+
+  context 'when event is validate_application' do
+    let(:datapass_webhook_params) { build(:datapass_webhook, event: 'validate_application', fired_at: fired_at, authorization_request_attributes: { id: authorization_id }) }
+
+    let!(:authorization_request) { create(:authorization_request, :with_contacts, external_id: authorization_id) }
+
+    it 'sets validated_at' do
+      expect {
+        subject
+      }.to change { authorization_request.reload.validated_at.to_i }.to(fired_at)
+    end
+  end
+end

--- a/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interac
     end
 
     it 'updates contacts associated to authorization request' do
-      expect(authorization_request.contact_metier.full_name).not_to eq("METIER LAST NAME metier first name")
-      expect(authorization_request.contact_technique.full_name).not_to eq("TECHNIQUE LAST NAME technique first name")
+      expect(authorization_request.contact_metier.full_name).not_to eq("CONTACT_METIER LAST NAME contact_metier first name")
+      expect(authorization_request.contact_technique.full_name).not_to eq("RESPONSABLE_TECHNIQUE LAST NAME responsable_technique first name")
 
       expect(authorization_request.contact_technique.email).not_to match(/technique\d+@/)
       expect(authorization_request.contact_metier.email).not_to match(/metier\d+@/)
@@ -39,8 +39,8 @@ RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interac
       expect(authorization_request.contact_technique.email).to match(/technique\d+@/)
       expect(authorization_request.contact_metier.email).to match(/metier\d+@/)
 
-      expect(authorization_request.contact_metier.full_name).to eq("METIER LAST NAME metier first name")
-      expect(authorization_request.contact_technique.full_name).to eq("TECHNIQUE LAST NAME technique first name")
+      expect(authorization_request.contact_metier.full_name).to eq("CONTACT_METIER LAST NAME contact_metier first name")
+      expect(authorization_request.contact_technique.full_name).to eq("RESPONSABLE_TECHNIQUE LAST NAME responsable_technique first name")
     end
 
     context 'when it is the same user' do

--- a/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interac
     end
 
     it 'updates contacts associated to authorization request' do
-      expect(authorization_request.contact_metier.full_name).not_to eq("metier last name metier first name")
-      expect(authorization_request.contact_technique.full_name).not_to eq("technique last name technique first name")
+      expect(authorization_request.contact_metier.full_name).not_to eq("METIER LAST NAME metier first name")
+      expect(authorization_request.contact_technique.full_name).not_to eq("TECHNIQUE LAST NAME technique first name")
 
       expect(authorization_request.contact_technique.email).not_to match(/technique\d+@/)
       expect(authorization_request.contact_metier.email).not_to match(/metier\d+@/)
@@ -38,8 +38,8 @@ RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interac
       expect(authorization_request.contact_technique.email).to match(/technique\d+@/)
       expect(authorization_request.contact_metier.email).to match(/metier\d+@/)
 
-      expect(authorization_request.contact_metier.full_name).to eq("metier last name metier first name")
-      expect(authorization_request.contact_technique.full_name).to eq("technique last name technique first name")
+      expect(authorization_request.contact_metier.full_name).to eq("METIER LAST NAME metier first name")
+      expect(authorization_request.contact_technique.full_name).to eq("TECHNIQUE LAST NAME technique first name")
     end
 
     context 'when it is the same user' do

--- a/spec/interactors/datapass_webhook/find_or_create_user_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_user_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatapassWebhook::FindOrCreateUser, type: :interactor do
+  describe '.call' do
+    subject { described_class.call(datapass_webhook_params) }
+
+    let(:datapass_webhook_params) { build(:datapass_webhook, user_attributes: user_attributes) }
+    let(:user_attributes) do
+      {
+        email: generate(:email),
+      }
+    end
+
+    context 'when there is no user with the same email' do
+      it { is_expected.to be_a_success }
+      it { expect(subject.user).to an_instance_of(User) }
+
+      it 'creates a new user with valid attributes' do
+        expect {
+          subject
+        }.to change { User.count }.by(1)
+
+        user = User.last
+        expect(user.oauth_api_gouv_id).to eq(datapass_webhook_params['data']['pass']['user']['uid'])
+        expect(user.first_name).to eq('John')
+        expect(user.last_name).to eq('Doe')
+      end
+    end
+
+    context 'when there is already a user with the same email' do
+      let!(:user) { create(:user, email: user_attributes[:email]) }
+
+      it { is_expected.to be_a_success }
+      it { expect(subject.user).to eq(user) }
+
+      it 'does not create a new user' do
+        expect {
+          subject
+        }.not_to change { User.count }
+      end
+
+      it 'updates existing user with attributes' do
+        expect {
+          subject
+        }.to change { user.reload.first_name }.to('John')
+      end
+    end
+  end
+end

--- a/spec/interactors/datapass_webhook/find_or_create_user_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_user_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe DatapassWebhook::FindOrCreateUser, type: :interactor do
   describe '.call' do
     subject { described_class.call(datapass_webhook_params) }
 
-    let(:datapass_webhook_params) { build(:datapass_webhook, user_attributes: user_attributes) }
-    let(:user_attributes) do
+    let(:datapass_webhook_params) { build(:datapass_webhook, demandeur_attributes: demandeur_attributes) }
+    let(:demandeur_attributes) do
       {
         email: generate(:email),
       }
@@ -23,14 +23,14 @@ RSpec.describe DatapassWebhook::FindOrCreateUser, type: :interactor do
         }.to change { User.count }.by(1)
 
         user = User.last
-        expect(user.oauth_api_gouv_id).to eq(datapass_webhook_params['data']['pass']['user']['uid'])
-        expect(user.first_name).to eq('John')
-        expect(user.last_name).to eq('Doe')
+        expect(user.oauth_api_gouv_id).to be_present
+        expect(user.first_name).to eq('demandeur first name')
+        expect(user.last_name).to eq('demandeur last name')
       end
     end
 
     context 'when there is already a user with the same email' do
-      let!(:user) { create(:user, email: user_attributes[:email]) }
+      let!(:user) { create(:user, email: demandeur_attributes[:email]) }
 
       it { is_expected.to be_a_success }
       it { expect(subject.user).to eq(user) }
@@ -44,7 +44,7 @@ RSpec.describe DatapassWebhook::FindOrCreateUser, type: :interactor do
       it 'updates existing user with attributes' do
         expect {
           subject
-        }.to change { user.reload.first_name }.to('John')
+        }.to change { user.reload.first_name }.to('demandeur first name')
       end
     end
   end

--- a/spec/interactors/datapass_webhook/schedule_authorization_request_emails_spec.rb
+++ b/spec/interactors/datapass_webhook/schedule_authorization_request_emails_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatapassWebhook::ScheduleAuthorizationRequestEmails, type: :interactor do
+  include ActiveJob::TestHelper
+
+  subject do
+    described_class.call(
+      datapass_webhook_params.merge(
+        authorization_request: authorization_request,
+        mailjet_variables: mailjet_variables,
+      )
+    )
+  end
+
+  let(:datapass_webhook_params) { build(:datapass_webhook, event: event) }
+  let(:authorization_request) { create(:authorization_request, :with_contacts) }
+  let(:mailjet_variables) { { lol: 'oki' } }
+
+  before do
+    Timecop.freeze
+  end
+
+  after do
+    Timecop.return
+
+    clear_enqueued_jobs
+  end
+
+  describe 'with an event which does not trigger email' do
+    let(:event) { 'created' }
+
+    it 'does not call schedule emails' do
+      subject
+
+      expect(ScheduleAuthorizationRequestMailjetEmailJob).not_to have_been_enqueued
+    end
+  end
+
+  context 'with an event which trigger emails, no conditions, a when key and no attributes on recipients' do
+    let(:event) { 'send_application' }
+
+    it 'schedules emails according to configuration, to authorization request\'s user' do
+      subject
+
+      expect(ScheduleAuthorizationRequestMailjetEmailJob).to have_been_enqueued.exactly(:twice)
+
+      expect(ScheduleAuthorizationRequestMailjetEmailJob).to have_been_enqueued.exactly(:once).with(
+        authorization_request.id,
+        authorization_request.status,
+        hash_including(
+          template_id: '11',
+          to: [
+            {
+              'email' => authorization_request.user.email,
+              'full_name' => authorization_request.user.full_name,
+            },
+          ],
+        )
+      ).at(Time.now)
+
+      expect(ScheduleAuthorizationRequestMailjetEmailJob).to have_been_enqueued.exactly(:once).with(
+        authorization_request.id,
+        authorization_request.status,
+        hash_including(
+          template_id: '12',
+          to: [
+            {
+              'email' => authorization_request.user.email,
+              'full_name' => authorization_request.user.full_name,
+            },
+          ],
+        )
+      ).at(14.days.from_now)
+    end
+  end
+
+  context 'with an event which trigger emails, conditions and recipients attributes' do
+    let(:event) { 'validate_application' }
+
+    context 'when all conditions are met' do
+      before do
+        authorization_request.user.update!(
+          first_name: 'run',
+          last_name: 'run',
+        )
+      end
+
+      it 'schedules emails according to configuration, with valid recipients attributes' do
+        subject
+
+        expect(ScheduleAuthorizationRequestMailjetEmailJob).to have_been_enqueued.exactly(:twice)
+
+        expect(ScheduleAuthorizationRequestMailjetEmailJob).to have_been_enqueued.exactly(:once).with(
+          authorization_request.id,
+          authorization_request.status,
+          hash_including(
+            template_id: '51',
+            to: [
+              {
+                'email' => authorization_request.user.email,
+                'full_name' => authorization_request.user.full_name,
+              },
+            ],
+          )
+        ).at(Time.now)
+
+        expect(ScheduleAuthorizationRequestMailjetEmailJob).to have_been_enqueued.exactly(:once).with(
+          authorization_request.id,
+          authorization_request.status,
+          hash_including(
+            template_id: '52',
+            to: [
+              {
+                'email' => authorization_request.contact_metier.email,
+                'full_name' => authorization_request.contact_metier.full_name,
+              },
+            ],
+            cc: [
+              {
+                'email' => authorization_request.contact_technique.email,
+                'full_name' => authorization_request.contact_technique.full_name,
+              },
+              {
+                'email' => authorization_request.user.email,
+                'full_name' => authorization_request.user.full_name,
+              },
+            ],
+          )
+        ).at(Time.now)
+      end
+    end
+
+    describe 'when one condition is not met' do
+      before do
+        authorization_request.user.update!(
+          first_name: 'run',
+          last_name: 'not run',
+        )
+      end
+
+      it 'schedules only the valid condition' do
+        subject
+
+        expect(ScheduleAuthorizationRequestMailjetEmailJob).to have_been_enqueued.exactly(:once)
+
+        expect(ScheduleAuthorizationRequestMailjetEmailJob).to have_been_enqueued.exactly(:once).with(
+          authorization_request.id,
+          authorization_request.status,
+          hash_including(
+            template_id: '51',
+            to: [
+              {
+                'email' => authorization_request.user.email,
+                'full_name' => authorization_request.user.full_name,
+              },
+            ],
+          )
+        ).at(Time.now)
+      end
+    end
+  end
+end

--- a/spec/interactors/datapass_webhook/schedule_authorization_request_emails_spec.rb
+++ b/spec/interactors/datapass_webhook/schedule_authorization_request_emails_spec.rb
@@ -77,7 +77,22 @@ RSpec.describe DatapassWebhook::ScheduleAuthorizationRequestEmails, type: :inter
   end
 
   context 'with an event which trigger emails, conditions and recipients attributes' do
-    let(:event) { 'validate_application' }
+    let(:event) { 'refuse_application' }
+
+    before do
+      AuthorizationRequestConditionFacade.define_method(:user_first_name_is_run?) do
+        user.first_name == 'run'
+      end
+
+      AuthorizationRequestConditionFacade.define_method(:user_last_name_is_run?) do
+        user.last_name == 'run'
+      end
+    end
+
+    after do
+      AuthorizationRequestConditionFacade.remove_method(:user_first_name_is_run?)
+      AuthorizationRequestConditionFacade.remove_method(:user_last_name_is_run?)
+    end
 
     context 'when all conditions are met' do
       before do

--- a/spec/interactors/datapass_webhook/update_mailjet_contacts_spec.rb
+++ b/spec/interactors/datapass_webhook/update_mailjet_contacts_spec.rb
@@ -1,0 +1,239 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatapassWebhook::UpdateMailjetContacts, type: :interactor do
+  subject { described_class.call(authorization_request: authorization_request) }
+
+  let(:authorization_request) { create(:authorization_request, user: user) }
+  let(:user) { create(:user, :with_full_name) }
+
+  it { is_expected.to be_a_success }
+
+  before do
+    allow(Mailjet::Contactslist_managemanycontacts).to receive(:create)
+  end
+
+  describe 'without contacts on authorization request' do
+    it 'updates mailjet authorization request user with first and last name' do
+      expect(Mailjet::Contactslist_managemanycontacts).to receive(:create).with(
+        id: anything,
+        action: 'addnoforce',
+        contacts: [
+          {
+            email: user.email,
+            properties: {
+              'prénom' => user.first_name,
+              'nom' => user.last_name,
+              'contact_demandeur' => true,
+              'contact_métier' => false,
+              'contact_technique' => false,
+            }
+          }
+        ]
+      )
+
+      subject
+    end
+  end
+
+  describe 'with contacts without attributes' do
+    before do
+      create(:contact, email: nil, first_name: nil, last_name: nil, contact_type: 'metier', authorization_request: authorization_request)
+    end
+
+    it 'updates mailjet authorization request user with first and last name, but not the contact' do
+      expect(Mailjet::Contactslist_managemanycontacts).to receive(:create).with(
+        id: anything,
+        action: 'addnoforce',
+        contacts: [
+          {
+            email: user.email,
+            properties: {
+              'prénom' => user.first_name,
+              'nom' => user.last_name,
+              'contact_demandeur' => true,
+              'contact_métier' => false,
+              'contact_technique' => false,
+            }
+          }
+        ]
+      )
+
+      subject
+    end
+  end
+
+  context 'with valid contacts' do
+    let(:authorization_request) { create(:authorization_request, :with_contacts, user: user) }
+
+    it 'updates authorization with all contacts' do
+      expect(Mailjet::Contactslist_managemanycontacts).to receive(:create).with(
+        id: anything,
+        action: 'addnoforce',
+        contacts: [
+          {
+            email: user.email,
+            properties: hash_including(
+              'contact_demandeur' => true,
+              'contact_métier' => false,
+              'contact_technique' => false,
+            ),
+          },
+          {
+            email: authorization_request.contact_metier.email,
+            properties: hash_including(
+              'contact_demandeur' => false,
+              'contact_métier' => true,
+              'contact_technique' => false,
+            ),
+          },
+          {
+            email: authorization_request.contact_technique.email,
+            properties: hash_including(
+              'contact_demandeur' => false,
+              'contact_métier' => false,
+              'contact_technique' => true,
+            ),
+          },
+        ]
+      )
+
+      subject
+    end
+
+    context 'when contact technique is the same as user' do
+      before do
+        user.update!(
+          email: authorization_request.contact_technique.email,
+        )
+      end
+
+      it 'updates accordingly' do
+        expect(Mailjet::Contactslist_managemanycontacts).to receive(:create).with(
+          id: anything,
+          action: 'addnoforce',
+          contacts: [
+            {
+              email: user.email,
+              properties: hash_including(
+                'contact_demandeur' => true,
+                'contact_métier' => false,
+                'contact_technique' => true,
+              ),
+            },
+            {
+              email: authorization_request.contact_metier.email,
+              properties: hash_including(
+                'contact_demandeur' => false,
+                'contact_métier' => true,
+                'contact_technique' => false,
+              ),
+            },
+          ]
+        )
+
+        subject
+      end
+    end
+
+    context 'when contact metier is the same as user' do
+      before do
+        user.update!(
+          email: authorization_request.contact_metier.email,
+        )
+      end
+
+      it 'updates accordingly' do
+        expect(Mailjet::Contactslist_managemanycontacts).to receive(:create).with(
+          id: anything,
+          action: 'addnoforce',
+          contacts: [
+            {
+              email: user.email,
+              properties: hash_including(
+                'contact_demandeur' => true,
+                'contact_métier' => true,
+                'contact_technique' => false,
+              ),
+            },
+            {
+              email: authorization_request.contact_technique.email,
+              properties: hash_including(
+                'contact_demandeur' => false,
+                'contact_métier' => false,
+                'contact_technique' => true,
+              ),
+            },
+          ]
+        )
+
+        subject
+      end
+    end
+
+    context 'when all contacts emails are the same' do
+      before do
+        authorization_request.contacts.update_all(
+          email: user.email,
+        )
+      end
+
+      it 'updates accordingly' do
+        expect(Mailjet::Contactslist_managemanycontacts).to receive(:create).with(
+          id: anything,
+          action: 'addnoforce',
+          contacts: [
+            {
+              email: user.email,
+              properties: hash_including(
+                'contact_demandeur' => true,
+                'contact_métier' => true,
+                'contact_technique' => true,
+              ),
+            },
+          ]
+        )
+
+        subject
+      end
+    end
+
+    context 'when contact metier and contact technique are the same' do
+      let(:another_email) { generate(:email) }
+
+      before do
+        authorization_request.contacts.update_all(
+          email: another_email,
+        )
+      end
+
+      it 'updates accordingly' do
+        expect(Mailjet::Contactslist_managemanycontacts).to receive(:create).with(
+          id: anything,
+          action: 'addnoforce',
+          contacts: [
+            {
+              email: user.email,
+              properties: hash_including(
+                'contact_demandeur' => true,
+                'contact_métier' => false,
+                'contact_technique' => false,
+              ),
+            },
+            {
+              email: another_email,
+              properties: hash_including(
+                'contact_demandeur' => false,
+                'contact_métier' => true,
+                'contact_technique' => true,
+              ),
+            },
+          ]
+        )
+
+        subject
+      end
+    end
+  end
+end

--- a/spec/jobs/schedule_authorization_request_mailjet_email_job_spec.rb
+++ b/spec/jobs/schedule_authorization_request_mailjet_email_job_spec.rb
@@ -59,28 +59,22 @@ RSpec.describe ScheduleAuthorizationRequestMailjetEmailJob, type: :job do
     context 'when current authorization request status did not changed' do
       it 'calls Mailjet client with valid params' do
         expect(Mailjet::Send).to receive(:create).with(
-          messages: [
-            {
-              'From' => anything,
-              'To' => [
-                {
-                  'Email' => to_user.email,
-                  'Name' => to_user.full_name,
-                },
-              ],
-              'Variables' => mailjet_template_vars,
-              'TemplateLanguage' => true,
-              'TemplateID' => mailjet_template_id,
-            }
-          ]
+          {
+            from_name: anything,
+            from_email: anything,
+            to: "#{to_user.full_name} <#{to_user.email}>",
+            vars: mailjet_template_vars,
+            'Mj-TemplateLanguage' => true,
+            'Mj-TemplateID' => mailjet_template_id,
+          }
         )
 
         subject
       end
 
       context 'when there is cc field in mailjet attributes' do
-        let(:cc_contact1) { create(:contact) }
-        let(:cc_contact2) { create(:contact) }
+        let(:cc_contact1) { create(:contact, :with_full_name) }
+        let(:cc_contact2) { create(:contact, :with_full_name) }
 
         before do
           mailjet_attributes[:cc] = [
@@ -97,30 +91,13 @@ RSpec.describe ScheduleAuthorizationRequestMailjetEmailJob, type: :job do
 
         it 'calls Mailjet client with the CC field for these users' do
           expect(Mailjet::Send).to receive(:create).with(
-            messages: [
-              {
-                'From' => anything,
-                'To' => [
-                  {
-                    'Email' => to_user.email,
-                    'Name' => to_user.full_name,
-                  },
-                ],
-                'Cc' => [
-                  {
-                    'Email' => cc_contact1.email,
-                    'Name' => cc_contact1.full_name,
-                  },
-                  {
-                    'Email' => cc_contact2.email,
-                    'Name' => cc_contact2.full_name,
-                  },
-                ],
-                'Variables' => mailjet_template_vars,
-                'TemplateLanguage' => true,
-                'TemplateID' => mailjet_template_id,
-              }
-            ]
+            from_name: anything,
+            from_email: anything,
+            to: "#{to_user.full_name} <#{to_user.email}>",
+            cc: "#{cc_contact1.full_name} <#{cc_contact1.email}>, #{cc_contact2.full_name} <#{cc_contact2.email}>",
+            vars: mailjet_template_vars,
+            'Mj-TemplateLanguage' => true,
+            'Mj-TemplateID' => mailjet_template_id,
           )
 
           subject

--- a/spec/jobs/schedule_authorization_request_mailjet_email_job_spec.rb
+++ b/spec/jobs/schedule_authorization_request_mailjet_email_job_spec.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ScheduleAuthorizationRequestMailjetEmailJob, type: :job do
+  describe '#perform' do
+    subject do
+      described_class.perform_now(
+        authorization_request_id,
+        authorization_request_status,
+        mailjet_attributes,
+      )
+    end
+
+    let(:authorization_request_id) { authorization_request.id }
+    let(:authorization_request_status) { 'created' }
+    let(:mailjet_attributes) do
+      {
+        template_id: mailjet_template_id,
+        vars: mailjet_template_vars,
+        to: [
+          {
+            email: to_user.email,
+            full_name: to_user.full_name,
+          },
+        ],
+      }
+    end
+
+    let(:authorization_request) { create(:authorization_request, status: authorization_request_status) }
+    let(:to_user) { create(:user, :with_full_name) }
+    let(:mailjet_template_id) { '1234567890' }
+    let(:mailjet_template_vars) { {} }
+
+    context 'when authorization request does not exist' do
+      let(:authorization_request_id) { 'invalid' }
+
+      it 'does nothing' do
+        expect(Mailjet::Send).not_to receive(:create)
+
+        subject
+      end
+    end
+
+    context 'when current authorization request status is different from authorization_request_status' do
+      before do
+        authorization_request.update!(
+          status: 'validated',
+        )
+      end
+
+      it 'does nothing' do
+        expect(Mailjet::Send).not_to receive(:create)
+
+        subject
+      end
+    end
+
+    context 'when current authorization request status did not changed' do
+      it 'calls Mailjet client with valid params' do
+        expect(Mailjet::Send).to receive(:create).with(
+          messages: [
+            {
+              'From' => anything,
+              'To' => [
+                {
+                  'Email' => to_user.email,
+                  'Name' => to_user.full_name,
+                },
+              ],
+              'Variables' => mailjet_template_vars,
+              'TemplateLanguage' => true,
+              'TemplateID' => mailjet_template_id,
+            }
+          ]
+        )
+
+        subject
+      end
+
+      context 'when there is cc field in mailjet attributes' do
+        let(:cc_contact1) { create(:contact) }
+        let(:cc_contact2) { create(:contact) }
+
+        before do
+          mailjet_attributes[:cc] = [
+            {
+              email: cc_contact1.email,
+              full_name: cc_contact1.full_name,
+            },
+            {
+              email: cc_contact2.email,
+              full_name: cc_contact2.full_name,
+            }
+          ]
+        end
+
+        it 'calls Mailjet client with the CC field for these users' do
+          expect(Mailjet::Send).to receive(:create).with(
+            messages: [
+              {
+                'From' => anything,
+                'To' => [
+                  {
+                    'Email' => to_user.email,
+                    'Name' => to_user.full_name,
+                  },
+                ],
+                'Cc' => [
+                  {
+                    'Email' => cc_contact1.email,
+                    'Name' => cc_contact1.full_name,
+                  },
+                  {
+                    'Email' => cc_contact2.email,
+                    'Name' => cc_contact2.full_name,
+                  },
+                ],
+                'Variables' => mailjet_template_vars,
+                'TemplateLanguage' => true,
+                'TemplateID' => mailjet_template_id,
+              }
+            ]
+          )
+
+          subject
+        end
+      end
+
+      context 'when Mailjet raises an error' do
+        let(:mailjet_error) do
+          Mailjet::ApiError.new(
+            code,
+            body,
+            nil,
+            'https://api.mailjet.com/v3/send',
+            params,
+          )
+        end
+        let(:code) { 418 }
+        let(:body) { "I'm a teapot!" }
+        let(:params) do
+          {
+            oki: 'lol',
+          }
+        end
+
+        before do
+          allow(Mailjet::Send).to receive(:create).and_raise(mailjet_error)
+          allow(Sentry).to receive(:capture_exception)
+        end
+
+        it 'tracks error through Sentry, with context' do
+          expect(Sentry).to receive(:set_context).with(
+            'mailjet error',
+            hash_including(
+              {
+                mailjet_error_code: code,
+                mailjet_error_reason: body,
+              }
+            )
+          ).and_call_original
+          expect(Sentry).to receive(:capture_exception)
+
+          begin
+            subject
+          rescue Mailjet::ApiError
+          end
+        end
+
+        it 'raises this error (which reschedule job exponentialy)' do
+          expect {
+            subject
+          }.to raise_error(Mailjet::ApiError)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/datapass_webhook_spec.rb
+++ b/spec/lib/datapass_webhook_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatapassWebhook, type: :interactor do
+  subject { described_class.call(datapass_webhook_params) }
+
+  let(:datapass_webhook_params) { build(:datapass_webhook, event: 'validate_application') }
+
+  before do
+    allow(Mailjet::Contactslist_managemanycontacts).to receive(:create)
+  end
+
+  it { is_expected.to be_a_success }
+
+  it 'creates a user' do
+    expect {
+      subject
+    }.to change { User.count }.by(1)
+  end
+
+  it 'creates an authorization request' do
+    expect {
+      subject
+    }.to change { AuthorizationRequest.count }.by(1)
+  end
+
+  it 'creates token and stores id in token_id' do
+    expect {
+      subject
+    }.to change { JwtApiEntreprise.count }.by(1)
+
+    token = JwtApiEntreprise.last
+
+    expect(subject.token_id).to eq(token.id)
+  end
+end

--- a/spec/mailers/jwt_api_entreprise_mailer_spec.rb
+++ b/spec/mailers/jwt_api_entreprise_mailer_spec.rb
@@ -67,10 +67,8 @@ RSpec.describe JwtApiEntrepriseMailer, type: :mailer do
       end
 
       it 'contains the URL to the JWT\'s renewal request form' do
-        renewal_url = "#{Rails.configuration.jwt_renewal_url}#{jwt.authorization_request_id}"
-
-        expect(subject.html_part.decoded).to include(renewal_url)
-        expect(subject.text_part.decoded).to include(renewal_url)
+        expect(subject.html_part.decoded).to include(jwt.renewal_url)
+        expect(subject.text_part.decoded).to include(jwt.renewal_url)
       end
     end
 

--- a/spec/models/authorization_request_spec.rb
+++ b/spec/models/authorization_request_spec.rb
@@ -4,4 +4,15 @@ RSpec.describe AuthorizationRequest, type: :model do
   it 'has valid factory' do
     expect(build(:authorization_request)).to be_valid
   end
+
+  describe 'contacts associations' do
+    let(:authorization_request) { create(:authorization_request, :with_contacts) }
+
+    it 'works' do
+      expect(authorization_request.contacts.count).to eq(2)
+
+      expect(authorization_request.contact_technique).to be_present
+      expect(authorization_request.contact_metier).to be_present
+    end
+  end
 end

--- a/spec/models/authorization_request_spec.rb
+++ b/spec/models/authorization_request_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe AuthorizationRequest, type: :model do
+  it 'has valid factory' do
+    expect(build(:authorization_request)).to be_valid
+  end
+end

--- a/spec/models/contact_spec.rb
+++ b/spec/models/contact_spec.rb
@@ -1,6 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe Contact do
+  it 'has valid factories' do
+    expect(build(:contact)).to be_valid
+  end
+
+  describe '.not_expired scope' do
+    subject { Contact.not_expired }
+
+    let!(:valid_contact) { create(:contact, jwt_api_entreprise: create(:jwt_api_entreprise, blacklisted: false, archived: false))}
+    let!(:invalid_contact) { create(:contact, jwt_api_entreprise: create(:jwt_api_entreprise, blacklisted: false, archived: true))}
+
+    it 'works' do
+      expect(subject.count).to eq(1)
+      expect(subject).to include(valid_contact)
+    end
+  end
+
   describe 'db columns' do
     it { is_expected.to have_db_column(:id).of_type(:uuid) }
     it { is_expected.to have_db_column(:email).of_type(:string) }
@@ -15,6 +31,6 @@ RSpec.describe Contact do
   end
 
   describe 'relationships' do
-    it { is_expected.to belong_to(:jwt_api_entreprise) }
+    it { is_expected.to have_one(:jwt_api_entreprise) }
   end
 end

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -1,6 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe JwtApiEntreprise, type: :model do
+  it 'has valid factories' do
+    expect(build(:jwt_api_entreprise)).to be_valid
+  end
+
   let(:jwt) { create(:jwt_api_entreprise) }
 
   describe 'db_columns' do
@@ -32,8 +36,8 @@ RSpec.describe JwtApiEntreprise, type: :model do
   end
 
   describe 'relationships' do
-    it { is_expected.to belong_to(:user) }
-    it { is_expected.to have_many(:contacts).dependent(:delete_all) }
+    it { is_expected.to have_one(:user) }
+    it { is_expected.to have_many(:contacts) }
     it { is_expected.to have_and_belong_to_many(:roles) }
   end
 
@@ -200,11 +204,18 @@ RSpec.describe JwtApiEntreprise, type: :model do
   end
 
   describe '#renewal_url' do
-    it 'returns the Signup\'s form URL' do
-      j = create(:jwt_api_entreprise, subject: 'coucou subject', authorization_request_id: '42')
-      url = Rails.configuration.jwt_renewal_url + '42'
+    let(:external_id) { generate(:external_authorization_request_id) }
 
-      expect(j.renewal_url).to eq(url)
+    before do
+      jwt.authorization_request.update!(
+        external_id: external_id,
+      )
+    end
+
+    it 'returns the Signup\'s form URL' do
+      url = Rails.configuration.jwt_renewal_url + external_id
+
+      expect(jwt.renewal_url).to eq(url)
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe User do
   end
 
   describe 'relationships' do
-    it { is_expected.to have_many(:jwt_api_entreprise).dependent(:nullify) }
+    it { is_expected.to have_many(:jwt_api_entreprise) }
     it { is_expected.to have_many(:roles).through(:jwt_api_entreprise) }
-    it { is_expected.to have_many(:contacts).through(:jwt_api_entreprise) }
+    it { is_expected.to have_many(:contacts) }
   end
 
   describe '.added_since_yesterday' do


### PR DESCRIPTION
D-D-D-D-DONE

* [x] Organizer
* [x] Gestion des vars mailjets
* [x] Création des contacts sur l'authorization request
* En intégration sur l'autre PR | Vérifier que les payloads datapass sont bonnes
* Non pas besoin | NOT SURE à vérifier | Ajout du subject dans les configs emails
* [x] Finaliser la création du jeton + `token_id` sur un validated
* [x] ScheduleAuthorizationRequestEmails: Gérer le récipient dans les vars (vu qu'on peut envoyer à plusieurs cibles, autre que user)
* [x] UpdateMailjetContact -> gérer TOUS les contacts + les booléens sur les propriétés
* [x] Rename UpdateMailjetContact -> handle tous les contacts
* [x] ScheduleAuthorizationRequestEmails: Harden tests sur le scheduling des emails
* [x] ScheduleAuthorizationRequestEmails: Gestion des conditions d'envoi (notamment pour les validations)
* [x] `last_update` / `first_submitted_at` / `validated_at` => prendre la bonne date (depuis `fired_at`)
* [x] Model: Ajout d'un `first_submitted_at` et `validated_at` pour les stats
* [x] Documentation
* [x] Rename ScheduleTransactionalMailjetEmailJob pour intégrer la notion d'authorization request (trop générique là)
* [x] Vérifier la payload de la factory webhook https://sentry.data.gouv.fr/organizations/sentry/issues/13115/events/a6053504d4bd45e3a11e38ae27bdba68/?project=15&query=is%3Aunresolved
* [x] Test e2e sur l'organizer
* [x] Review
* [x] Flip le `SafeEval` et mettre une façade (cf https://github.com/etalab/admin_api_entreprise/pull/141#issuecomment-905541362 )
* [x] Remettre les tests de relations sur les modèles
* [x] Wrap les `context.fail!` pour tracker les erreurs dans Sentry
* [x] Renvoyer un 422 en cas de fail de l'organizer
* [x] `Rails.configuration.emails_sender_address`
* [x] `JwtApiEntreprise#renewal_url` => code dégueu why ?
* Point du dessous implémenté, ce qui répond à la problématique | NOT SURE | Gestion des duplicata cf https://github.com/etalab/admin_api_entreprise/pull/141/files#r695814989
* [x] Lié au point du dessus -> Mettre une contrainte d'unicité sur `jwt_api_entreprise#authorization_request_model_id`
* Overkill | ExtractMailjetVariables: bien prendre le dernier event de l'instructeur (i.e. les filtrer)
* [x] Migrer en Mailjet v3 ou v3.1 (à voir avec la branche `features/mailjet-v3.1`)
* [x] Finaliser la config pour la prod (à voir au retour de Dorine)
* [x] Tacler la problématique du `full_name` (à voir au retour de Dorine)
* [x] Faire une repasse sur la migration (tester manuellement que ça fonctionne bien)

Related https://github.com/betagouv/signup-back/pull/264

Pour gérer les emails transac notamment, mais on va aussi refactoriser la validation là dedans.