### PR TITLE
Fix/orphaned tokens

### DIFF
--- a/app/controllers/jwt_api_entreprise_controller.rb
+++ b/app/controllers/jwt_api_entreprise_controller.rb
@@ -6,6 +6,10 @@ class JwtAPIEntrepriseController < AuthenticatedUsersController
       .where(archived: false)
   end
 
+  def show
+    @token = JwtAPIEntreprise.find(params[:id])
+  end
+
   def stats
     retrieve_stats = RetrieveTokenStats.call(token_id: params[:id])
 

--- a/app/controllers/jwt_api_entreprise_controller.rb
+++ b/app/controllers/jwt_api_entreprise_controller.rb
@@ -8,6 +8,11 @@ class JwtAPIEntrepriseController < AuthenticatedUsersController
 
   def show
     @token = JwtAPIEntreprise.find(params[:id])
+
+    unless access_allowed_for_current_user?
+      error_message(title: t('.error.title'))
+      redirect_current_user_to_homepage
+    end
   end
 
   def stats
@@ -28,5 +33,10 @@ class JwtAPIEntrepriseController < AuthenticatedUsersController
 
   def period_to_display
     params[:period]&.to_sym || :last_8_days
+  end
+
+  def access_allowed_for_current_user?
+    current_user == @token.user ||
+      current_user.admin?
   end
 end

