### PR TITLE
Archivage des vieux jetons

### DIFF
--- a/app/interactors/datapass_webhook/archive_previous_token.rb
+++ b/app/interactors/datapass_webhook/archive_previous_token.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class DatapassWebhook::ArchivePreviousToken < ApplicationInteractor
+  def call
+    return if context.event != 'validate_application'
+    return if context.authorization_request.previous_external_id.blank?
+    return if previous_token.blank?
+
+    previous_token.update(
+      archived: true,
+    )
+  end
+
+  private
+
+  def previous_token
+    @previous_token ||= begin
+      previous_authorization_request = AuthorizationRequest.find_by(external_id: context.authorization_request.previous_external_id)
+
+      previous_authorization_request.try(:jwt_api_entreprise)
+    end
+  end
+end

--- a/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
+++ b/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
@@ -39,6 +39,7 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
       'status',
     ).merge(authorization_request_attributes_for_current_event).merge(
       'last_update' => fired_at_as_datetime,
+      'previous_external_id' => context.data['pass']['copied_from_enrollment_id'],
     )
   end
 

--- a/app/lib/datapass_webhook.rb
+++ b/app/lib/datapass_webhook.rb
@@ -4,6 +4,7 @@ class DatapassWebhook
   organize ::DatapassWebhook::FindOrCreateUser,
            ::DatapassWebhook::FindOrCreateAuthorizationRequest,
            ::DatapassWebhook::CreateJwtToken,
+           ::DatapassWebhook::ArchivePreviousToken,
            ::DatapassWebhook::UpdateMailjetContacts,
            ::DatapassWebhook::ExtractMailjetVariables,
            ::DatapassWebhook::ScheduleAuthorizationRequestEmails

--- a/db/migrate/20210914083037_add_previous_external_id_to_authorization_requests.rb
+++ b/db/migrate/20210914083037_add_previous_external_id_to_authorization_requests.rb
@@ -1,0 +1,5 @@
+class AddPreviousExternalIdToAuthorizationRequests < ActiveRecord::Migration[6.1]
+  def change
+    add_column :authorization_requests, :previous_external_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_30_072250) do
+ActiveRecord::Schema.define(version: 2021_09_14_083037) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2021_08_30_072250) do
     t.datetime "validated_at"
     t.datetime "created_at"
     t.uuid "user_id", null: false
+    t.string "previous_external_id"
     t.index ["external_id"], name: "index_authorization_requests_on_external_id", unique: true, where: "(external_id IS NOT NULL)"
   end
 

--- a/spec/factories/datapass_webhooks.rb
+++ b/spec/factories/datapass_webhooks.rb
@@ -38,6 +38,7 @@ FactoryBot.define do
     intitule { 'intitule from webhook' }
     description { 'description from webhook' }
     status { 'sent' }
+    copied_from_enrollment_id { nil }
 
     events { build_list(:datapass_webhook_event_model, 2) }
 

--- a/spec/interactors/datapass_webhook/archive_previous_token_spec.rb
+++ b/spec/interactors/datapass_webhook/archive_previous_token_spec.rb
@@ -1,0 +1,54 @@
+require 'rails_helper'
+
+RSpec.describe DatapassWebhook::ArchivePreviousToken, type: :interactor do
+  subject { described_class.call(datapass_webhook_params.merge(authorization_request: authorization_request)) }
+
+  let(:authorization_request) { create(:authorization_request, previous_external_id: previous_external_id) }
+  let(:datapass_webhook_params) { build(:datapass_webhook, event: event) }
+
+  let(:jwt_api_entreprise) { create(:jwt_api_entreprise) }
+
+  before do
+    if previous_external_id
+      create(:authorization_request, jwt_api_entreprise: jwt_api_entreprise, external_id: previous_external_id)
+    end
+  end
+
+  context 'when event is validate_application' do
+    let(:event) { 'validate_application' }
+
+    context 'when authorization request has a previous external id' do
+      let(:previous_external_id) { rand(9001).to_s }
+
+      it 'archives previous token' do
+        expect {
+          subject
+        }.to change { jwt_api_entreprise.reload.archived }.to(true)
+      end
+    end
+
+    context 'when authorization request has no previous external id' do
+      let(:previous_external_id) { nil }
+
+      it 'does nothing' do
+        expect {
+          subject
+        }.not_to change { JwtApiEntreprise.where(archived: true).count }
+      end
+    end
+  end
+
+  context 'when event is not validate_application' do
+    let(:event) { 'sent' }
+
+    context 'when authorization request has a previous external id' do
+      let(:previous_external_id) { rand(9001).to_s }
+
+      it 'does nothing' do
+        expect {
+          subject
+        }.not_to change { JwtApiEntreprise.where(archived: true).count }
+      end
+    end
+  end
+end

