### PR TITLE
First part of DataPass migration

### DIFF
--- a/app/interactors/datapass_webhook/archive_previous_token.rb
+++ b/app/interactors/datapass_webhook/archive_previous_token.rb
@@ -2,7 +2,7 @@
 
 class DatapassWebhook::ArchivePreviousToken < ApplicationInteractor
   def call
-    return if context.event != 'validate_application'
+    return if %w(validate_application validate).exclude?(context.event)
     return if context.authorization_request.previous_external_id.blank?
     return if previous_token.blank?
 

--- a/app/interactors/datapass_webhook/create_jwt_token.rb
+++ b/app/interactors/datapass_webhook/create_jwt_token.rb
@@ -1,6 +1,6 @@
 class DatapassWebhook::CreateJwtToken < ApplicationInteractor
   def call
-    return if context.event != 'validate_application'
+    return if %w(validate_application validate).exclude?(context.event)
     return if token_already_exists?
 
     token = create_jwt_token

--- a/app/interactors/datapass_webhook/extract_mailjet_variables.rb
+++ b/app/interactors/datapass_webhook/extract_mailjet_variables.rb
@@ -72,6 +72,10 @@ class DatapassWebhook::ExtractMailjetVariables < ApplicationInteractor
       review_application
       validate_application
       notify
+
+      refuse
+      request_changes
+      validate
     ].freeze
   end
 

--- a/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
+++ b/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
@@ -45,7 +45,7 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
 
   def authorization_request_attributes_for_current_event
     case context.event
