### PR TITLE
Try to fix 500 errors from Mailjet

### DIFF
--- a/app/jobs/concerns/mailjet_helpers.rb
+++ b/app/jobs/concerns/mailjet_helpers.rb
@@ -1,7 +1,7 @@
 module MailjetHelpers
   def deliver_mailjet_email(message)
     Mailjet::Send.create(
-      message,
+      sanitize_message_payload(message),
     )
   end
 
@@ -17,5 +17,23 @@ module MailjetHelpers
       mailjet_error_code: mailjet_exception.code,
       mailjet_error_reason: mailjet_exception.reason,
     }
+  end
+
+  private
+
+  def sanitize_message_payload(message)
+    message.stringify_keys!
+
+    message['vars'] = replace_nil_values_with_empty_string(message['vars'])
+
+    message
+  end
+
+  def replace_nil_values_with_empty_string(vars)
+    return if vars.nil?
+
+    vars.transform_values do |value|
+      value.nil? ? '' : value
+    end
   end
 end

--- a/spec/jobs/schedule_authorization_request_mailjet_email_job_spec.rb
+++ b/spec/jobs/schedule_authorization_request_mailjet_email_job_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe ScheduleAuthorizationRequestMailjetEmailJob, type: :job do
             vars: mailjet_template_vars,
             'Mj-TemplateLanguage' => true,
             'Mj-TemplateID' => mailjet_template_id,
-          }
+          }.stringify_keys
         )
 
         subject
@@ -91,13 +91,15 @@ RSpec.describe ScheduleAuthorizationRequestMailjetEmailJob, type: :job do
 
         it 'calls Mailjet client with the CC field for these users' do
           expect(Mailjet::Send).to receive(:create).with(
-            from_name: anything,
-            from_email: anything,
-            to: "#{to_user.full_name} <#{to_user.email}>",
-            cc: "#{cc_contact1.full_name} <#{cc_contact1.email}>, #{cc_contact2.full_name} <#{cc_contact2.email}>",
-            vars: mailjet_template_vars,
-            'Mj-TemplateLanguage' => true,
-            'Mj-TemplateID' => mailjet_template_id,
+            {
+              from_name: anything,
+              from_email: anything,
+              to: "#{to_user.full_name} <#{to_user.email}>",
+              cc: "#{cc_contact1.full_name} <#{cc_contact1.email}>, #{cc_contact2.full_name} <#{cc_contact2.email}>",
+              vars: mailjet_template_vars,
+              'Mj-TemplateLanguage' => true,
+              'Mj-TemplateID' => mailjet_template_id,
+            }.stringify_keys
           )
 
           subject

--- a/spec/jobs/schedule_expiration_notice_mailjet_email_job_spec.rb
+++ b/spec/jobs/schedule_expiration_notice_mailjet_email_job_spec.rb
@@ -34,6 +34,14 @@ RSpec.describe ScheduleExpirationNoticeMailjetEmailJob, type: :job do
     end
 
     context 'when token is found and expires_in is valid' do
+      let(:external_id) { '9001' }
+
+      before do
+        token.authorization_request.update!(
+          external_id: external_id,
+        )
+      end
+
       it 'calls Mailjet client with valid params' do
         expect(Mailjet::Send).to receive(:create).with(
           {
@@ -42,7 +50,7 @@ RSpec.describe ScheduleExpirationNoticeMailjetEmailJob, type: :job do
             to: "#{token.user.full_name} <#{token.user.email}>",
             vars: {
               cadre_utilisation_token: token.subject,
-              authorization_request_id: token.authorization_request.external_id,
+              authorization_request_id: external_id,
               expiration_date: "#{Time.zone.at(token.exp).strftime('%d/%m/%Y à %Hh%M')} (heure de Paris)"
             },
             'Mj-TemplateLanguage' => true,


### PR DESCRIPTION
Thanks to multiple errors raised from Sentry, I think the issue is to
have null values for some vars. This PR changes null values to empty
string ( '' ). It has the same behaviour for Mailjet.

Ref https://github.com/etalab/admin_api_entreprise/issues/192