### PR TITLE
Fix token index for admins

### DIFF
--- a/app/views/admin/tokens/index.html.erb
+++ b/app/views/admin/tokens/index.html.erb
@@ -22,7 +22,11 @@
           <tr id="<%= dom_id(token) %>" class='token_summary'>
             <td><%= I18n.l(token.created_at, format: :compact ) %></td>
             <td class="filter"><%= link_to token.displayed_subject, admin_token_path(token), class: "filter" %></td>
-            <td><%= I18n.l(Time.zone.at(token.exp), format: :compact_with_hours) %></td>
+            <% if token.exp %>
+              <td><%= I18n.l(Time.zone.at(token.exp), format: :compact_with_hours) %></td>
+            <% else %>
+              <td><%= t('.no_expiration') %></td>
+            <% end %>
             <td><%= boolean_i18n(token.archived?)    %></td>
             <td><%= boolean_i18n(token.blacklisted?) %></td>
           </tr>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -191,6 +191,8 @@ fr:
         alert: Le jeton "%{token_subject}" a bien été blacklisté.
       archive:
         alert: Le jeton "%{token_subject}" a bien été archivé.
+      index:
+        no_expiration: jamais
 
   endpoints:
     index:

--- a/spec/features/admin/token_index_spec.rb
+++ b/spec/features/admin/token_index_spec.rb
@@ -72,4 +72,15 @@ RSpec.describe 'admin token index', type: :feature do
       expect(page).to have_content('Non')
     end
   end
+
+  describe 'regression tests' do
+    context 'when one token exp is nil (usually admin/ping tokens)' do
+      before { create(:jwt_api_entreprise, exp: nil) }
+
+      it 'works' do
+        expect { visit(admin_tokens_path) }
+          .not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix error raised when at least one token has its exp attribute to nil.

@skelz0r tu peux merge si ça te va. 