### PR TITLE
Fixed issue with back to token list on page stats

### DIFF
--- a/app/views/jwt_api_entreprise/stats.html.erb
+++ b/app/views/jwt_api_entreprise/stats.html.erb
@@ -7,7 +7,11 @@
             <%= t('.title', title: @token.intitule) %>
 
             <span class="fr-text--sm fr-m-0 pull-right">
-              <%= link_to t('.links.user_tokens'), user_tokens_path, id: :user_tokens_link, class: %w(fr-link fr-link--sm fr-fi-arrow-right-line fr-link--icon-right) %>
+              <% if current_user_admin? %>
+                <%= link_to t('.links.user_tokens'), admin_user_path(@token.user), id: :user_tokens_link, class: %w(fr-link fr-link--sm fr-fi-arrow-right-line fr-link--icon-right) %>
+              <% else %>
+                <%= link_to t('.links.user_tokens'), user_tokens_path, id: :user_tokens_link, class: %w(fr-link fr-link--sm fr-fi-arrow-right-line fr-link--icon-right) %>
+              <% end %>
             </span>
           </h4>
 

--- a/spec/features/token_stats_spec.rb
+++ b/spec/features/token_stats_spec.rb
@@ -2,6 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'stats page for a token', type: :feature do
   let(:user) { create(:user, :with_jwt) }
+  let(:admin) { create(:user, :admin) }
   let(:token) { user.jwt_api_entreprise.take }
 
   subject { visit token_stats_path(token) }
@@ -22,10 +23,24 @@ RSpec.describe 'stats page for a token', type: :feature do
       })
     end
 
-    it 'has a link back to the list of tokens' do
-      subject
+    context 'when connected as a simple user' do
+      it 'has a link back to the list of tokens' do
+        subject
 
-      expect(page).to have_link(href: user_tokens_path)
+        expect(page).to have_link(href: user_tokens_path)
+      end
+    end
+
+    context 'when connected as an admin' do
+      before do
+        login_as(admin)
+      end
+
+      it 'has a link back to the list of tokens' do
+        subject
+
+        expect(page).to have_link(href: admin_user_path(token.user))
+      end
     end
 
     it 'displays the token intitule' do


### PR DESCRIPTION
Previously was going to the logged user (i.e admin) JWT page
Now as admin, go back to the inspected user JWT page

Fix https://github.com/etalab/admin_api_entreprise/issues/288

C'est ma première PR sur ce repo donc hésitez pas à bien regarder^^