### PR TITLE
Features/uniq emails

### DIFF
--- a/app/concepts/oauth_api_gouv/tasks/retrieve_user_info.rb
+++ b/app/concepts/oauth_api_gouv/tasks/retrieve_user_info.rb
@@ -27,7 +27,7 @@ module OAuthAPIGouv::Tasks
 
     def find_related_user(ctx, raw_response:, **)
       ctx[:user_info] = JSON.parse(raw_response.body, symbolize_names: true)
-      ctx[:user] = User.find_by(email: ctx[:user_info][:email])
+      ctx[:user] = User.insensitive_find_by_email(ctx[:user_info][:email])
     end
 
     def log_error(ctx, raw_response:, **)

--- a/app/concepts/user/operation/transfer_ownership.rb
+++ b/app/concepts/user/operation/transfer_ownership.rb
@@ -15,7 +15,7 @@ module User::Operation
 
 
     def find_new_owner(ctx, params:, **)
-      ctx[:new_owner] = User.find_by_email(params[:email])
+      ctx[:new_owner] = User.insensitive_find_by_email(params[:email])
     end
 
     def transfer_tokens(ctx, model:, new_owner:, **)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,7 @@ class SessionsController < ApplicationController
   end
 
   def create
-    if user = User.find_by(email: authenticated_user_email)
+    if user = User.insensitive_find_by_email(authenticated_user_email)
       sign_in_and_redirect(user)
     else
       error_message(title: t('.not_found.title'), description: t('.not_found.description'))

--- a/app/interactors/datapass_webhook/find_or_create_user.rb
+++ b/app/interactors/datapass_webhook/find_or_create_user.rb
@@ -1,6 +1,6 @@
 class DatapassWebhook::FindOrCreateUser < ApplicationInteractor
   def call
-    context.user = User.find_or_initialize_by(email: user_attributes['email'])
+    context.user = User.find_or_initialize_by(email: user_attributes['email'].downcase)
     context.user.assign_attributes(user_attributes_to_assign)
 
     return if context.user.save

--- a/app/interactors/datapass_webhook/find_or_create_user.rb
+++ b/app/interactors/datapass_webhook/find_or_create_user.rb
@@ -1,6 +1,6 @@
 class DatapassWebhook::FindOrCreateUser < ApplicationInteractor
   def call
-    context.user = User.find_or_initialize_by(email: user_attributes['email'].downcase)
+    context.user = User.find_or_initialize_by_email(user_attributes['email'])
     context.user.assign_attributes(user_attributes_to_assign)
 
     return if context.user.save

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,11 +6,17 @@ class User < ApplicationRecord
   has_many :contacts, through: :authorization_requests
   has_many :roles, through: :jwt_api_entreprise
 
-  validates :email, uniqueness: true
+  validates :email, uniqueness: { case_sensitive: false }
 
   scope :added_since_yesterday, -> { where('created_at > ?', 1.day.ago) }
 
-  before_save { email.downcase! }
+  def self.find_or_initialize_by_email(email)
+    insensitive_find_by_email(email) || new(email: email)
+  end
+
+  def self.insensitive_find_by_email(email)
+    where('email ilike (?)', email).limit(1).first
+  end
 
   def confirmed?
     !!oauth_api_gouv_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,6 +8,8 @@ class User < ApplicationRecord
 
   scope :added_since_yesterday, -> { where('created_at > ?', 1.day.ago) }
 
+  before_save { email.downcase! }
+
   def confirmed?
     !!oauth_api_gouv_id
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,8 @@ class User < ApplicationRecord
   has_many :contacts, through: :authorization_requests
   has_many :roles, through: :jwt_api_entreprise
 
+  validates :email, uniqueness: true
+
   scope :added_since_yesterday, -> { where('created_at > ?', 1.day.ago) }
 
   before_save { email.downcase! }

