### PR TITLE
Liens vers les formulaires de demandes d'accès et de renouvellement de jetons 

### DIFF
--- a/app/helpers/friendly_date_helper.rb
+++ b/app/helpers/friendly_date_helper.rb
@@ -1,0 +1,5 @@
+module FriendlyDateHelper
+  def friendly_format_from_timestamp(timestamp)
+    "#{Time.zone.at(timestamp).strftime('%d/%m/%Y à %Hh%M')} (heure de Paris)"
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,6 @@
 class ApplicationMailer < ActionMailer::Base
   default from: Rails.configuration.emails_sender_address
   layout 'mailer'
+
+  helper :friendly_date
 end

--- a/app/models/jwt_api_entreprise.rb
+++ b/app/models/jwt_api_entreprise.rb
@@ -23,10 +23,6 @@ class JwtAPIEntreprise < ApplicationRecord
     self.roles.pluck(:code)
   end
 
-  def user_friendly_exp_date
-    "#{Time.zone.at(exp).strftime('%d/%m/%Y à %Hh%M')} (heure de Paris)"
-  end
-
   def renewal_url
     "#{Rails.configuration.jwt_renewal_url}#{authorization_request.external_id}"
   end

--- a/app/models/jwt_api_entreprise.rb
+++ b/app/models/jwt_api_entreprise.rb
@@ -27,6 +27,10 @@ class JwtAPIEntreprise < ApplicationRecord
     "#{Rails.configuration.jwt_renewal_url}#{authorization_request.external_id}"
   end
 
+  def authorization_request_url
+    "#{Rails.configuration.jwt_authorization_request_url}#{authorization_request.external_id}"
+  end
+
   def user_and_contacts_email
     Set[*contacts.pluck(:email)] << user.email
   end

--- a/app/views/jwt_api_entreprise/_jwt_api_entreprise.html.erb
+++ b/app/views/jwt_api_entreprise/_jwt_api_entreprise.html.erb
@@ -17,6 +17,6 @@
   <%= button_to 'Transmettre le jeton à mon equipe technique', '#', id: 'magic_link_button' %>
   <%= button_to 'Renouveler ou étendre mes droits', jwt_api_entreprise.renewal_url, id: 'renew_access_button' %>
 
-  <%= link_to 'Aller à la demande DataPass', '#' %>
+  <%= link_to 'Aller à la demande DataPass', jwt_api_entreprise.authorization_request_url, id: :authorization_request_link %>
   <%= link_to 'Voir les statistiques', '#' %>
 </div>

--- a/app/views/jwt_api_entreprise/_jwt_api_entreprise.html.erb
+++ b/app/views/jwt_api_entreprise/_jwt_api_entreprise.html.erb
@@ -15,7 +15,7 @@
   <p><%= jwt_api_entreprise.rehash %></p>
 
   <%= button_to 'Transmettre le jeton à mon equipe technique', '#', id: 'magic_link_button' %>
-  <%= button_to 'Renouveler ou étendre mes droits', '#', id: 'renew_access_button' %>
+  <%= button_to 'Renouveler ou étendre mes droits', jwt_api_entreprise.renewal_url, id: 'renew_access_button' %>
 
   <%= link_to 'Aller à la demande DataPass', '#' %>
   <%= link_to 'Voir les statistiques', '#' %>

--- a/app/views/jwt_api_entreprise/_jwt_api_entreprise.html.erb
+++ b/app/views/jwt_api_entreprise/_jwt_api_entreprise.html.erb
@@ -1,8 +1,8 @@
 <div class="jwt_api_entreprise_tile" id="<%= dom_id(jwt_api_entreprise) %>">
   <h4>Cadre d'utilisation : <%= jwt_api_entreprise.displayed_subject %></h4>
 