--- a/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
@@ -5,9 +5,10 @@ require 'rails_helper'
 RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interactor do
   subject { described_class.call(datapass_webhook_params.merge(user: user)) }
 
-  let(:datapass_webhook_params) { build(:datapass_webhook, fired_at: fired_at, authorization_request_attributes: { id: authorization_id }) }
+  let(:datapass_webhook_params) { build(:datapass_webhook, fired_at: fired_at, authorization_request_attributes: { id: authorization_id, copied_from_enrollment_id: previous_authorization_id }) }
   let(:user) { create(:user) }
-  let(:authorization_id) { rand(1..9001) }
+  let(:authorization_id) { rand(1..4000).to_s }
+  let(:previous_authorization_id) { rand(4001..9001).to_s }
   let(:fired_at) { 2.minutes.ago.to_i }
 
   context 'when authorization request already exists' do
@@ -76,6 +77,7 @@ RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interac
       authorization_request = user.authorization_requests.last
 
       expect(authorization_request.intitule).to eq(datapass_webhook_params['data']['pass']['intitule'])
+      expect(authorization_request.previous_external_id).to eq(datapass_webhook_params['data']['pass']['copied_from_enrollment_id'])
       expect(authorization_request.contacts.count).to eq(2)
       expect(authorization_request.contact_technique.email).to match(/technique\d+@/)
       expect(authorization_request.contact_metier.email).to match(/metier\d+@/)

--- a/spec/lib/datapass_webhook_spec.rb
+++ b/spec/lib/datapass_webhook_spec.rb
@@ -5,10 +5,14 @@ require 'rails_helper'
 RSpec.describe DatapassWebhook, type: :interactor do
   subject { described_class.call(datapass_webhook_params) }
 
-  let(:datapass_webhook_params) { build(:datapass_webhook, event: 'validate_application') }
+  let(:datapass_webhook_params) { build(:datapass_webhook, event: 'validate_application', authorization_request_attributes: { copied_from_enrollment_id: previous_enrollment_id }) }
+  let(:previous_enrollment_id) { rand(9001).to_s }
+  let(:jwt_api_entreprise) { create(:jwt_api_entreprise) }
 
   before do
     allow(Mailjet::Contactslist_managemanycontacts).to receive(:create)
+
+    create(:authorization_request, external_id: previous_enrollment_id, jwt_api_entreprise: jwt_api_entreprise)
   end
 
   it { is_expected.to be_a_success }
@@ -33,5 +37,11 @@ RSpec.describe DatapassWebhook, type: :interactor do
     token = JwtApiEntreprise.last
 
     expect(subject.token_id).to eq(token.id)
+  end
+
+  it 'archives previous token' do
+    expect {
+      subject
+    }.to change { jwt_api_entreprise.reload.archived }.to(true)
   end
 end


### PR DESCRIPTION
Morceau qui a été oublié de l'ancien comportement avant l'introduction des webhooks. 

Lorsqu'un événement est une validation et que la demande d'autorisation est une copie d'une ancienne demande validé, on archive le jeton associé à cette ancienne demande.