-    when 'send_application'
+    when 'send_application', 'submit'
       if context.authorization_request.first_submitted_at.nil?
         {
           'first_submitted_at' => fired_at_as_datetime,
@@ -53,7 +53,7 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
       else
         {}
       end
-    when 'validate_application'
+    when 'validate_application', 'validate'
       {
         'validated_at' => fired_at_as_datetime,
       }

--- a/app/jobs/schedule_authorization_request_mailjet_email_job.rb
+++ b/app/jobs/schedule_authorization_request_mailjet_email_job.rb
@@ -9,7 +9,7 @@ class ScheduleAuthorizationRequestMailjetEmailJob < ApplicationJob
     @authorization_request = AuthorizationRequest.find_by(id: authorization_request_id)
 
     return if authorization_request.blank?
-    return if authorization_request.status != authorization_request_status
+    return if authorization_request_status_changed?(authorization_request_status)
 
     deliver_mailjet_email(
       build_message(mailjet_attributes.stringify_keys)
@@ -18,6 +18,8 @@ class ScheduleAuthorizationRequestMailjetEmailJob < ApplicationJob
     set_mailjet_context_for_sentry(e)
     raise
   end
+
+  private
 
   def build_message(mailjet_attributes)
     {
@@ -39,5 +41,20 @@ class ScheduleAuthorizationRequestMailjetEmailJob < ApplicationJob
 
       "#{recipient_payload['full_name']} <#{recipient_payload['email']}>"
     end.join(', ')
+  end
+
+  def authorization_request_status_changed?(authorization_request_status)
+    authorization_request.status != authorization_request_status &&
+      new_status_nomenclature[authorization_request.status] != authorization_request_status
+  end
+
+  def new_status_nomenclature
+    {
+      'pending' => 'draft',
+      'modification_pending' => 'changes_requested',
+      'sent' => 'submitted',
+      'validated' => 'validated',
+      'refused' => 'refused'
+    }.freeze
   end
 end

--- a/config/datapass_webhooks.yml
+++ b/config/datapass_webhooks.yml
@@ -1,18 +1,17 @@
 # Check https://github.com/betagouv/signup-back/tree/master/docs/webhooks.md for all events and their details
 ---
 development: &development
-  created: {}
-  updated: {}
-  owner_updated: {}
-  rgpd_contact_updated: {}
-  send_application:
+  created: &created {}
+  updated: &updated {}
+  team_member_updated: &team_member_updated {}
+  send_application: &send_application
     emails:
       - id: '11'
       - id: '12'
         when: 'in 14 days'
-  notify: {}
-  review_application: {}
-  refuse_application:
+  notify: &notify {}
+  review_application: &review_application {}
+  refuse_application: &refuse_application
     emails:
       - id: '51'
         condition_on_authorization: 'user_first_name_is_run?'
@@ -23,32 +22,40 @@ development: &development
         cc:
           - 'authorization_request.contact_technique'
           - 'authorization_request.user'
-  validate_application: {}
+  validate_application: &validate_application {}
+
+  create: *created
+  update: *updated
+  team_member_update: *team_member_updated
+  submit: *send_application
+  request_changes: *review_application
+  refuse: *refuse_application
+  validate: *validate_application
+
 test: *development
 
 production: &production
-  created:
+  created: &created
     emails:
       - id: '3098214'
         when: 'in 14 days'
-  updated: {}
-  owner_updated: {}
-  rgpd_contact_updated: {}
-  send_application:
+  updated: &updated {}
+  team_member_updated: &team_member_updated {}
+  send_application: &send_application
     emails:
       - id: '3098391'
       - id: '3098436'
         when: 'in 14 days'
-  notify: {}
-  review_application:
+  notify: &notify {}
+  review_application: &review_application
     emails:
       - id: '3098236'
       - id: '3098155'
         when: 'in 14 days'
-  refuse_application:
+  refuse_application: &refuse_application
     emails:
       - id: '3084277'
-  validate_application:
+  validate_application: &validate_application
     emails:
       - id: '3090261'
         condition_on_authorization: 'all_contacts_have_the_same_email?'
@@ -101,6 +108,14 @@ production: &production
         when: 'in 30 days'
         to:
           - 'authorization_request.user'
+
+  create: *created
+  update: *updated
+  team_member_update: *team_member_updated
+  submit: *send_application
+  request_changes: *review_application
+  refuse: *refuse_application
+  validate: *validate_application
 
 sandbox: *production
 staging: *production

--- a/spec/factories/datapass_webhooks.rb
+++ b/spec/factories/datapass_webhooks.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :datapass_webhook, class: Hash do
     initialize_with { attributes.stringify_keys }
 
-    event { 'refuse_application' }
+    event { %w(refuse_application refuse).sample }
     model_type { 'Pass' }
     fired_at { Time.now.to_i }
     data do

--- a/spec/interactors/datapass_webhook/archive_previous_token_spec.rb
+++ b/spec/interactors/datapass_webhook/archive_previous_token_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe DatapassWebhook::ArchivePreviousToken, type: :interactor do
     end
   end
 
-  context 'when event is validate_application' do
-    let(:event) { 'validate_application' }
+  context 'when event is validate_application or validate' do
+    let(:event) { %w(validate_application validate).sample }
 
     context 'when authorization request has a previous external id' do
       let(:previous_external_id) { rand(9001).to_s }
@@ -39,7 +39,7 @@ RSpec.describe DatapassWebhook::ArchivePreviousToken, type: :interactor do
   end
 
   context 'when event is not validate_application' do
-    let(:event) { 'sent' }
+    let(:event) { %w(send_application submit) }
 
     context 'when authorization request has a previous external id' do
       let(:previous_external_id) { rand(9001).to_s }

--- a/spec/interactors/datapass_webhook/extract_mailjet_variables_spec.rb
+++ b/spec/interactors/datapass_webhook/extract_mailjet_variables_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe DatapassWebhook::ExtractMailjetVariables, type: :interactor do
   let(:datapass_webhook_params) { build(:datapass_webhook, event: event) }
   let(:authorization_request) { create(:authorization_request) }
 
-  let(:event) { 'created' }
+  let(:event) { %w(created create).sample }
 
   it { is_expected.to be_a_success }
 
@@ -27,7 +27,7 @@ RSpec.describe DatapassWebhook::ExtractMailjetVariables, type: :interactor do
   end
 
   context 'when event is from an instructor' do
-    let(:event) { 'refuse_application' }
+    let(:event) { %w(refuse_application refuse).sample }
 
     it 'sets instructor first and last name' do
       expect(subject.mailjet_variables['instructor_first_name']).to eq('Instructor first name')
@@ -36,7 +36,7 @@ RSpec.describe DatapassWebhook::ExtractMailjetVariables, type: :interactor do
   end
 
   context 'when event is not from an instructor' do
-    let(:event) { 'created' }
+    let(:event) { %w(created create).sample }
 
     it 'does not set instructor first and last name' do
       expect(subject.mailjet_variables['instructor_first_name']).to be_nil

--- a/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
@@ -84,8 +84,8 @@ RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interac
     end
   end
 
-  context 'when event is send_application' do
-    let(:datapass_webhook_params) { build(:datapass_webhook, event: 'send_application', fired_at: fired_at, authorization_request_attributes: { id: authorization_id }) }
+  context 'when event is send_application or submit' do
+    let(:datapass_webhook_params) { build(:datapass_webhook, event: %w(send_application submit).sample, fired_at: fired_at, authorization_request_attributes: { id: authorization_id }) }
 
     let!(:authorization_request) { create(:authorization_request, :with_contacts, external_id: authorization_id, first_submitted_at: first_submitted_at) }
 
@@ -110,8 +110,8 @@ RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interac
     end
   end
 
-  context 'when event is validate_application' do
-    let(:datapass_webhook_params) { build(:datapass_webhook, event: 'validate_application', fired_at: fired_at, authorization_request_attributes: { id: authorization_id }) }
+  context 'when event is validate_application or validate' do
+    let(:datapass_webhook_params) { build(:datapass_webhook, event: %w(validate_application validate).sample, fired_at: fired_at, authorization_request_attributes: { id: authorization_id }) }
 
     let!(:authorization_request) { create(:authorization_request, :with_contacts, external_id: authorization_id) }
 

--- a/spec/interactors/datapass_webhook/schedule_authorization_request_emails_spec.rb
+++ b/spec/interactors/datapass_webhook/schedule_authorization_request_emails_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe DatapassWebhook::ScheduleAuthorizationRequestEmails, type: :inter
   end
 
   describe 'with an event which does not trigger email' do
-    let(:event) { 'created' }
+    let(:event) { %w(created create).sample }
 
     it 'does not call schedule emails' do
       subject
@@ -39,7 +39,7 @@ RSpec.describe DatapassWebhook::ScheduleAuthorizationRequestEmails, type: :inter
   end
 
   context 'with an event which trigger emails, no conditions, a when key and no attributes on recipients' do
-    let(:event) { 'send_application' }
+    let(:event) { %w(send_application submit).sample }
 
     it 'schedules emails according to configuration, to authorization request\'s user' do
       subject
@@ -77,7 +77,7 @@ RSpec.describe DatapassWebhook::ScheduleAuthorizationRequestEmails, type: :inter
   end
 
   context 'with an event which trigger emails, conditions and recipients attributes' do
-    let(:event) { 'refuse_application' }
+    let(:event) { %w(refuse_application refuse).sample }
 
     before do
       AuthorizationRequestConditionFacade.define_method(:user_first_name_is_run?) do


### PR DESCRIPTION
This PR enables the app to handle both old and new DataPass event nomenclature, which should be in production before https://github.com/betagouv/datapass/pull/213