-  <p>Délivré le : <%= jwt_api_entreprise.iat %></p>
-  <p>Expire le : <%= jwt_api_entreprise.user_friendly_exp_date %></p>
+  <p>Délivré le : <%= friendly_format_from_timestamp(jwt_api_entreprise.iat) %></p>
+  <p>Expire le : <%= friendly_format_from_timestamp(jwt_api_entreprise.exp) %></p>
 
   <h5>Accès</h5>
   <ul>

--- a/app/views/jwt_api_entreprise_mailer/expiration_notice.html.erb
+++ b/app/views/jwt_api_entreprise_mailer/expiration_notice.html.erb
@@ -10,7 +10,7 @@
 
     <p>En effet, le jeton attribué dans le cadre d'utilisation "<%= @jwt.subject %>" (id : <%= @jwt.id %>) ne sera bientôt plus valide !
 
-    <p><strong>Passée la date du <%= @jwt.user_friendly_exp_date %> les appels à API Entreprise avec ce jeton seront rejetés.</strong></p>
+    <p><strong>Passée la date du <%= friendly_format_from_timestamp(@jwt.exp) %> les appels à API Entreprise avec ce jeton seront rejetés.</strong></p>
 
     <p>Le lien <%= link_to("suivant", @jwt.renewal_url) %> vous permet de demander le renouvellement de votre jeton. Le formulaire a été pré-rempli avec les données fournies lors de votre précédente demande d'accès, veuillez cependant vérifier que les informations sont à jour (notamment les coordonnées de contact) et les re-saisir dans le cas contraire. De plus, de nouvelles sources de données auxquelles vous auriez accès sont potentiellement disponibles depuis votre dernière demande !</p>
 

--- a/app/views/jwt_api_entreprise_mailer/expiration_notice.text.erb
+++ b/app/views/jwt_api_entreprise_mailer/expiration_notice.text.erb
@@ -4,7 +4,7 @@ Un de vos jetons d'accès à API Entreprise expire dans moins de <%= @nb_days %>
 
 En effet, le jeton attribué dans le cadre d'utilisation "<%= @jwt.subject %>" (id : <%= @jwt.id %>) ne sera bientôt plus valide !
 
-Passée la date du <%= @jwt.user_friendly_exp_date %> les appels à API Entreprise avec ce jeton seront rejetés.
+Passée la date du <%= friendly_format_from_timestamp(@jwt.exp) %> les appels à API Entreprise avec ce jeton seront rejetés.
 
 Le lien <%= @jwt.renewal_url %> vous permet de demander le renouvellement de votre jeton. Le formulaire a été pré-rempli avec les données fournies lors de votre précédente demande d'accès, veuillez cependant vérifier que les informations sont à jour (notamment les coordonnées de contact) et les re-saisir dans le cas contraire. De plus, de nouvelles sources de données auxquelles vous auriez accès sont potentiellement disponibles depuis votre dernière demande !
 

--- a/app/views/jwt_api_entreprise_mailer/expiration_notice_old.html.erb
+++ b/app/views/jwt_api_entreprise_mailer/expiration_notice_old.html.erb
@@ -10,7 +10,7 @@
 
     <p>En effet, le jeton attribué dans le cadre d'utilisation "<%= @jwt.subject %>" (id : <%= @jwt.id %>) ne sera bientôt plus valide !
 
-    <p><strong>Passée la date du <%= @jwt.user_friendly_exp_date %> les appels à API Entreprise avec ce jeton seront rejetés.</strong></p>
+    <p><strong>Passée la date du <%= friendly_format_from_timestamp(@jwt.exp) %> les appels à API Entreprise avec ce jeton seront rejetés.</strong></p>
 
 
     <p>Pour obtenir un nouveau jeton il vous faut faire une nouvelle demande d'accès comme décrit ici : https://entreprise.api.gouv.fr/doc/#renouvellement-token</p>

