### PR TITLE
Message d'alerte de transmission du jeton plus explicite

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -131,10 +131,10 @@ fr:
         blacklist: Blacklister
       magic_link:
         title: Transférer le jeton d'accès
-        description: Votre clé d'accès est unique et privée. L'utilisation de cette fonctionnalité a pour unique objectif la transmission sécurisée de votre jeton d'accès aux services techniques qui intégreront l'API Entreprise.
+        description: Votre clé d'accès est privée et vous en êtes responsable au titre des engagements pris lors de la signature de nos <a href="https://entreprise.api.gouv.fr/cgu/">CGU</a>, notamment le fait de ne pas divulguer les accès à des tiers non-habilités. L'utilisation de la fonctionnalité "Transmettre le jeton" a pour objectif de sécuriser l'envoi de votre jeton d'accès aux services techniques qui intègreront l'API Entreprise.
           <br />
           <br />
-          Le renouvellement d’un jeton est très facile et rapide. C’est pourquoi, si vous avez divulgué votre jeton par erreur, n’hésitez pas à écrire rapidement à <a href="mailto:support@entreprise.api.gouv.fr">support@entreprise.api.gouv.fr</a>.
+          Si vous avez divulgué votre jeton par erreur, le renouvellement d’un jeton est très facile et rapide. Écrivez rapidement à <a href="mailto:support@entreprise.api.gouv.fr">support@entreprise.api.gouv.fr</a>.
           <br />
           <br />
           Adresse e-mail à laquelle un lien d'accès au jeton, d'une durée de 4 heures, sera envoyé.


### PR DESCRIPTION
Ajoute notamment une référence aux CGU et un lien.
Cette PR fait suite au changement de libellé du bouton : https://github.com/etalab/admin_api_entreprise/pull/321#event-6068116965