--- a/db/migrate/20211125152733_add_constraint_on_emails.rb
+++ b/db/migrate/20211125152733_add_constraint_on_emails.rb
@@ -1,0 +1,9 @@
+class AddConstraintOnEmails < ActiveRecord::Migration[6.1]
+  def up
+    add_index :users, :email, unique: true
+  end
+
+  def down
+    remove_index :users, name: :index_users_on_email
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_08_111119) do
+ActiveRecord::Schema.define(version: 2021_11_25_152733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -36,9 +36,9 @@ ActiveRecord::Schema.define(version: 2021_10_08_111119) do
     t.string "contact_type"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.uuid "authorization_request_id"
     t.string "first_name"
     t.string "last_name"
-    t.uuid "authorization_request_id"
     t.index ["created_at"], name: "index_contacts_on_created_at"
   end
 

--- a/lib/tasks/db_seed/create_admins.rake
+++ b/lib/tasks/db_seed/create_admins.rake
@@ -3,7 +3,7 @@ namespace :db_seed do
   task create_admins: :environment do
     admin_emails = Rails.application.credentials.admin_accounts
     admin_emails.each do |acc_email|
-      user = User.find_or_initialize_by(email: acc_email)
+      user = User.find_or_initialize_by_email(acc_email)
       user.update(admin: true, context: 'Administrateur API Entreprise')
     end
   end

--- a/spec/concepts/user/operation/transfer_ownership_spec.rb
+++ b/spec/concepts/user/operation/transfer_ownership_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe User::Operation::TransferOwnership do
       it 'gives the token ownership to the new user' do
         transfered_jwt_ids = old_owner.jwt_api_entreprise_ids
         subject
-        new_owner = User.find_by_email(new_owner_email)
+        new_owner = User.insensitive_find_by_email(new_owner_email)
 
         # added a sort call, equal was enforced but the order was not preserved in some
         # test seeds
@@ -109,7 +109,7 @@ RSpec.describe User::Operation::TransferOwnership do
 
       it 'creates a ghost user' do
         subject
-        new_owner = User.find_by_email(new_owner_email)
+        new_owner = User.insensitive_find_by_email(new_owner_email)
 
         expect(new_owner).to have_attributes({
           email: new_owner_email,

--- a/spec/features/transfer_account_spec.rb
+++ b/spec/features/transfer_account_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe 'transfer user account ownership', type: :feature do
     it 'transfer the tokens to the target account' do
       tokens_id = user.jwt_api_entreprise.pluck(:id)
       subject
-      target_user = User.find_by(email: email)
+      target_user = User.insensitive_find_by_email(email)
 
       expect(target_user.jwt_api_entreprise.pluck(:id)).to include(*tokens_id)
     end

--- a/spec/interactors/datapass_webhook/find_or_create_user_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_user_spec.rb
@@ -47,23 +47,5 @@ RSpec.describe DatapassWebhook::FindOrCreateUser, type: :interactor do
         }.to change { user.reload.first_name }.to('demandeur first name')
       end
     end
-
-    context 'when the input email contains upcase' do
-      before do
-        demandeur_attributes[:email].upcase!
-      end
-
-      it { is_expected.to be_a_success }
-      it { expect(subject.user.email).to eq(demandeur_attributes[:email].downcase) }
-
-      context 'when the input emails already exists' do
-        before do
-          create :user, email: demandeur_attributes[:email].downcase
-        end
-
-        it { is_expected.to be_a_success }
-        it { expect(subject.user.email).to eq(demandeur_attributes[:email].downcase) }
-      end
-    end
   end
 end

--- a/spec/interactors/datapass_webhook/find_or_create_user_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_user_spec.rb
@@ -47,5 +47,23 @@ RSpec.describe DatapassWebhook::FindOrCreateUser, type: :interactor do
         }.to change { user.reload.first_name }.to('demandeur first name')
       end
     end
+
+    context 'when the input email contains upcase' do
+      before do
+        demandeur_attributes[:email].upcase!
+      end
+
+      it { is_expected.to be_a_success }
+      it { expect(subject.user.email).to eq(demandeur_attributes[:email].downcase) }
+
+      context 'when the input emails already exists' do
+        before do
+          create :user, email: demandeur_attributes[:email].downcase
+        end
+
+        it { is_expected.to be_a_success }
+        it { expect(subject.user.email).to eq(demandeur_attributes[:email].downcase) }
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe User do
     it { is_expected.to have_many(:contacts) }
   end
 
+  describe 'constraints' do
+    it { is_expected.to validate_uniqueness_of(:email).case_insensitive }
+  end
+
   describe '.added_since_yesterday' do
     subject { described_class }
 
@@ -67,10 +71,28 @@ RSpec.describe User do
     end
   end
 
-  describe 'saving callbacks' do
-    it 'downcase emails before saving' do
-      user = create :user, email: 'CAPS_LOCK@EMAIL.COM'
-      expect(user.email).to eq('caps_lock@email.com')
+  describe '#find_or_initialize_by_email' do
+    subject { described_class.find_or_initialize_by_email(email) }
+
+    let(:email) { 'email_WITH@case.COM' }
+
+    context 'when email does not exist' do
+      its(:id) { is_expected.to be_nil }
+      its(:email) { is_expected.to eq email }
+    end
+
+    context 'when email already exists' do
+      let!(:user) { create :user, email: email }
+
+      its(:id) { is_expected.to eq user.id }
+      its(:email) { is_expected.to eq email }
+    end
+
+    context 'when email already exists with different case' do
+      let!(:user) { create :user, email: 'EMAIL_with@CASE.com' }
+
+      its(:id) { is_expected.to eq user.id }
+      its(:email) { is_expected.to eq 'EMAIL_with@CASE.com' }
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -66,4 +66,11 @@ RSpec.describe User do
       it { is_expected.to eq(false) }
     end
   end
+
+  describe 'saving callbacks' do
+    it 'downcase emails before saving' do
+      user = create :user, email: 'CAPS_LOCK@EMAIL.COM'
+      expect(user.email).to eq('caps_lock@email.com')
+    end
+  end
 end


### PR DESCRIPTION
Suite à un ticket de [support](https://3.basecamp.com/4318089/buckets/14298426/todos/4361531434)

1. s'assurer que les emails seront toujours downcase
2. nettoyage de la base
3. ajout de la contrainte manquante

```ruby
# to run in production
emails = [...]

emails.each do |email|
  duplicates = User.select { |e| e.email.downcase == email }.sort_by(&:updated_at)
  next if duplicates.size != 2

  newest = duplicates.last
  oldest = duplicates.first

  newest.authorization_requests << oldest.authorization_requests
  oldest.authorization_requests.clear
  puts "JWT migrated from #{oldest.email} to #{newest.email}"

  oldest.destroy
  puts "User #{oldest.email} destroyed"
end
```