--- a/app/views/jwt_api_entreprise_mailer/expiration_notice_old.text.erb
+++ b/app/views/jwt_api_entreprise_mailer/expiration_notice_old.text.erb
@@ -4,7 +4,7 @@ Un de vos jetons d'accès à API Entreprise expire dans moins de <%= @nb_days %>
 
 En effet, le jeton attribué dans le cadre d'utilisation "<%= @jwt.subject %>" (id : <%= @jwt.id %>) ne sera bientôt plus valide !
 
-Passée la date du <%= @jwt.user_friendly_exp_date %> les appels à API Entreprise avec ce jeton seront rejetés.
+Passée la date du <%= friendly_format_from_timestamp(@jwt.exp) %> les appels à API Entreprise avec ce jeton seront rejetés.
 
 Pour obtenir un nouveau jeton il vous faut faire une nouvelle demande d'accès comme décrit ici : https://entreprise.api.gouv.fr/doc/#renouvellement-token
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -74,7 +74,7 @@ Rails.application.configure do
   # config.action_cable.disable_request_forgery_protection = true
 
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/me/tokens/'
-  config.jwt_renewal_url  = 'https://signup-staging.api.gouv.fr/copy-authorization-request/'
+  config.jwt_renewal_url  = 'https://datapass-staging.api.gouv.fr/copy-authorization-request/'
   config.jwt_magic_link_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/magic_link'
 
   config.redis_database = 'redis://localhost:6379/0'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -75,6 +75,7 @@ Rails.application.configure do
 
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/me/tokens/'
   config.jwt_renewal_url  = 'https://datapass-staging.api.gouv.fr/copy-authorization-request/'
+  config.jwt_authorization_request_url  = 'https://datapass-staging.api.gouv.fr/api-entreprise/'
   config.jwt_magic_link_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/magic_link'
 
   config.redis_database = 'redis://localhost:6379/0'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,6 +64,7 @@ Rails.application.configure do
 
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/me/tokens/'
   config.jwt_renewal_url  = 'https://datapass-staging.api.gouv.fr/copy-authorization-request/'
+  config.jwt_authorization_request_url  = 'https://datapass-staging.api.gouv.fr/api-entreprise/'
   config.jwt_magic_link_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/magic_link'
 
   config.redis_database = 'redis://localhost:6379/0'

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
   config.middleware.use RackSessionAccess::Middleware
 
   config.account_tokens_list_url  = 'https://sandbox.dashboard.entreprise.api.gouv.fr/me/tokens/'
-  config.jwt_renewal_url  = 'https://signup-staging.api.gouv.fr/copy-authorization-request/'
+  config.jwt_renewal_url  = 'https://datapass-staging.api.gouv.fr/copy-authorization-request/'
   config.jwt_magic_link_url = 'https://sandbox.dashboard.entreprise.api.gouv.fr/magic_link'
 
   config.redis_database = 'redis://localhost:6379/0'

--- a/spec/helpers/feature_helper.rb
+++ b/spec/helpers/feature_helper.rb
@@ -1,4 +1,4 @@
-module FeatureHelpers
+module FeatureHelper
   def login_as(user)
     page.set_rack_session(current_user_id: user.id)
   end

--- a/spec/mailers/jwt_api_entreprise_mailer_spec.rb
+++ b/spec/mailers/jwt_api_entreprise_mailer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe JwtAPIEntrepriseMailer, type: :mailer do
       end
 
       it 'contains the exact expiration time of the JWT' do
-        expiration_datetime = jwt.user_friendly_exp_date
+        expiration_datetime = friendly_format_from_timestamp(jwt.exp)
         tested_corpus = "Passée la date du #{expiration_datetime} les appels à API Entreprise avec ce jeton seront rejetés."
 
         expect(subject.html_part.decoded).to include(tested_corpus)

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe JwtAPIEntreprise, type: :model do
     end
   end
 
-  describe '#renewal_url' do
+  describe 'external URLs to DataPass' do
     let(:external_id) { generate(:external_authorization_request_id) }
 
     before do
@@ -201,10 +201,20 @@ RSpec.describe JwtAPIEntreprise, type: :model do
       )
     end
 
