### PR TITLE
Harden tokens data integrity

### DIFF
--- a/app/models/jwt_api_entreprise.rb
+++ b/app/models/jwt_api_entreprise.rb
@@ -6,7 +6,11 @@ class JwtAPIEntreprise < ApplicationRecord
 
   include RandomToken
 
-  belongs_to :authorization_request, foreign_key: 'authorization_request_model_id', required: false
+  belongs_to :authorization_request, foreign_key: 'authorization_request_model_id'
+  validates :authorization_request, presence: true
+
+  validates :exp, presence: true
+
   has_one :user, through: :authorization_request
   has_many :contacts, through: :authorization_request
   has_and_belongs_to_many :roles

--- a/app/views/jwt_api_entreprise/_jwt_api_entreprise.html.erb
+++ b/app/views/jwt_api_entreprise/_jwt_api_entreprise.html.erb
@@ -18,15 +18,9 @@
         <li>
           <%= t('.delivered_at', humanized_date: friendly_format_from_timestamp(jwt_api_entreprise.iat)) %>
         </li>
-        <% if jwt_api_entreprise.exp %>
-          <li>
-            <%= t('.expired_at', humanized_date: friendly_format_from_timestamp(jwt_api_entreprise.exp)) %>
-          </li>
-        <% else %>
-          <li>
-            <%= t('.no_expiry') %>
-          </li>
-        <% end %>
+        <li>
+          <%= t('.expired_at', humanized_date: friendly_format_from_timestamp(jwt_api_entreprise.exp)) %>
+        </li>
       </ul>
 
       <div class="fr-mb-2v">

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -119,7 +119,6 @@ fr:
         stats: Voir les statistiques
       delivered_at: "Délivré le : %{humanized_date}"
       expired_at: "Expire le : %{humanized_date}"
-      no_expiry: N'expire jamais
       access: Accès
       token: Jeton
       actions:

--- a/db/migrate/20211210095845_add_constraint_on_exp_and_authorization_request_model_id_to_jwt_api_entreprises.rb
+++ b/db/migrate/20211210095845_add_constraint_on_exp_and_authorization_request_model_id_to_jwt_api_entreprises.rb
@@ -1,0 +1,6 @@
+class AddConstraintOnExpAndAuthorizationRequestModelIdToJwtAPIEntreprises < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :jwt_api_entreprises, :exp, false
+    change_column_null :jwt_api_entreprises, :authorization_request_model_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_25_152733) do
+ActiveRecord::Schema.define(version: 2021_12_10_095845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define(version: 2021_11_25_152733) do
     t.integer "iat"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "exp"
+    t.integer "exp", null: false
     t.string "version"
     t.boolean "blacklisted", default: false
     t.json "days_left_notification_sent", default: [], null: false
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 2021_11_25_152733) do
     t.boolean "access_request_survey_sent", default: false, null: false
     t.string "magic_link_token"
     t.datetime "magic_link_issuance_date"
-    t.uuid "authorization_request_model_id"
+    t.uuid "authorization_request_model_id", null: false
     t.index ["access_request_survey_sent"], name: "index_jwt_api_entreprises_on_access_request_survey_sent"
     t.index ["archived"], name: "index_jwt_api_entreprises_on_archived"
     t.index ["blacklisted"], name: "index_jwt_api_entreprises_on_blacklisted"

--- a/spec/factories/jwt_api_entreprises.rb
+++ b/spec/factories/jwt_api_entreprises.rb
@@ -33,10 +33,6 @@ FactoryBot.define do
       end
     end
 
-    trait :without_authorization_request_id do
-      authorization_request_id { nil }
-    end
-
     trait :access_request_survey_not_sent do
       access_request_survey_sent { false }
     end

--- a/spec/features/admin/token_index_spec.rb
+++ b/spec/features/admin/token_index_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe 'admin token index', type: :feature do
   let!(:active_token) { create(:jwt_api_entreprise, archived: false, blacklisted: false) }
   let!(:archived_token) { create(:jwt_api_entreprise, archived: true) }
   let!(:blacklisted_token) { create(:jwt_api_entreprise, blacklisted: true) }
