### PR TITLE
Aliases ApiGouv with APIGouv

### DIFF
--- a/app/lib/omni_auth/strategies/api_gouv.rb
+++ b/app/lib/omni_auth/strategies/api_gouv.rb
@@ -1,5 +1,5 @@
 module OmniAuth::Strategies
-  class ApiGouv < OmniAuth::Strategies::OAuth2
+  class APIGouv < OmniAuth::Strategies::OAuth2
     option :name, :api_gouv
 
     option :client_options, {
@@ -25,3 +25,5 @@ module OmniAuth::Strategies
     end
   end
 end
+
+OmniAuth::Strategies::ApiGouv = OmniAuth::Strategies::APIGouv


### PR DESCRIPTION
Try to fix 2 issues here:

1. Zeitwerk loading, which tries to infer from inflections APIGouv (in production)
2. OmniAuth provider config, which tries to infer from `:api_gouv`
   ApiGouv (in dev/test)