--- a/app/models/jwt_api_entreprise.rb
+++ b/app/models/jwt_api_entreprise.rb
@@ -66,7 +66,7 @@ class JwtAPIEntreprise < ApplicationRecord
 
   def token_payload
     payload = {
-      uid: self.user&.id,
+      uid: self.user ? self.user.id : nil,
       jti: self.id,
       roles: self.roles.pluck(:code),
       sub: self.subject,

--- a/app/models/jwt_api_entreprise.rb
+++ b/app/models/jwt_api_entreprise.rb
@@ -66,7 +66,7 @@ class JwtAPIEntreprise < ApplicationRecord
 
   def token_payload
     payload = {
-      uid: self.user.id,
+      uid: self.user&.id,
       jti: self.id,
       roles: self.roles.pluck(:code),
       sub: self.subject,

--- a/app/views/admin/tokens/index.html.erb
+++ b/app/views/admin/tokens/index.html.erb
@@ -21,7 +21,7 @@
         <% @tokens.each do |token| %>
           <tr id="<%= dom_id(token) %>" class='token_summary'>
             <td><%= I18n.l(token.created_at, format: :compact ) %></td>
-            <td class="filter"><%= link_to token.displayed_subject, admin_token_path(token), class: "filter" %></td>
+            <td class="filter"><%= link_to token.displayed_subject, token_path(token), class: "filter" %></td>
             <% if token.exp %>
               <td><%= I18n.l(Time.zone.at(token.exp), format: :compact_with_hours) %></td>
             <% else %>

--- a/app/views/jwt_api_entreprise/_jwt_api_entreprise.html.erb
+++ b/app/views/jwt_api_entreprise/_jwt_api_entreprise.html.erb
@@ -5,7 +5,9 @@
 
       <% if user_signed_in? %>
         <span class="fr-text--sm fr-m-0 pull-right">
-          <%= link_to t('.links.datapass'), jwt_api_entreprise.authorization_request_url, target: '_blank', id: :authorization_request_link, class: %w(fr-link fr-link--sm) %>
+          <% if jwt_api_entreprise.authorization_request %>
+            <%= link_to t('.links.datapass'), jwt_api_entreprise.authorization_request_url, target: '_blank', id: :authorization_request_link, class: %w(fr-link fr-link--sm) %>
+          <% end %>
           <%= link_to t('.links.stats'), token_stats_path(jwt_api_entreprise), id: dom_id(jwt_api_entreprise, :stats_link), class: %w(fr-link fr-link--sm fr-fi-arrow-right-line fr-link--icon-right) %>
         </span>
       <% end %>
@@ -47,39 +49,41 @@
         <input id="<%= dom_id(jwt_api_entreprise, :token_hash) %>" class="fr-input" type="text" data-clipboard-target="source" readonly value="<%= jwt_api_entreprise.rehash %>" />
       </div>
 
-        <div class="actions">
-          <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left">
+      <div class="actions">
+        <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left">
+          <li>
+            <%= button_tag class: 'fr-btn fr-fi-file-line fr-btn--icon-left', id: dom_id(jwt_api_entreprise, :copy_button), data: { action: 'click->clipboard#copy' } do %>
+              Copier
+            <% end %>
+          </li>
+          <% if user_signed_in? %>
             <li>
-              <%= button_tag class: 'fr-btn fr-fi-file-line fr-btn--icon-left', id: dom_id(jwt_api_entreprise, :copy_button), data: { action: 'click->clipboard#copy' } do %>
-                Copier
+              <button id="<%= dom_id(jwt_api_entreprise, :modal_button) %>" class="fr-btn fr-btn--secondary" data-fr-opened="false" aria-controls="<%= dom_id(jwt_api_entreprise, :modal) %>">
+                <%= t('.actions.transfer') %>
+              </button>
+            </li>
+            <li>
+              <% if jwt_api_entreprise.authorization_request %>
+                <%= button_to t('.actions.renew'), jwt_api_entreprise.renewal_url, id: dom_id(jwt_api_entreprise, :renew), class: %w(fr-btn) %>
               <% end %>
             </li>
-            <% if user_signed_in? %>
+          <% end %>
+        </ul>
+        <% if current_user_admin? %>
+          <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left">
+            <% unless jwt_api_entreprise.archived? %>
               <li>
-                <button id="<%= dom_id(jwt_api_entreprise, :modal_button) %>" class="fr-btn fr-btn--secondary" data-fr-opened="false" aria-controls="<%= dom_id(jwt_api_entreprise, :modal) %>">
-                  <%= t('.actions.transfer') %>
-                </button>
+                <%= button_to t('.actions.archive'), archive_admin_token_path(jwt_api_entreprise), method: :patch, id: dom_id(jwt_api_entreprise, :archive_button), class: %w(fr-btn) %>
               </li>
+            <% end %>
+            <% unless jwt_api_entreprise.blacklisted? %>
               <li>
-                <%= button_to t('.actions.renew'), jwt_api_entreprise.renewal_url, id: dom_id(jwt_api_entreprise, :renew), class: %w(fr-btn) %>
+                <%= button_to t('.actions.blacklist'), blacklist_admin_token_path(jwt_api_entreprise), method: :patch, id: dom_id(jwt_api_entreprise, :blacklist_button), class: %w(fr-btn) %>
               </li>
             <% end %>
           </ul>
-          <% if current_user_admin? %>
-            <ul class="fr-btns-group fr-btns-group--inline fr-btns-group--icon-left">
-              <% unless jwt_api_entreprise.archived? %>
-                <li>
-                  <%= button_to t('.actions.archive'), archive_admin_token_path(jwt_api_entreprise), method: :patch, id: dom_id(jwt_api_entreprise, :archive_button), class: %w(fr-btn) %>
-                </li>
-              <% end %>
-              <% unless jwt_api_entreprise.blacklisted? %>
-                <li>
-                  <%= button_to t('.actions.blacklist'), blacklist_admin_token_path(jwt_api_entreprise), method: :patch, id: dom_id(jwt_api_entreprise, :blacklist_button), class: %w(fr-btn) %>
-                </li>
-              <% end %>
-            </ul>
-          <% end %>
-        </div>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/jwt_api_entreprise/show.html.erb
+++ b/app/views/jwt_api_entreprise/show.html.erb
@@ -1,0 +1,5 @@
+<div class="fr-grid-row">
+  <div class="fr-col-12 fr-pb-2w">
+    <%= render partial: 'jwt_api_entreprise/jwt_api_entreprise', object: @token %>
+  </div>
+</div>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -109,6 +109,9 @@ fr:
   jwt_api_entreprise:
     index:
       title: Jetons de l'organisation
+    show:
+      error:
+        title: Accès au jeton non autorisé
     jwt_api_entreprise:
       title: "Cadre d'utilisation : %{displayed_subject}"
       links:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
   post 'users/:id/transfer_account', to: 'users#transfer_account', as: :user_transfer_account
   post 'tokens/:id/create_magic_link', to: 'restricted_token_magic_links#create', as: :token_create_magic_link
   get 'tokens/:id/stats', to: 'jwt_api_entreprise#stats', as: :token_stats
+  get 'tokens/:id', to: 'jwt_api_entreprise#show', as: :token
   get '/magic_link', to: 'public_token_magic_links#show', as: :token_show_magic_link_legacy
   get '/public/tokens/:token', to: 'public_token_magic_links#show', as: :token_show_magic_link
 

--- a/spec/features/admin/token_index_spec.rb
+++ b/spec/features/admin/token_index_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'admin token index', type: :feature do
   let!(:active_token) { create(:jwt_api_entreprise, archived: false, blacklisted: false) }
   let!(:archived_token) { create(:jwt_api_entreprise, archived: true) }
   let!(:blacklisted_token) { create(:jwt_api_entreprise, blacklisted: true) }
+  let!(:orphan_token) { create(:jwt_api_entreprise, :without_authorization_request_id) }
 
   before do
     login_as(admin)
@@ -33,11 +34,11 @@ RSpec.describe 'admin token index', type: :feature do
     end
   end
 
-  it 'clicking subject redirects to user profile' do
+  it 'clicking subject redirects to token details' do
     within('#' << dom_id(random_token)) do
       click_link(random_token.displayed_subject)
 
-      expect(page.current_path).to eq(admin_user_path(random_token.user))
+      expect(page.current_path).to eq(token_path(random_token))
     end
   end
 

--- a/spec/features/token_details_spec.rb
+++ b/spec/features/token_details_spec.rb
@@ -1,0 +1,86 @@
+require 'rails_helper'
+
+RSpec.describe 'token details page', type: :feature do
+  let(:user) { create(:user, :with_jwt) }
+  let(:token) { create(:jwt_api_entreprise, user: user) }
+
+  before do
+    login_as(user)
+    visit token_path(token)
+  end
+
+  it 'displays tokens subject' do
+    expect(page).to have_content(token.displayed_subject)
+  end
+
+  it 'displays tokens creation date' do
+    expect(page).to have_content(friendly_format_from_timestamp(token.iat))
+  end
+
+  it 'displays tokens expiration date' do
+    expect(page).to have_content(friendly_format_from_timestamp(token.exp))
+  end
+
+  it 'has a button to copy active tokens hash to clipboard' do
+    expect(page).to have_css("##{dom_id(token, :copy_button)}")
+  end
+
+  it 'displays tokens access roles' do
+    token = create(:jwt_api_entreprise, :with_roles, user: user)
+    roles = token.roles.pluck(:code)
+    visit token_path(token)
+
+    expect(page).to have_content(*roles)
+  end
+
+  it 'has a button to create a magic link' do
+    expect(page).to have_button(dom_id(token, :modal_button))
+  end
+
+  it 'has a link to access token stats' do
+    expect(page).to have_link(href: token_stats_path(token))
+  end
+
+  context 'when the token has an authorization request' do
+    it 'has a link for token renewal' do
+      expect(page).to have_button(dom_id(token, :renew))
+    end
+
+    it 'has a link to authorization request' do
+      expect(page).to have_link(href: token.authorization_request_url)
+    end
+  end
+
+  context 'when the token has no authorization request' do
+    let(:user) { create(:user, :admin) }
+    let(:token) { create(:jwt_api_entreprise, :without_authorization_request_id) }
+
+    context 'when the token has no authorization request' do
+      it 'works' do
+        expect { visit token_path(token) }.not_to raise_error
+      end
+    end
+  end
+
+  context 'when connected as a simple user' do
+    it 'has no button to archive tokens' do
+      expect(page).to_not have_button(dom_id(token, :archive_button))
+    end
+
+    it 'has no button to blacklist tokens' do
+      expect(page).to_not have_button(dom_id(token, :blacklist_button))
+    end
+  end
+
+  context 'when connected as an admin' do
+    let(:user) { create(:user, :admin) }
+
+    it 'has button to archive tokens' do
+      expect(page).to have_button(dom_id(token, :archive_button))
+    end
+
+    it 'has button to blacklist tokens' do
+      expect(page).to have_button(dom_id(token, :blacklist_button))
+    end
+  end
+end

--- a/spec/features/token_details_spec.rb
+++ b/spec/features/token_details_spec.rb
@@ -83,4 +83,18 @@ RSpec.describe 'token details page', type: :feature do
       expect(page).to have_button(dom_id(token, :blacklist_button))
     end
   end
+
+  describe 'when requested from another user that does not own the token' do
+    before do
+      another_user = create(:user)
+      login_as(another_user)
+      visit token_path(token)
+    end
+
+    it_behaves_like :display_alert, :error
+
+    it 'redirects to the user profile' do
+      expect(page).to have_current_path(user_profile_path)
+    end
+  end
 end

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -177,6 +177,24 @@ RSpec.describe JwtAPIEntreprise, type: :model do
         expect(payload.fetch(:version)).to eq(jwt.version)
       end
     end
+
+    describe 'non-regression test' do
+      context 'when the token has no authorization request' do
+        let(:jwt) { create(:jwt_api_entreprise, :without_authorization_request_id) }
+
+        subject { jwt.rehash }
+
+        it 'still works' do
+          expect(subject).to match(/\A([a-zA-Z0-9_-]+\.){2}([a-zA-Z0-9_-]+)?\z/)
+        end
+
+        it 'sets uid field to nil in the JWT' do
+          payload = extract_payload_from(subject)
+
+          expect(payload.fetch(:uid)).to be_nil
+        end
+      end
+    end
   end
 
   describe 'external URLs to DataPass' do


### PR DESCRIPTION
Closes #247

J'ai introduit une vue pour isoler le détail d'un jeton hors du profil d'un utilisateur. 

Dans une PR à venir je ferai une passe le dit profil : lister les jetons d'une organisation sans tous les détails et rediriger par clique la vue du jeton unique. Dans un premier temps ça fixe juste le bug pour les admins. 