-    it 'returns the Signup\'s form URL' do
-      url = Rails.configuration.jwt_renewal_url + external_id
+    describe '#renewal_url' do
+      it 'returns the DataPass\' renewal form URL' do
+        url = Rails.configuration.jwt_renewal_url + external_id
 
-      expect(jwt.renewal_url).to eq(url)
+        expect(jwt.renewal_url).to eq(url)
+      end
+    end
+
+    describe '#authorization_request_url' do
+      it 'returns the DataPass\' authorization request URL' do
+        url = Rails.configuration.jwt_authorization_request_url + external_id
+
+        expect(jwt.authorization_request_url).to eq(url)
+      end
     end
   end
 

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -125,17 +125,6 @@ RSpec.describe JwtAPIEntreprise, type: :model do
     end
   end
 
-  describe '#user_friendly_exp_date' do
-    it 'returns a friendly formated date' do
-      # About the offset here, during winter (March 17th here)
-      # it is UTC+01:00 so this is a valid datetime in Paris
-      datetime = DateTime.new(1998, 3, 17, 15, 28, 49, '+1')
-      jwt.exp = datetime.to_i
-
-      expect(jwt.user_friendly_exp_date).to eq('17/03/1998 à 15h28 (heure de Paris)')
-    end
-  end
-
   describe '.unexpired' do
     subject { described_class.unexpired }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -61,6 +61,8 @@ RSpec.configure do |config|
   # Include factory_bot methods into test suite
   config.include FactoryBot::Syntax::Methods
 
+  config.include FriendlyDateHelper
+
   # Include helpers / support accurately for each spec type
   config.include AuthenticationHelper, type: :controller
   config.include JWTHelper, type: :jwt

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,7 +67,7 @@ RSpec.configure do |config|
   config.include JWTHelper, type: :model
   config.include JWTHelper, type: :request
   config.include ResponseHelper, type: :controller
-  config.include FeatureHelpers, type: :feature
+  config.include FeatureHelper, type: :feature
 
   # Include fixtures tokens to test OAuth API Gouv interaction
   config.include OAuthAPIGouv

--- a/spec/views/jwt_api_entreprise/_jwt_api_entreprise_spec.rb
+++ b/spec/views/jwt_api_entreprise/_jwt_api_entreprise_spec.rb
@@ -14,4 +14,5 @@ RSpec.describe 'jwt_api_entreprise/_jwt_api_entreprise.html.erb' do
   it { is_expected.to include(*token.roles.pluck(:code)) }
   it { is_expected.to include(token.rehash) }
   it { is_expected.to include(token.renewal_url) }
+  it { is_expected.to include(token.authorization_request_url) }
 end

--- a/spec/views/jwt_api_entreprise/_jwt_api_entreprise_spec.rb
+++ b/spec/views/jwt_api_entreprise/_jwt_api_entreprise_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'jwt_api_entreprise/_jwt_api_entreprise.html.erb' do
+  let(:token) { create(:jwt_api_entreprise) }
+
+  subject do
+    render partial: 'jwt_api_entreprise', object: token
+    rendered
+  end
+
+  it { is_expected.to include(token.displayed_subject) }
+  it { is_expected.to include(friendly_format_from_timestamp(token.iat)) }
+  it { is_expected.to include(friendly_format_from_timestamp(token.exp)) }
+  it { is_expected.to include(*token.roles.pluck(:code)) }
+  it { is_expected.to include(token.rehash) }
+  it { is_expected.to include(token.renewal_url) }
+end


### PR DESCRIPTION
### Contenu de la PR 
* Ajout du lien vers le formulaire de demande d'accès DataPass d'un jeton 
* Ajout du lien vers le formulaire de renouvellement pré-rempli d'un jeton
* Specs des vues des jetons
* Déplacement de la logique de formatage des dates (friendly format) hors du modèle => dans un helper Rails