### PR TITLE
Regen binstubs

### DIFF
--- a/bin/rails
+++ b/bin/rails
@@ -1,9 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 load File.expand_path("spring", __dir__)
 APP_PATH = File.expand_path('../config/application', __dir__)
 require_relative "../config/boot"

--- a/bin/rake
+++ b/bin/rake
@@ -1,9 +1,4 @@
 #!/usr/bin/env ruby
-begin
-  load File.expand_path('../spring', __FILE__)
-rescue LoadError => e
-  raise unless e.message.include?('spring')
-end
 load File.expand_path("spring", __dir__)
 require_relative "../config/boot"
 require "rake"

--- a/bin/spring
+++ b/bin/spring
@@ -1,17 +1,14 @@
 #!/usr/bin/env ruby
+if !defined?(Spring) && [nil, "development", "test"].include?(ENV["RAILS_ENV"])
+  gem "bundler"
+  require "bundler"
 
-# This file loads Spring without using Bundler, in order to be fast.
-# It gets overwritten when you run the `spring binstub` command.
-
-unless defined?(Spring)
-  require 'rubygems'
-  require 'bundler'
-
-  lockfile = Bundler::LockfileParser.new(Bundler.default_lockfile.read)
-  spring = lockfile.specs.detect { |spec| spec.name == 'spring' }
-  if spring
+  # Load Spring without loading other gems in the Gemfile, for speed.
+  Bundler.locked_gems&.specs&.find { |spec| spec.name == "spring" }&.tap do |spring|
     Gem.use_paths Gem.dir, Bundler.bundle_path.to_s, *Gem.path
-    gem 'spring', spring.version
-    require 'spring/binstub'
+    gem "spring", spring.version
+    require "spring/binstub"
+  rescue Gem::LoadError
+    # Ignore when Spring is not installed.
   end
 end


### PR DESCRIPTION
For some reason can't deploy on watchdoge host anymore, I just regenerated binstubs as recommended by the error message...

```
Deploy to sandbox
 !     :environment is DEPRECATED! Please use local_environment and remote_environment
-----> Loading rbenv
       Beginning in Rails 4, Rails ships with a `rails` binstub at ./bin/rails that
       should be used instead of the Bundler-generated `rails` binstub.

       If you are seeing this message, your binstub at ./bin/rails was generated by
       Bundler instead of Rails.

       You might need to regenerate your `rails` binstub locally and add it to source
       control:

        rails app:update:bin           # Bear in mind this generates other binstubs
                                       # too that you may or may not want (like yarn)

       If you already have Rails binstubs in source control, you might be
       inadvertently overwriting them during deployment by using bundle install
       with the --binstubs option.

       If your application was created prior to Rails 4, here's how to upgrade:

         bundle config --delete bin    # Turn off Bundler's stub generator
         rails app:update:bin          # Use the new Rails executables
         git add bin                   # Add bin/ to source control

       You may need to remove bin/ from your .gitignore as well.

       When you install a gem whose executable you want to use in your app,
       generate it and add it to source control:

         bundle binstubs some-gem-name
         git add bin/new-executable

       rails aborted!
```