### PR TITLE
Replacing Redis.current (deprecated)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,6 +89,11 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/GlobalVars:
+  AllowedVariables:
+    - $redis
+    - $elastic
+
 Style/MethodCalledOnDoEndBlock:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,7 +91,6 @@ Style/FrozenStringLiteralComment:
 
 Style/GlobalVars:
   AllowedVariables:
-    - $redis
     - $elastic
 
 Style/MethodCalledOnDoEndBlock:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -333,17 +333,6 @@ Style/ClassAndModuleChildren:
     - 'app/organizers/token/send_expiration_notices.rb'
     - 'app/organizers/user/transfer_account.rb'
 
-# Offense count: 6
-# Configuration parameters: AllowedVariables.
-Style/GlobalVars:
-  Exclude:
-    - 'app/services/most_active_user_ids_with_volume_elastic_query.rb'
-    - 'app/services/not_in_production_jwt_ids_elastic_query.rb'
-    - 'app/services/used_jwt_ids_elastic_query.rb'
-    - 'spec/services/most_active_user_ids_with_volume_elastic_query_spec.rb'
-    - 'spec/services/not_in_production_jwt_ids_elastic_query_spec.rb'
-    - 'spec/services/used_jwt_ids_elastic_query_spec.rb'
-
 # Offense count: 3
 # Configuration parameters: MinBodyLength.
 Style/GuardClause:

--- a/app/services/status_page.rb
+++ b/app/services/status_page.rb
@@ -19,14 +19,14 @@ class StatusPage
   private
 
   def raw_current_status
-    redis.get(redis_cached_key) ||
+    $redis.get(redis_cached_key) ||
       retrieve_from_status_page
   end
 
   def retrieve_from_status_page
     status = page_summary['page']['status']
 
-    redis.set(redis_cached_key, status, ex: 5.minutes.to_i)
+    $redis.set(redis_cached_key, status, ex: 5.minutes.to_i)
 
     status
   end
@@ -47,9 +47,5 @@ class StatusPage
 
   def redis_cached_key
     'status_page_current_status'
-  end
-
-  def redis
-    Redis.current
   end
 end

--- a/app/services/status_page.rb
+++ b/app/services/status_page.rb
@@ -19,14 +19,14 @@ class StatusPage
   private
 
   def raw_current_status
-    $redis.get(redis_cached_key) ||
+    redis.get(redis_cached_key) ||
       retrieve_from_status_page
   end
 
   def retrieve_from_status_page
     status = page_summary['page']['status']
 
-    $redis.set(redis_cached_key, status, ex: 5.minutes.to_i)
+    redis.set(redis_cached_key, status, ex: 5.minutes.to_i)
 
     status
   end
@@ -47,5 +47,9 @@ class StatusPage
 
   def redis_cached_key
     'status_page_current_status'
+  end
+
+  def redis
+    @redis ||= Redis.new(host: 'localhost', post: 6379, db: 0)
   end
 end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,1 @@
+$redis = Redis.new(host: 'localhost', post: 6379, db: 0)

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,1 +1,0 @@
-$redis = Redis.new(host: 'localhost', post: 6379, db: 0)

--- a/spec/services/status_page_spec.rb
+++ b/spec/services/status_page_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe StatusPage, type: :service do
     let(:status) { 'UP' }
 
     before do
-      Redis.current.del('status_page_current_status')
+      $redis.del('status_page_current_status')
       stubbed_request
     end
 
@@ -30,13 +30,13 @@ RSpec.describe StatusPage, type: :service do
       it 'stores value in redis' do
         expect {
           retrieve_current_status
-        }.to change { Redis.current.get('status_page_current_status') }.to('UP')
+        }.to change { $redis.get('status_page_current_status') }.to('UP')
       end
 
       it 'sets a ttl of 5 minutes on redis key' do
         retrieve_current_status
 
-        expect(Redis.current.ttl('status_page_current_status')).to be_within(5.seconds.to_i).of(5.minutes.to_i)
+        expect($redis.ttl('status_page_current_status')).to be_within(5.seconds.to_i).of(5.minutes.to_i)
       end
 
       context 'when Instatus works' do
@@ -70,7 +70,7 @@ RSpec.describe StatusPage, type: :service do
 
     context 'with cache set' do
       before do
-        Redis.current.set('status_page_current_status', status)
+        $redis.set('status_page_current_status', status)
       end
 
       it 'does not call Instatus' do

--- a/spec/services/status_page_spec.rb
+++ b/spec/services/status_page_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe StatusPage, type: :service do
         }.to_json
       )
     end
+    let(:redis) { Redis.new(host: 'localhost', post: 6379, db: 0) }
     let(:status) { 'UP' }
 
     before do
-      $redis.del('status_page_current_status')
+      redis.del('status_page_current_status')
       stubbed_request
     end
 
@@ -30,13 +31,13 @@ RSpec.describe StatusPage, type: :service do
       it 'stores value in redis' do
         expect {
           retrieve_current_status
-        }.to change { $redis.get('status_page_current_status') }.to('UP')
+        }.to change { redis.get('status_page_current_status') }.to('UP')
       end
 
       it 'sets a ttl of 5 minutes on redis key' do
         retrieve_current_status
 
-        expect($redis.ttl('status_page_current_status')).to be_within(5.seconds.to_i).of(5.minutes.to_i)
+        expect(redis.ttl('status_page_current_status')).to be_within(5.seconds.to_i).of(5.minutes.to_i)
       end
 
       context 'when Instatus works' do
@@ -70,7 +71,7 @@ RSpec.describe StatusPage, type: :service do
 
     context 'with cache set' do
       before do
-        $redis.set('status_page_current_status', status)
+        redis.set('status_page_current_status', status)
       end
 
       it 'does not call Instatus' do

--- a/spec/services/status_page_spec.rb
+++ b/spec/services/status_page_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe StatusPage, type: :service do
         }.to_json
       )
     end
-    let(:redis) { Redis.new(host: 'localhost', post: 6379, db: 0) }
+    let(:redis) { described_class.new.send(:redis) }
     let(:status) { 'UP' }
 
     before do


### PR DESCRIPTION
Redis.current est deprecated et sera supprimé bientôt (et les messages d'alerte sont relous)

A la place je propose une global var dans les initializers (on fait déjà ça pour ElasticSearch). C'est pas le plus propre mais AFAIK ça devrait rien changer de l'actuel.

Attention j'ai zéro experience avec Redis donc reviewez prudemment...