### PR TITLE
DataPass webhook: persists datapass' siret in User#context

### DIFF
--- a/app/interactors/datapass_webhook/find_or_create_user.rb
+++ b/app/interactors/datapass_webhook/find_or_create_user.rb
@@ -15,13 +15,18 @@ class DatapassWebhook::FindOrCreateUser < ApplicationInteractor
       'first_name' => user_attributes['given_name'],
       'last_name' => user_attributes['family_name'],
       'phone_number' => user_attributes['phone_number'],
-      'oauth_api_gouv_id' => user_attributes['uid']
+      'oauth_api_gouv_id' => user_attributes['uid'],
+      'context' => datapass_attributes['siret']
     }
   end
 
   def user_attributes
-    context.data['pass']['team_members'].find do |team_member|
+    datapass_attributes['team_members'].find do |team_member|
       team_member['type'] == 'demandeur'
     end
+  end
+
+  def datapass_attributes
+    context.data['pass']
   end
 end

--- a/spec/factories/datapass_webhooks.rb
+++ b/spec/factories/datapass_webhooks.rb
@@ -39,6 +39,7 @@ FactoryBot.define do
     description { 'description from webhook' }
     status { 'sent' }
     copied_from_enrollment_id { nil }
+    siret { '13002526500013' }
 
     events { build_list(:datapass_webhook_event_model, 2) }
 

--- a/spec/interactors/datapass_webhook/find_or_create_user_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_user_spec.rb
@@ -23,10 +23,12 @@ RSpec.describe DatapassWebhook::FindOrCreateUser, type: :interactor do
         }.to change { User.count }.by(1)
 
         user = User.last
+
         expect(user.oauth_api_gouv_id).to be_present
         expect(user.first_name).to eq('demandeur first name')
         expect(user.last_name).to eq('demandeur last name')
         expect(user.phone_number).to be_present
+        expect(user.context).to eq('13002526500013')
       end
     end
 


### PR DESCRIPTION
Temporary solution (which was the case before the migration on
DataPass).

This data will be migrate soon to a specific table (for data analysis).