### PR TITLE
Introduce table to store access logs

### DIFF
--- a/app/models/access_log.rb
+++ b/app/models/access_log.rb
@@ -1,0 +1,3 @@
+class AccessLog < ApplicationRecord
+  belongs_to :jwt_api_entreprise
+end

--- a/db/migrate/20220111162835_create_access_logs.rb
+++ b/db/migrate/20220111162835_create_access_logs.rb
@@ -1,0 +1,27 @@
+class CreateAccessLogs < ActiveRecord::Migration[6.1]
+  def change
+    enable_extension "btree_gin"
+
+    create_table :access_logs, id: false do |t|
+      t.datetime :timestamp
+      t.string :action
+      t.string :api_version
+      t.string :host
+      t.string :method
+      t.string :path
+      t.string :route
+      t.string :controller
+      t.string :duration
+      t.string :status
+      t.string :ip
+      t.string :source
+      t.belongs_to :jwt_api_entreprise, foreign_key: true, type: :uuid, index: true
+      t.jsonb :params, default: '{}'
+    end
+
+    add_index :access_logs, "(params->>'siren')", using: :gin, name: 'index_access_logs_on_params_siren'
+    add_index :access_logs, "(params->>'siret')", using: :gin, name: 'index_access_logs_on_params_siret'
+    add_index :access_logs, "(params->>'siret_or_eori')", using: :gin, name: 'index_access_logs_on_params_siret_or_eori'
+    add_index :access_logs, "(params->>'recipient')", using: :gin, name: 'index_access_logs_on_params_recipient'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,34 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_31_143609) do
+ActiveRecord::Schema.define(version: 2022_01_11_162835) do
 
   # These are extensions that must be enabled in order to support this database
+  enable_extension "btree_gin"
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
+
+  create_table "access_logs", id: false, force: :cascade do |t|
+    t.datetime "timestamp"
+    t.string "action"
+    t.string "api_version"
+    t.string "host"
+    t.string "method"
+    t.string "path"
+    t.string "route"
+    t.string "controller"
+    t.string "duration"
+    t.string "status"
+    t.string "ip"
+    t.string "source"
+    t.uuid "jwt_api_entreprise_id"
+    t.jsonb "params", default: "{}"
+    t.index "((params ->> 'recipient'::text))", name: "index_access_logs_on_params_recipient", using: :gin
+    t.index "((params ->> 'siren'::text))", name: "index_access_logs_on_params_siren", using: :gin
+    t.index "((params ->> 'siret'::text))", name: "index_access_logs_on_params_siret", using: :gin
+    t.index "((params ->> 'siret_or_eori'::text))", name: "index_access_logs_on_params_siret_or_eori", using: :gin
+    t.index ["jwt_api_entreprise_id"], name: "index_access_logs_on_jwt_api_entreprise_id"
+  end
 
   create_table "authorization_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "intitule"
@@ -99,4 +122,5 @@ ActiveRecord::Schema.define(version: 2021_12_31_143609) do
     t.index ["pwd_renewal_token"], name: "index_users_on_pwd_renewal_token"
   end
 
+  add_foreign_key "access_logs", "jwt_api_entreprises"
 end


### PR DESCRIPTION
Cette PR introduit uniquement une table dans en base pour y stocker les logs d'accès. L'objectif est de tester les visualisations dans metabase qui sera dans un premier temps l'unique point d'entré à ces données. 

Une fois déployé en sandbox j'y importe les logs issus de Elasticsearch. 

Suite et industrialisation : 
* création du modèle dans l'application Rails avec liens relationnels  
* script d'export/import de Elasticsearch vers cette table PG