### PR TITLE
Change le label de la demande Datapass dans le dashboard

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -117,7 +117,7 @@ fr:
     jwt_api_entreprise:
       title: "Cadre d'utilisation : %{intitule}"
       links:
-        datapass: Demande d'accès intiale (N° %{id})
+        datapass: Demande d'accès initiale (N° %{id})
         stats: Voir les statistiques
         contacts: Contacts
       delivered_at: "Délivré le : %{humanized_date}"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -117,7 +117,7 @@ fr:
     jwt_api_entreprise:
       title: "Cadre d'utilisation : %{intitule}"
       links:
-        datapass: Demande DataPass N° %{id}
+        datapass: Demande d'accès intiale (N° %{id})
         stats: Voir les statistiques
         contacts: Contacts
       delivered_at: "Délivré le : %{humanized_date}"


### PR DESCRIPTION
Parler de demande initiale ou d'habilitation plutôt que Datapass qui est un terme interne.