### PR TITLE
Feature/token separation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -62,6 +62,10 @@ Metrics/BlockLength:
     - "get"
     - "response"
 
+Metrics/ClassLength:
+  Exclude:
+    - "app/lib/seeds.rb"
+
 Naming/MethodParameterName:
   AllowedNames:
     - "_"

--- a/app/models/jwt_api_entreprise.rb
+++ b/app/models/jwt_api_entreprise.rb
@@ -31,6 +31,10 @@ class JwtAPIEntreprise < ApplicationRecord
     roles.pluck(:code)
   end
 
+  def expired?
+    exp < Time.zone.now.to_i
+  end
+
   def renewal_url
     "#{Rails.configuration.jwt_renewal_url}#{authorization_request.external_id}"
   end

--- a/app/views/authorization_requests/index.html.erb
+++ b/app/views/authorization_requests/index.html.erb
@@ -42,7 +42,11 @@
 
             <td>
               <% if token = authorization_request.jwt_api_entreprise %>
-                <% if token.archived? %>
+                <% if token.expired? %>
+                  <%= link_to t('.table.token.expired'), token_path(token), class: %w(fr-tag fr-tag--sm fr-tag--purple-glycine fr-fi-arrow-right-line), data: { turbo_frame: '_top' } %>
+                <% elsif token.blacklisted? %>
+                  <%= link_to t('.table.token.blacklisted'), token_path(token), class: %w(fr-tag fr-tag--sm fr-tag--purple-glycine fr-fi-arrow-right-line), data: { turbo_frame: '_top' } %>
+                <% elsif token.archived? %>
                   <%= link_to t('.table.token.archived'), token_path(token), class: %w(fr-tag fr-tag--sm fr-fi-arrow-right-line), data: { turbo_frame: '_top' } %>
                 <% else %>
                   <%= link_to t('.table.token.active'), token_path(token), class: %w(fr-tag fr-tag--sm fr-tag--green-emeraude fr-fi-arrow-right-line), data: { turbo_frame: '_top' } %>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -186,7 +186,7 @@ fr:
         token:
           archived: "Jeton archivé"
           active: "Jeton actif"
-
+          expired: "Jeton expiré"
 
   restricted_token_magic_links:
     create:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -184,9 +184,10 @@ fr:
           validated: "Demande validée ✅"
           refused: "Demande refusée ❌"
         token:
-          archived: "Jeton archivé"
           active: "Jeton actif"
+          archived: "Jeton archivé"
           expired: "Jeton expiré"
+          blacklisted: "Jeton désactivé"
 
   restricted_token_magic_links:
     create:

--- a/spec/features/user_tokens_spec.rb
+++ b/spec/features/user_tokens_spec.rb
@@ -34,6 +34,13 @@ RSpec.describe 'User JWT listing', type: :feature do
       expect(page).not_to have_css("input[value='#{blacklisted_jwt.rehash}']")
     end
 
+    it 'does not display expired tokens' do
+      expired_jwt = create(:jwt_api_entreprise, exp: 1.day.ago, user:)
+      jwt_index
+
+      expect(page).not_to have_css("input[value='#{expired_jwt.rehash}']")
+    end
+
     it 'has no button to archive tokens' do
       jwt_index
 

--- a/spec/models/jwt_api_entreprise_spec.rb
+++ b/spec/models/jwt_api_entreprise_spec.rb
@@ -182,6 +182,24 @@ RSpec.describe JwtAPIEntreprise, type: :model do
     end
   end
 
+  describe '#expired?' do
+    context 'when not expired' do
+      let(:token) { create(:jwt_api_entreprise, exp: 1.day.from_now) }
+
+      it 'returns false' do
+        expect(token).not_to be_expired
+      end
+    end
+
+    context 'when expired' do
+      let(:token) { create(:jwt_api_entreprise, exp: 1.day.ago) }
+
+      it 'returns true' do
+        expect(token).to be_expired
+      end
+    end
+  end
+
   describe 'external URLs to DataPass' do
     let(:external_id) { jwt.authorization_request.external_id }
 


### PR DESCRIPTION
Fait :

- Ajouté + de seeds pour bien test les cas existants
- Modifié les tags des jetons depuis la vue authorization_requests (cf screen) pour bien différencier les actifs des autres
- Ajouté un test pour vérifier que les users ne voient pas les jetons inactifs dans leur page de jetons actifs

Pas fait :

- Réparé le bug où on voit les jetons expirés en tant que jetons actifs sur la vue admin car on va drop la vue admin

![image](https://user-images.githubusercontent.com/14159757/162193739-0c623e13-08b8-4018-9e84-04a8f21a4e78.png)