-  let!(:orphan_token) { create(:jwt_api_entreprise, :without_authorization_request_id) }
 
   before do
     login_as(admin)
@@ -71,17 +70,6 @@ RSpec.describe 'admin token index', type: :feature do
   it 'archived status as Non for not archived token' do
     within('#' << dom_id(active_token)) do
       expect(page).to have_content('Non')
-    end
-  end
-
-  describe 'regression tests' do
-    context 'when one token exp is nil (usually admin/ping tokens)' do
-      before { create(:jwt_api_entreprise, exp: nil) }
-
-      it 'works' do
-        expect { visit(admin_tokens_path) }
-          .not_to raise_error
-      end
     end
   end
 end

--- a/spec/features/token_details_spec.rb
+++ b/spec/features/token_details_spec.rb
@@ -51,17 +51,6 @@ RSpec.describe 'token details page', type: :feature do
     end
   end
 
-  context 'when the token has no authorization request' do
-    let(:user) { create(:user, :admin) }
-    let(:token) { create(:jwt_api_entreprise, :without_authorization_request_id) }
-
-    context 'when the token has no authorization request' do
-      it 'works' do
-        expect { visit token_path(token) }.not_to raise_error
-      end
-    end
-  end
-
   context 'when connected as a simple user' do
     it 'has no button to archive tokens' do
       expect(page).to_not have_button(dom_id(token, :archive_button))

--- a/spec/features/token_details_spec.rb
+++ b/spec/features/token_details_spec.rb
@@ -97,14 +97,4 @@ RSpec.describe 'token details page', type: :feature do
       expect(page).to have_current_path(user_profile_path)
     end
   end
-
-  describe 'non-regression tests' do
-    context 'when the token has no expiration' do
-      let(:token) { create(:jwt_api_entreprise, exp: nil, user: user) }
-
-      it 'works' do
-        expect { visit token_path(token) }.not_to raise_error
-      end
-    end
-  end
 end

--- a/spec/jobs/schedule_expiration_notice_mailjet_email_job_spec.rb
+++ b/spec/jobs/schedule_expiration_notice_mailjet_email_job_spec.rb
@@ -33,20 +33,6 @@ RSpec.describe ScheduleExpirationNoticeMailjetEmailJob, type: :job do
       end
     end
 
-    context 'when token has no authorization request (no user/contact)' do
-      before do
-        token.update!(
-          authorization_request_model_id: nil,
-        )
-      end
-
-      it 'does nothing' do
-        expect(Mailjet::Send).not_to receive(:create)
-
-        subject
-      end
-    end
-
     context 'when token is found and expires_in is valid' do
       let(:external_id) { '9001' }
       let(:contact) { create(:contact, :with_full_name, authorization_request: token.authorization_request) }

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -177,24 +177,6 @@ RSpec.describe JwtAPIEntreprise, type: :model do
         expect(payload.fetch(:version)).to eq(jwt.version)
       end
     end
-
-    describe 'non-regression test' do
-      context 'when the token has no authorization request' do
-        let(:jwt) { create(:jwt_api_entreprise, :without_authorization_request_id) }
-
-        subject { jwt.rehash }
-
-        it 'still works' do
-          expect(subject).to match(/\A([a-zA-Z0-9_-]+\.){2}([a-zA-Z0-9_-]+)?\z/)
-        end
-
-        it 'sets uid field to nil in the JWT' do
-          payload = extract_payload_from(subject)
-
-          expect(payload.fetch(:uid)).to be_nil
-        end
-      end
-    end
   end
 
   describe 'external URLs to DataPass' do


### PR DESCRIPTION
* `exp` ne peut pas être vide
* `authorization request` existe forcément

Fait parti du chantier de l'harden de la bdd (intégrité tout ça)

Au passage les jetons en prod qui n'avait ni `exp` ni `authorization request` ont été supprimés:

* ceux sans `exp` sont les notres, aucun intérêt vu qu'on peut les générer depuis siade
* ceux sans `authorization request` sont des relicats de duplication lors de la création du jeton (car originellement pas de vérification de l'intégrité)

Closes https://github.com/etalab/admin_api_entreprise/issues/251