### PR TITLE
Enhance header

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,7 @@
 /*
  *= require dsfr-fonts
  *= require dsfr
+ *= require dsfr-extensions
  *= require_self
  *= require_tree ./components
  *= require_tree ./pages

--- a/app/assets/stylesheets/dsfr-extensions.scss
+++ b/app/assets/stylesheets/dsfr-extensions.scss
@@ -1,0 +1,10 @@
+.fr-header__tools-links .fr-links-group > *:not(:last-child) > turbo-frame > .fr-link::after {
+  content: "";
+  display: block;
+  position: relative;
+  right: -1rem;
+  width: 1px;
+  height: 1rem;
+
+  box-shadow: inset 0 0 0 1px var(--border-default-grey);
+}

--- a/app/views/pages/current_status.html.erb
+++ b/app/views/pages/current_status.html.erb
@@ -1,5 +1,5 @@
 <turbo-frame id="current_status">
-  <a href="https://status.entreprise.api.gouv.fr" alt="API Entreprise Status Page" target="_blank">
-    <%= t('.title') %> : <span class="circle circle-<%= status_to_color(@current_status) %>"></span> <%= t(".values.#{@current_status}") %>
+  <a class="fr-link" href="https://status.entreprise.api.gouv.fr" alt="API Entreprise Status Page" target="_blank">
+    <span class="circle circle-<%= status_to_color(@current_status) %> fr-mr-1w"></span> <%= t('.title') %>
   </a>
 </turbo-frame>

--- a/app/views/shared/_user_signed_in_side_menu.html.erb
+++ b/app/views/shared/_user_signed_in_side_menu.html.erb
@@ -16,12 +16,6 @@
             <%= t('.tokens') %>
           </a>
         </li>
-
-        <li class="fr-sidemenu__item">
-          <a id="logout_button" class="fr-sidemenu__link" href="<%= logout_path %>" target="_self" data-method="delete">
-            <%= t('.sign_out') %>
-          </a>
-        </li>
       </ul>
     </div>
   </div>

--- a/app/views/shared/header/_tools.html.erb
+++ b/app/views/shared/header/_tools.html.erb
@@ -2,7 +2,7 @@
   <ul class="fr-links-group">
     <li>
       <turbo-frame id="current_status" src="<%= current_status_path %>">
-        <%= t('pages.current_status.title') %> : <%= t('pages.current_status.loading') %>
+        <span class="circle circle-undefined"></span> <%= t('pages.current_status.title') %>
       </turbo-frame>
     </li>
     <!-- <li> -->

--- a/app/views/shared/header/_tools.html.erb
+++ b/app/views/shared/header/_tools.html.erb
@@ -1,20 +1,36 @@
 <div class="fr-header__tools-links">
   <ul class="fr-links-group">
     <li>
-      <turbo-frame id="current_status" src="<%= current_status_path %>">
-        <span class="circle circle-undefined"></span> <%= t('pages.current_status.title') %>
-      </turbo-frame>
+      <a class="fr-link fr-fi-<%= t('.links.faq_contact.icon') %>" href="https://entreprise.api.gouv.fr/support/" #target="_blank">
+        <%= t('.links.faq_contact.title') %>
+      </a>
     </li>
-    <!-- <li> -->
-    <!--   <a class="fr&#45;link fr&#45;fi&#45;<%= t('.links.notification.icon') %>" href="#"> -->
-    <!--     <%= t('.links.notification.title') %> -->
-    <!--   </a> -->
-    <!-- </li> -->
-    <!-- <li> -->
-    <!--   <a class="fr&#45;link fr&#45;fi&#45;<%= t('.links.faq_contact.icon') %>" href="#"> -->
-    <!--     <%= t('.links.faq_contact.title') %> -->
-    <!--   </a> -->
-    <!-- </li> -->
+    <li>
+      <turbo-frame id="current_status" src="<%= current_status_path %>">
+        <a class="fr-link" href="https://status.entreprise.api.gouv.fr" alt="API Entreprise Status Page" target="_blank">
+          <span class="circle circle-undefined fr-mr-1w"></span> <%= t('pages.current_status.title') %>
+        </a>
+      </turbo-frame>
+      <span class="fr-header-separator"></span>
+    </li>
+    <% if user_signed_in? %>
+      <li>
+        <a class="fr-link fr-fi-<%= t('.links.user_connected.icon') %>" href="<%= user_profile_path %>">
+          <%= current_user.full_name %>
+        </a>
+      </li>
+      <li>
+        <a class="fr-link fr-fi-<%= t('.links.sign_out.icon') %>" id="logout_button" href="<%= logout_path %>" target="_self" data-method="delete">
+          <%= t('.links.sign_out.title') %>
+        </a>
+      </li>
+    <% else %>
+      <li>
+        <%= form_with(url: login_api_gouv_path, method: :post, data: { turbo: false }) do |f| %>
+          <%= f.button t('.links.sign_in.title'), class: "fr-link fr-fi-#{t('.links.sign_in.icon')}", id: 'login_header' %>
+        <% end %>
+      </li>
+    <% end %>
   </ul>
 </div>
 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -46,12 +46,17 @@ fr:
       tagline: Les données des entreprises et des associations <strong>pour les administrations</strong>
       tools:
         links:
-          notification:
-            title: Notifications
-            icon: mail-fill
           faq_contact:
-            title: FAQ & Contact
-            icon: question-fill
+            title: "FAQ & Contact"
+            icon: "question-fill"
+          sign_in:
+            title: "Se connecter"
+            icon: "lock-fill"
+          user_connected:
+            icon: "user-fill"
+          sign_out:
+            title: "Se déconnecter"
+            icon: "logout-box-r-fill"
     footer:
       tagline: API Entreprise, un <strong>service de l'écosystème des API et de la circulation des données</strong> au sein des administrations.
       external_links:
@@ -63,7 +68,6 @@ fr:
       toggle: "Menu"
       profil: "Compte utilisateur"
       tokens: "Jetons d'accès"
-      sign_out: "Se déconnecter"
 
 
   pages:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -68,13 +68,7 @@ fr:
 
   pages:
     current_status:
-      title: "Status des API"
-      loading: 'Chargement...'
-      values:
-        up: OK
-        has_issues: NOK
-        maintenance: Maintenance
-        undefined: Indéfini
+      title: "Statuts des API"
     redoc:
       title: "Documentation technique"
       description: "Cette documentation technique est propulsée par <a href='https://github.com/Redocly/redoc' target='_blank'>Redoc</a> et se base sur le fichier OpenAPI."


### PR DESCRIPTION
Mise à niveau graphique du header de navigation.

Pour le moment il n'y a pas de liste déroulante dans le header (j'ai tout de même demandé sur le slack du DSFr), imo c'est pas bloquant pour avancer. Ce menu déroulant aurait servi sur le hover du nom du user pour afficher un "Se déconnecter". On peut s'amuser à le coder, mais relou pour X raisons (responsive, pas accessible, etc etc..)

Au passage, n'ayant nul part l'info de l'organisation je ne peux pas l'afficher pour le moment, j'ai mis le full name en attendant. On verra quand on l'introduira.

Cette PR close 2 issues mineures qui trainaient au passage.

Des screenshots:

![Screen Shot 2022-01-27 at 18 00 28](https://user-images.githubusercontent.com/1279968/151407805-354fb33a-7daf-4129-9f1a-15bd2dd28020.png)
![Screen Shot 2022-01-27 at 18 00 24](https://user-images.githubusercontent.com/1279968/151407808-7d34703f-830f-42b2-b6e6-66e5192a5a20.png)
