### PR TITLE
Relecture des fiches métiers ajoutée dans lindex v3

### DIFF
--- a/config/endpoints/10_dgfip_chiffres_affaires.yml
+++ b/config/endpoints/10_dgfip_chiffres_affaires.yml
@@ -9,7 +9,7 @@
     Seuls les trois derniers exercices sont renvoyés.
     \n
     Ceux-ci ne sont pas forcément les exercices des trois dernières années car il peut y avoir plusieurs exercices dans une même année. Le nombre d’exercices renvoyés varie de 1 à 3.
-    Les exercices renvoyés sont listés les uns après les autres, le premier étant le plus récent.
+    Les exercices renvoyés sont listés les uns après les autres, le premier étant le plus récent des trois.
     \n
     \n
     Pour chaque exercice, le chiffre d’affaire en euros et la date de fin de l’exercice sont transmis.
@@ -19,7 +19,7 @@
     \n
     \n
     Sont disponibles uniquement les chiffres d&apos;affaires des **entreprises qui
-vérifient les deux conditions** suivantes&nbps;:
+vérifient les deux conditions** suivantes&nbsp;:
     \n
     \n
     - ✅ être **soumises à l&apos;impôt sur les sociétés** selon les règles des régimes d&apos;imposition réels, normal ou simplifié ;
@@ -27,10 +27,10 @@ vérifient les deux conditions** suivantes&nbps;:
     - ✅ avoir **transmis ses comptes annuels** aux greffes.
     \n
     \n
-    Les micro-entrepreneurs ne sont pas soumis à l&apos;IS mais à l&apos;IR ; leurs chiffres d&apos;affaires ne sont donc pas disponibles via API Entreprise."
+    ❌ Les micro-entrepreneurs ne sont pas soumis à l&apos;IS mais à l&apos;IR ; leurs chiffres d&apos;affaires ne sont donc pas disponibles via API Entreprise."
     entities:
       - entreprises
-  call_id: "SIRET"
+  call_id: "SIREN"
   providers:
     - 'dgfip'
   opening: protected
@@ -38,7 +38,7 @@ vérifient les deux conditions** suivantes&nbps;:
     - Aides publiques
     - Marchés publics
   parameters:
-    - Numéro de SIRET de l&apos;établissement
+    - Numéro de SIREN de l'entreprise
   faq:
     - q: "Quelle est la définition du chiffre d&apos;affaires transmis ?"
       a: "###### Le cas du régime réel normal

--- a/config/endpoints/13_dgfip_liasses_fiscales.yml
+++ b/config/endpoints/13_dgfip_liasses_fiscales.yml
@@ -3,23 +3,20 @@
   path: '/v3/dgfip/liasses_fiscales/declarations/{year}/{siren}'
   position: 240
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
-    Cette API délivre la liste des différentes conventions de l’établissement.
-    Les caractéristiques suivantes sont données&nbsp;:
+    Cette API délivre les liasses fiscales d&apos;une entreprise pour l'année renseignée. Pour chaque liasse fiscale, les informations suivantes sont transmises&nbsp;:
     \n
     \n
-    - le titre et le titre court de la convention ;
+    - Les règles d'imposition applicables à l'entreprise&nbsp;; 
     \n
-    - l’état en vigueur étendu ou non de la convention ;
+    - Des informations sur le formulaire complêté par l'entreprise&nbsp;, à l'origine des données transmises;
     \n
-    - son identifiant IDCC, numéro à 4 chiffres ;
-    \n
-    - l’URL Légifrance du texte en vigueur.
+    - Les données.
     \n
     \n
-    **Établissements concernés&nbsp;:**
+    ###### Établissements concernés&nbsp;:
     \n
     \n
     Cette API délivre les liasses fiscales des entreprises&nbsp;:
@@ -35,15 +32,15 @@
     - ✅ aux bénéfices agricoles (BA)*.
     \n
     \n
-    *selon les règles des régimes réels normal ou simplifié.
+    *selon les règles des régimes réels, normal ou simplifié.
     \n
     \n
-    ℹ️ Les entreprises anciennement aux forfaits BIC/BNC/BA , désormais ❌ régimes micro-BIC, micro-BNC 
-et micro-BA ne déposent pas de déclaration de résultat mais des éléments spécifiques dans la déclaration 2042C
- qui relève de d’impôt sur le revenu et ne sont donc pas dans le périmètre de cet endpoint.
+    ❌ Les entreprises anciennement aux forfaits BIC/BNC/BA, désormais régimes micro-BIC, micro-BNC 
+et micro-BA ne déposent pas de déclarations de résultat mais des éléments spécifiques dans la déclaration 2042C
+qui relève de d’impôt sur le revenu et ne sont donc pas dans le périmètre de cette API.
     \n
     \n
-    **Fraicheur de la donnée&nbsp;:**
+    ###### Fraicheur de la donnée&nbsp;:
     \n
     \n
     Les déclarations de résultat sont disponibles à compter du lendemain de la date de dépôt (J+1) 
@@ -54,7 +51,7 @@ et trois jours plus tard (J+3) si le dépôt intervient une veille de week-end.
 qui clôturent à la fin de l’année civile.
     \n
     \n
-    En cas d’exercice à cheval, la date limite de dépôt est positionnée exactement 3 mois après la date de clôture de l’exercice déclaré."
+    En cas d’exercice à cheval, la date limite de dépôt est positionnée exactement trois mois après la date de clôture de l’exercice déclaré."
     entities:
       - entreprises
   call_id: "SIREN"
@@ -64,7 +61,7 @@ qui clôturent à la fin de l’année civile.
   use_cases:
     - Détection de la fraude
   parameters:
-    - Numéro de SIREN de l&apos;entreprise
+    - Numéro de SIREN de l'entreprise
   faq:  
     - q: "Comment distinguer l&apos;imprimé rectificatif de l&apos;initial ?"
       a: "Il peut arriver que pour un même exercice il y ait plusieurs fois le même imprimé&nbps;; 

--- a/config/endpoints/14_dgfip_attestation_fiscale.yml
+++ b/config/endpoints/14_dgfip_attestation_fiscale.yml
@@ -6,7 +6,11 @@
     description: "###### Type de données&nbsp;:
     \n
     \n
-    Cette API délivre l&apos;attestation de régularité fiscale au format PDF. 
+    Cette API délivre l&apos;attestation de régularité fiscale d'une entreprise, au format PDF.
+    \n
+    \n
+    L'attestation est délivrée si l'entreprise est en règle de ses obligations déclaratives et de paiement d&apos;IS et de TVA.
+    Les sociétés bénéficiant d’un plan de règlement, redressement, sauvegarde ou conciliation ainsi que les sociétés ayant formulé un recours contentieux assorti d’un sursis de paiement ne peuvent pas se voir délivrer une attestation fiscale.
     \n
     \n
     ###### Entreprises concernées&nbsp;:
@@ -38,14 +42,7 @@
     > \n
     > Une attestation peut être renvoyée en cas d'appel d&apos;une entreprise \"fille\", mais cette attestation ne sera pas valable car incomplète. En effet, il manquera les informations de la société \"mère\".
     > Il est de votre ressort de vérifier si l&apos;entreprise est membre ou non d&apos;un groupe de sociétés imposé selon le régime fiscal d&apos;intégration visé à l&apos;[article 223 A du CGI](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042340402/).
-    > afin de ne pas utiliser une attestation qui ne serait pas valable. Deux API spécifiques à ces sociétés seront bientôt disponibles.
-    \n
-    \n
-    ###### Conditions de délivrance de l&apos;attestation :
-    \n
-    \n
-    L&apos;attestation est délivrée si les obligations déclaratives et de paiement d&apos;IS et de TVA de la société sont en règle.
-    Les sociétés bénéficiant d’un plan de règlement, redressement, sauvegarde ou conciliation ainsi que les sociétés ayant formulé un recours contentieux assorti d’un sursis de paiement ne peuvent pas se voir délivrer une attestation fiscale."
+    > afin de ne pas utiliser une attestation qui ne serait pas valable. Deux API spécifiques à ces sociétés seront bientôt disponibles."
     entities:
       - entreprises
   call_id: "SIREN"

--- a/config/endpoints/14_dgfip_attestation_fiscale.yml
+++ b/config/endpoints/14_dgfip_attestation_fiscale.yml
@@ -4,14 +4,7 @@
   path: '/v3/dgfip/attestations_fiscales/{siren}'
   perimeter:
     description: "
-    **Entreprises concernées :**
-    \n
-    \n
-    Cette API ne concerne pas **❌ les sociétés \"filles\" appartenant à un groupe de société**.
-    \n
-    ⚠️ Une attestation pourrait toutefois être renvoyée si vous utilisez le SIREN d&apos;une entreprise \"fille\". Cette attestation ne sera pas valable car incomplète ; en effet, il manquera les informations concernant la société \"mère\".
-    Il est de votre ressort de vérifier si l&apos;entreprise est membre ou non d&apos;un groupe de sociétés imposé selon le régime fiscal d&apos;intégration visé à l&apos;[article 223 A du CGI](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042340402/).
-    afin de ne pas utiliser une attestation qui ne serait pas valable. Deux API spécifiques à ces sociétés seront bientôt disponibles.
+    ###### Entreprises concernées&nbsp;:
     \n
     \n
     L&apos;attestation de régularité fiscale est **limitée aux ✅ entreprises soumises 
@@ -35,11 +28,19 @@
     * ❌ groupements passibles de l&apos;impôt sur le revenu (entrepreneurs individuels).
     \n
     \n
-    **Conditions de délivrance de l&apos;attestation :**
+    {:.fr-highlight--caution}
+    > ** ⚠️ Cette API n'est pas fiable pour ❌ les sociétés \"filles\" appartenant à un groupe de société**.
+    > \n
+    > Une attestation peut être renvoyée en cas d'appel d&apos;une entreprise \"fille\", mais cette attestation ne sera pas valable car incomplète. En effet, il manquera les informations de la société \"mère\".
+    > Il est de votre ressort de vérifier si l&apos;entreprise est membre ou non d&apos;un groupe de sociétés imposé selon le régime fiscal d&apos;intégration visé à l&apos;[article 223 A du CGI](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000042340402/).
+    > afin de ne pas utiliser une attestation qui ne serait pas valable. Deux API spécifiques à ces sociétés seront bientôt disponibles.
+    \n
+    \n
+    ###### Conditions de délivrance de l&apos;attestation :
     \n
     \n
     L&apos;attestation est délivrée si les obligations déclaratives et de paiement d&apos;IS et de TVA de la société sont en règle.
-    Ainsi, les sociétés bénéficiant d’un plan de règlement, redressement, sauvegarde ou conciliation ainsi que les sociétés ayant formulé un recours contentieux assorti d’un sursis de paiement ne peuvent pas se voir délivrer une attestation fiscale."
+    Les sociétés bénéficiant d’un plan de règlement, redressement, sauvegarde ou conciliation ainsi que les sociétés ayant formulé un recours contentieux assorti d’un sursis de paiement ne peuvent pas se voir délivrer une attestation fiscale."
     entities:
       - entreprises
   call_id: "SIREN"
@@ -47,11 +48,11 @@
   providers:
     - 'dgfip'
   use_cases:
-    - Aides publiques
     - Marchés publics
+    - Aides publiques
     - Détection de la fraude
   parameters:
-    - Numéro de SIREN de la personne morale recherchée
+    - Numéro de SIREN de l'entreprise
   faq:
     - q: "Quelles obligations fiscales sont prises en compte ?" 
       a: "L&apos;attestation concerne seulement :

--- a/config/endpoints/14_dgfip_attestation_fiscale.yml
+++ b/config/endpoints/14_dgfip_attestation_fiscale.yml
@@ -3,7 +3,12 @@
   position: 250
   path: '/v3/dgfip/attestations_fiscales/{siren}'
   perimeter:
-    description: "
+    description: "###### Type de données&nbsp;:
+    \n
+    \n
+    Cette API délivre l&apos;attestation de régularité fiscale au format PDF. 
+    \n
+    \n
     ###### Entreprises concernées&nbsp;:
     \n
     \n

--- a/config/endpoints/15_urssaf_attestation_sociale.yml
+++ b/config/endpoints/15_urssaf_attestation_sociale.yml
@@ -6,16 +6,7 @@
     description: "###### Type de données&nbsp;:
     \n
     \n
-    Cette API délivre l&apos;attestation de vigileance au format PDF. 
-    \n
-    \n
-    ###### Entreprises concernées&nbsp;:
-    \n
-    \n
-    ✅ Toutes les entreprises sont concernées, y compris les micro-entreprises.
-    \n
-    \n
-    ###### Conditions de délivrance de l&apos;attestation&nbsp;:
+    Cette API délivre l&apos;attestation de vigilance, au format PDF. 
     \n
     \n
     L&apos;attestation est délivrée si l&apos;entreprise&nbps;:
@@ -35,7 +26,13 @@
     \n
     {:.fr-highlight}
     > ℹ️ Depuis 2021, la contribution annuelle de l&apos;OETH (Obligation d&apos;Emploi de Travailleur Handicapé), fait partie des contribution dues pour obtenir l&apos;attestation.
-    > Cette compétence était auparavant attribuée à l&apos;AGEFIPH."
+    > Cette compétence était auparavant attribuée à l&apos;AGEFIPH.
+    \n
+    \n
+    ###### Entreprises concernées&nbsp;:
+    \n
+    \n
+    ✅ Toutes les entreprises sont concernées, y compris les micro-entreprises."
     entities:
       - entreprises
   opening: protected

--- a/config/endpoints/15_urssaf_attestation_sociale.yml
+++ b/config/endpoints/15_urssaf_attestation_sociale.yml
@@ -3,49 +3,56 @@
   position: 260
   path: '/v3/acoss/attestations_sociales/{siren}'
   perimeter:
-    description: "**Entreprises concernées&nbsp;:**
+    description: "###### Type de données&nbsp;:
+    \n
+    \n
+    Cette API délivre l&apos;attestation de vigileance au format PDF. 
+    \n
+    \n
+    ###### Entreprises concernées&nbsp;:
     \n
     \n
     ✅ Toutes les entreprises sont concernées, y compris les micro-entreprises.
     \n
     \n
-    **Conditions de délivrance de lattestation&nbsp;:**
+    ###### Conditions de délivrance de l&apos;attestation&nbsp;:
     \n
     \n
-    L’attestation est délivrée si l&apos;entreprise&nbps;:
+    L&apos;attestation est délivrée si l&apos;entreprise&nbps;:
     \n
     \n
-    * s’est acquitée des cotisations et contributions dues à leur date normale d’exigibilité ;
+    - s&apos;est acquitée des cotisations et contributions dues à leur date normale d&apos;exigibilité ;
     \n
-    * a souscrit un plan d’apurement des cotisations et contributions restant dues, qu’elle respecte ;
+    - a souscrit un plan d&apos;apurement (planification des remboursements) des cotisations et contributions restant dues, qu&apos;elle respecte ;
     \n
-    * s’est acquitée des cotisations et contributions dues, mais n’est pas à jour par ailleurs dans le paiement des majorations et pénalités ;
+    - s&apos;est acquitée des cotisations et contributions dues, mais n&apos;est pas à jour dans le paiement des majorations et pénalités ;
     \n
-    * ne s’est pas acquittée des cotisations et contributions dues mais en conteste le montant par recours contentieux.
-    \n
-    \n
-    Le cadre précis de délivrance de l’attestation est expliqué sur le [site de l’URSSAF](https://www.urssaf.fr/portail/home/employeur/declarer-et-payer/obtenir-une-attestation/attestation-de-vigilance.html).
+    - ne s&apos;est pas acquittée des cotisations et contributions dues mais en conteste le montant par recours contentieux.
     \n
     \n
-    ℹ️ Depuis 2021, la contribution annuelle de l’OETH (Obligation d’Emploi de Travailleur Handicapé), fait partie des contribution dues pour obtenir l&apos;attestation.
-Cette compétence était auparavant attribuée à l’AGEFIPH."
+    Le cadre précis de délivrance de l&apos;attestation est expliqué sur le [site de l&apos;URSSAF](https://www.urssaf.fr/portail/home/employeur/declarer-et-payer/obtenir-une-attestation/attestation-de-vigilance.html).
+    \n
+    \n
+    {:.fr-highlight}
+    > ℹ️ Depuis 2021, la contribution annuelle de l&apos;OETH (Obligation d&apos;Emploi de Travailleur Handicapé), fait partie des contribution dues pour obtenir l&apos;attestation.
+    > Cette compétence était auparavant attribuée à l&apos;AGEFIPH."
     entities:
       - entreprises
   opening: protected
   call_id: "SIREN"
   parameters:
-    - Numéro de SIREN de la personne physique ou morale recherchée
+    - Numéro de SIREN de l'entreprise
   use_cases:
-    - Aides publiques
     - Marchés publics
+    - Aides publiques
     - Détection de la fraude
   providers:
     - 'acoss'
   faq:
-    - q: "Combien de temps est valide l’attestation de vigilance ?"
-      a: "L’attestation de vigilance est valide 6 mois à compter de la dernière date de période analysée. Celle-ci dépend de la situation
+    - q: "Combien de temps est valide l&apos;attestation de vigilance ?"
+      a: "L&apos;attestation de vigilance est valide 6 mois à compter de la dernière date de période analysée. Celle-ci dépend de la situation
 de chaque entreprise et de la dernière déclaration enregistrée dans le système."
 
-    - q: "L’API ne renvoie pas de pièce, peut-on considérer que l&apos;entreprise n&apos;est pas à jour ?"
-      a: "Non, dans certain cas, l&apos;API ne peut pas délivrer l’attestation, cela ne signifie pas
-que l’entreprise n’est pas à jour."
+    - q: "L&apos;API ne renvoie pas de pièce, peut-on considérer que l&apos;entreprise n&apos;est pas à jour ?"
+      a: "Non, dans certain cas, l&apos;API ne peut pas délivrer l&apos;attestation, cela ne signifie pas
+que l&apos;entreprise n&apos;est pas à jour."

--- a/config/endpoints/16_msa_conformites_cotisations.yml
+++ b/config/endpoints/16_msa_conformites_cotisations.yml
@@ -3,25 +3,26 @@
   path: '/v3/msa/conformites_cotisations/{siret}'
   position: 270
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
-    La réponse indique si l&apos;entreprise est à jour de ses cotisations sociales auprès de la MSA. Il existe donc trois situations possibles pour une entreprise&nbps;:
+    Cette API indique si l&apos;entreprise est à jour de ses cotisations sociales auprès de la MSA. Il existe donc trois situations possibles pour une entreprise&nbsp;:
     \n
     \n
     - L&apos;entreprise est à jour de ses cotisations sociales auprès de la MSA ;
     \n
-    L&apos;entreprise n’est pas à jour de ses cotisations sociales ;
+    - L&apos;entreprise n’est pas à jour de ses cotisations sociales ;
     \n
-    La régularité de l&apos;entreprise est inconnue. Une analyse est à effectuer par un agent caisse de la MSA pour savoir si le débiteur est à jour ou pas. 
+    - La régularité de l&apos;entreprise est inconnue. Une analyse est à effectuer par un agent caisse de la MSA pour savoir si le débiteur est à jour ou pas. 
 Ce cas particulier intervient sur un laps de temps limité.
     \n
     \n
+    {:.fr-highlight}
     ℹ️ Depuis 2021, la conformité n&apos;est délivrée que si la contribution annuelle de l&apos;OETH (Obligation d’Emploi de Travailleur Handicapé) 
 a été acquittée par l&apos;entreprise. Cette compétence était auparavant attribuée à l&apos;AGEFIPH.
     \n
     \n
-    **Établissements concernés&nbsp;:**
+    ###### Établissements concernés&nbsp;:
     \n
     \n
     Sont éligibles à la MSA les entreprises de :
@@ -43,8 +44,8 @@ a été acquittée par l&apos;entreprise. Cette compétence était auparavant at
     - 'msa'
   opening: protected
   use_cases:
-    - Aides publiques
     - Marchés publics
+    - Aides publiques
     - Détection de la fraude
   parameters:
-    - Numéro de SIRET de l&apos;établissement
+    - Numéro de SIRET de l'établissement

--- a/config/endpoints/17_probtp_conformites_cotisations_retraite.yml
+++ b/config/endpoints/17_probtp_conformites_cotisations_retraite.yml
@@ -3,22 +3,16 @@
   path: '/v3/probtp/attestations_cotisations_retraite/{siret}'
   position: 280
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
-    TODO
+    Cette API délivre l&apos;attestation PROBTP au format PDF permettant de savoir si l&apos;entreprise est à jour de ses cotisations retraite à la Protection Sociale du Bâtiment et des Travaux publics (PROBTP).
     \n
     \n
-    **Établissements concernés&nbsp;:**
+    ###### Établissements concernés&nbsp;:
     \n
     \n
-    TODO
-    \n
-    \n
-    **Fraicheur de la donnée&nbsp;:**
-    \n
-    \n
-    TODO."
+    Entreprises du secteur du bâtiment et des travaux publics."
     entities:
       - entreprises
   call_id: "SIRET"
@@ -26,8 +20,8 @@
     - 'probtp'
   opening: protected
   use_cases:
-    - Aides publiques
     - Marchés publics
+    - Aides publiques
     - Détection de la fraude
   parameters:
-    - Numéro de SIRET de l&apos;établissement
+    - Numéro de SIRET de l'établissement

--- a/config/endpoints/18_fntp_cartes_pro_travaux_publics.yml
+++ b/config/endpoints/18_fntp_cartes_pro_travaux_publics.yml
@@ -10,7 +10,7 @@
 lorsque cette dernière est en règle de ses obligations sociales, administratives et juridiques.
     \n
     \n
-    **Établissements concernés&nbsp;:**
+    **Entreprises concernées&nbsp;:**
     \n
     \n
     Toutes les entreprises de travaux publics sont éligibles à demander une carte professionnelle à la FNTP.
@@ -27,4 +27,4 @@ lorsque cette dernière est en règle de ses obligations sociales, administrativ
   use_cases:
     - Marchés publics
   parameters:
-    - Numéro de SIREN de l&apos;entreprise
+    - Numéro de SIREN de l'entreprise

--- a/config/endpoints/19_cnetp_attestations_cotisations_conges_payes_chomage_intemperies.yml
+++ b/config/endpoints/19_cnetp_attestations_cotisations_conges_payes_chomage_intemperies.yml
@@ -3,18 +3,18 @@
   path: '/v3/cnetp/attestations_cotisations_conges_payes_chomage_intemperies/{siren}'
   position: 300
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
     Cette API permet d&apos;obtenir au format PDF une attestation délivrée à l&apos;entreprise sous réserve que celle-ci&nbsp;:
     \n
     \n
-    - soit à jour de ses déclarations exigibles servant à l&apos;assiette des cotisations de congés payés et des cotisations de chômage-intempéries ;
+    - soit à jour de ses déclarations de cotisations congés payés et chômage-intempéries ;
     \n
     - soit à jour du paiement des cotisations citées.
     \n
     \n
-    **Établissements concernés&nbsp;:**
+    ###### Établissements concernés&nbsp;:
     \n
     \n
     Cette API couvre l&apos;ensemble des entreprises exerçant une ou plusieurs activités entrant
@@ -32,16 +32,16 @@ dans le champ d&apos;application des conventions collectives nationales étendue
 ❌ sauf pour celles qui règlent les cotisations dues à la CNETP à l’URSSAF dans le cadre du Titre Emploi Service Entreprise (TESE).
     \n
     \n
-    **Pour en savoir plus sur les entreprises concernées&nbsp;:**
+    ###### Pour en savoir plus sur les entreprises concernées&nbsp;:
     \n
     \n
     - le [site de la CNETP](https://www.cnetp.org/category/affiliation/}{:target=\"_blank\"}) est une source d&apos;information ;
     \n
     - l&apos;[article D.3141-12 du code du travail](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000020572124/}{:target=\"_blank\"})
 définit les entreprises qui sont tenues d’adhérer auprès d&apos;une Caisse de Congés Payés du BTP&nbsp;:
-&laquo;Dans les entreprises exerçant une ou plusieurs activités entrant dans le champ d&apos;application des conventions collectives
+&laquo;_Dans les entreprises exerçant une ou plusieurs activités entrant dans le champ d&apos;application des conventions collectives
 nationales étendues du bâtiment et des travaux publics, le service des congés est assuré, sur la base de celles-ci, par des
-caisses constituées à cet effet.&raquo;"
+caisses constituées à cet effet._&raquo;"
     entities:
       - entreprises
   call_id: "SIREN"
@@ -49,11 +49,11 @@ caisses constituées à cet effet.&raquo;"
     - 'cnetp'
   opening: protected
   use_cases:
-    - Aides publiques
     - Marchés publics
+    - Aides publiques
     - Détection de la fraude
   parameters:
-    - Numéro de SIREN de l&apos;entreprise
+    - Numéro de SIREN de l'entreprise
   faq:
     - q: "L&apos;api ne renvoie pas de pièce, peut-on considérer que l&apos;entreprise n&apos;est pas à jour ?"
       a: "Non, dans certains cas nous ne pouvons pas récupérer l’attestation.

--- a/config/endpoints/1_insee_unites_legales.yml
+++ b/config/endpoints/1_insee_unites_legales.yml
@@ -68,7 +68,7 @@
   opening: protected
   call_id: &insee_unites_legales_call_id SIREN
   parameters: &insee_unites_legales_parameters
-    - Numéro de SIREN de l&apos;unité légale
+    - Numéro de SIREN de l'unité légale
   use_cases: &insee_unites_legales_use_cases
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/1_insee_unites_legales.yml
+++ b/config/endpoints/1_insee_unites_legales.yml
@@ -3,7 +3,7 @@
   path: '/v3/insee/sirene/unites_legales/{siren}'
   position: 105
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
     Cette API délivre les informations de référence des unités légales inscrites au répertoire Sirene, diffusibles ou \"non-diffusibles\".
@@ -19,7 +19,7 @@
     * les informations détaillées du siège social, appelables avec les API `unites_legales/diffusibles/:siren/siege_social` et `unites_legales/:siren/siege_social`.
     \n
     \n
-    **Entreprises/associations concernées&nbsp;:**
+    ###### Entreprises/associations concernées&nbsp;:
     \n
     \n
     Toutes les unités légales suivantes sont présentes&nbsp;:
@@ -43,7 +43,7 @@
     * ✅ Les organismes publics ou privés et les entreprises étrangères qui ont une représentation ou une activité en France.
     \n
     \n
-    **Périmètre géographique&nbsp;:**
+    ###### Périmètre géographique&nbsp;:
     \n
     \n
     La base Sirene concerne les unités implantées en métropole, dans les DOM et dans les collectivités d&apos;Outre-Mer de Saint-Pierre-et-Miquelon, Saint-Barthélémy et Saint-Martin.
@@ -52,13 +52,13 @@
     ⚠️ Pour la Nouvelle-Calédonie, la Polynésie française, et Wallis-et-Futuna, seul le secteur public administratif, de l&apos;État ou des communes est répertorié ; ❌ les entreprises ne sont donc pas disponibles.
     \n
     \n
-    **Fraicheur de la donnée&nbsp;:**
+    ###### Fraicheur de la donnée&nbsp;:
     \n
     \n
     La mise a jour des données est faite quotidiennement entre 0h et 3h à l&apos;INSEE.<br>
     \n
     \n
-    **Pour en savoir plus&nbsp;:**
+    ###### Pour en savoir plus&nbsp;:
     \n
     \n
     [Contexte juridique du Répertoire National d&apos;identification des entreprises et des établissements](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=134EFA0EE7BDCA89C2D6B31E02C48430.tplgfr30s_3?idSectionTA=LEGISCTA000006178890&cidTexte=LEGITEXT000005634379&dateTexte=20100904)"
@@ -70,9 +70,9 @@
   parameters: &insee_unites_legales_parameters
     - Numéro de SIREN de l&apos;unité légale
   use_cases: &insee_unites_legales_use_cases
-    - Aides publiques
     - Marchés publics
-    - Préremplissage d&apos;un formulaire
+    - Aides publiques
+    - Préremplissage d'un formulaire
     - Détection de la fraude
   providers: &insee_unites_legales_providers
     - 'insee'
@@ -133,7 +133,7 @@
   path: '/v3/insee/sirene/unites_legales/diffusibles/{siren}'
   position: 100
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "####### Type de données&nbsp;:
     \n
     \n
     Cette API délivre les informations de référence concernant les unités légales inscrites au répertoire Sirene et diffusibles commercialement.
@@ -151,7 +151,7 @@
     * les informations détaillées du siège social, appelables avec les API `unites_legales/diffusibles/:siren/siege_social` et `unites_legales/:siren/siege_social`.
     \n
     \n
-    **Entreprises/associations concernées&nbsp;:**
+    ###### Entreprises/associations concernées&nbsp;:
     \n
     \n
     * Uniquement les unités dîtes \"diffusibles\", c&apos;est-à-dire ayant donné leur accord pour que leurs informations soient publiques et utilisées à des fins commerciales.
@@ -175,7 +175,7 @@
     * ✅ Les organismes publics ou privés et les entreprises étrangères qui ont une représentation ou une activité en France.
     \n
     \n
-    **Périmètre géographique&nbsp;:**
+    ###### Périmètre géographique&nbsp;:
     \n
     \n
     La base Sirene concerne les unités implantées en métropole, dans les DOM et dans les collectivités d&apos;Outre-Mer de Saint-Pierre-et-Miquelon, Saint-Barthélémy et Saint-Martin.
@@ -184,13 +184,13 @@
     ⚠️ Pour la Nouvelle-Calédonie, la Polynésie française, et Wallis-et-Futuna, seul le secteur public administratif, de l&apos;État ou des communes est répertorié ; ❌ les entreprises ne sont donc pas disponibles.
     \n
     \n
-    **Fraicheur de la donnée&nbsp;:**
+    ###### Fraicheur de la donnée&nbsp;:
     \n
     \n
     La mise a jour des données est faite quotidiennement entre 0h et 3h à l&apos;INSEE.<br>
     \n
     \n
-    **Pour en savoir plus&nbsp;:**
+    ###### Pour en savoir plus&nbsp;:
     \n
     \n
     [Contexte juridique du Répertoire National d&apos;identification des entreprises et des établissements](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=134EFA0EE7BDCA89C2D6B31E02C48430.tplgfr30s_3?idSectionTA=LEGISCTA000006178890&cidTexte=LEGITEXT000005634379&dateTexte=20100904)"

--- a/config/endpoints/22_qualibat_certifications_batiment.yml
+++ b/config/endpoints/22_qualibat_certifications_batiment.yml
@@ -3,13 +3,13 @@
   path: '/v3/qualibat/certifications_batiment/{siret}'
   position: 330
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
     Cette API délivre le certificat Qualibat de l&apos;entreprise au format PDF, comportant de nombreuses informations.
     \n
     \n
-    #### Des informations sur l&apos;entreprise&nbsp;:
+    **Des informations sur l&apos;établissement&nbsp;:**
     \n
     \n
     - raison sociale ;
@@ -41,7 +41,7 @@
     - chiffre d&apos;affaires hors taxes.
     \n
     \n
-    #### Des informations sur la qualification&nbsp;:
+    **Des informations sur la qualification&nbsp;:**
     \n
     \n
     - code à quatre chiffre de la capacité technique reconnue à l&apos;entreprise dans une des 9 activités détaillées sur le [site Qualibat](https://www.qualibat.com/nomenclature/}{:target=\"_blank\"});
@@ -60,7 +60,7 @@
     la certification de son système qualité est mentionnée en annexe.
     \n
     \n
-    #### Des informations liées au certificat&nbsp;:
+    **Des informations liées au certificat&nbsp;:**
     \n
     \n
     - millésime ;
@@ -68,7 +68,13 @@
     - numéro d&apos;identification du certificat.
     \n
     \n
-    [Source : Qualibat](https://www.qualibat.com/){:target=\"_blank\"})"
+    [Source : Qualibat](https://www.qualibat.com/){:target=\"_blank\"})
+    \n
+    \n
+    ###### Entreprises concernées&nbsp;:
+    \n
+    \n
+    Toutes les entreprises et les artisans du bâtiment ayant le label de fiabilité Qualibat."
     entities:
       - associations
       - entreprises
@@ -79,4 +85,4 @@
   use_cases:
     - Marchés publics
   parameters:
-    - Numéro de SIRET de l&apos;établissement
+    - Numéro de SIRET de l'établissement

--- a/config/endpoints/24_inpi_brevets.yml
+++ b/config/endpoints/24_inpi_brevets.yml
@@ -3,10 +3,10 @@
   path: '/v3/inpi/brevets/{siren}'
   position: 350
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
-    Cette API délivre le nombre de brevets France et brevets Europe déposés par l&apos;entreprise, et pour lesquels le SIREN était précisé. 
+    Cette API délivre le nombre de brevets France et brevets Europe déposés par l&apos;entreprise, pour lesquels le SIREN était précisé dans le dépôt. 
 L&apos;INPI indique qu&apos;environ 80% des demandes de brevets publiées ces vingt dernières années sont rattachées à un SIREN.
     \n
     \n
@@ -30,4 +30,4 @@ L&apos;INPI indique qu&apos;environ 80% des demandes de brevets publiées ces vi
   use_cases:
     - Marchés publics
   parameters:
-    - Numéro de SIREN de l&apos;unité légale
+    - Numéro de SIREN de l'unité légale

--- a/config/endpoints/25_inpi_marques.yml
+++ b/config/endpoints/25_inpi_marques.yml
@@ -3,10 +3,10 @@
   path: '/v3/inpi/marques/{siren}'
   position: 360
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
-    Cette API délivre le nombre de marques déposées par l&apos;entreprise, et pour lesquelles le SIREN était précisé. 
+    Cette API délivre le nombre de marques déposées par l&apos;entreprise, et pour lesquelles le SIREN était précisé lors du dépôt. 
 L&apos;INPI indique qu&apos;environ 60% des dépôts de marques France effectués sont rattachés à un SIREN. 
 Les marques déposées au niveau européen ou international ne sont pas renvoyées par cette API car le taux de sirenage de ces dépôts est de 0%.
     \n
@@ -32,4 +32,4 @@ Les marques déposées au niveau européen ou international ne sont pas renvoyé
   use_cases:
     - Marchés publics
   parameters:
-    - Numéro de SIREN de l&apos;unité légale
+    - Numéro de SIREN de l'unité légale

--- a/config/endpoints/26_inpi_modeles.yml
+++ b/config/endpoints/26_inpi_modeles.yml
@@ -3,10 +3,10 @@
   path: '/v3/inpi/modeles/{siren}'
   position: 370
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
-    Cette API délivre le nombre de modèles déposés par l&apos;entreprise, et pour lesquels le SIREN était précisé. 
+    Cette API délivre le nombre de modèles déposés par l&apos;entreprise, pour lesquels le SIREN était précisé lors du dépôt. 
 L&apos;INPI indique qu&apos;environ 50% des dépôts de dessins & modèles France effectués sont rattachés à un SIREN. 
 Les modèles déposés au niveau international, à l&apos;OMPI, ne sont pas renvoyés par cette API car le taux de sirenage est de 0%.
     \n
@@ -31,4 +31,4 @@ Les modèles déposés au niveau international, à l&apos;OMPI, ne sont pas renv
   use_cases:
     - Marchés publics
   parameters:
-    - Numéro de SIREN de l&apos;unité légale
+    - Numéro de SIREN de l'unité légale

--- a/config/endpoints/2_infogreffe_mandataires_sociaux.yml
+++ b/config/endpoints/2_infogreffe_mandataires_sociaux.yml
@@ -3,24 +3,24 @@
   path: '/v3/infogreffe/mandataires_sociaux/{siren}'
   position: 110
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
     Cette API délivre tous les mandataires sociaux de l&apos;entreprise&nbsp;:
     \n
     \n
-    * S&apos;il s&apos;agit de personnes morales, le numéro de SIREN, la raison sociale et le nom du greffe seront précisés ;
+    * S&apos;il s&apos;agit de personnes morales : le numéro de SIREN, la raison sociale et le nom du greffe seront précisés ;
     \n
-    * S&apos;il s&apos;agit de personne physiques, le nom, le prénom, la date de naissance, ainsi que le lieu de naissance de la personne physique seront indiqués ;
+    * S&apos;il s&apos;agit de personnes physiques : le nom, le prénom, la date de naissance, ainsi que le lieu de naissance de la personne physique seront indiqués ;
     \n
     * La fonction du mandataire social au sein de l&apos;entreprise, par exemple, \"Président\" est également spécifiée.
     \n
     \n
-    **Entreprises concernées&nbsp;:**
+    ###### Entreprises concernées&nbsp;:
     \n
     \n
     Toutes les entreprises inscrites au registre du commerce et des sociétés (RCS) sont concernées.
-    Il s&apos;agit des entreprises ayant une activité commerciale, plus d&apos;informations à ce sujet sur [le site du ministère de l&apos;économie](https://www.economie.gouv.fr/entreprises/registre-commerce-societes-rcs)"
+    Il s&apos;agit des entreprises ayant une activité commerciale. Pour plus de détails, consulter [le site du ministère de l&apos;économie](https://www.economie.gouv.fr/entreprises/registre-commerce-societes-rcs)"
     entities:
       - entreprises
   call_id: "SIREN"
@@ -28,7 +28,7 @@
     - 'infogreffe'
   opening: protected
   use_cases:
-    - Aides publiques
     - Marchés publics
+    - Aides publiques
   parameters:
-    - Numéro de SIREN de l&apos;entreprise recherchée
+    - Numéro de SIREN de l'unité légale

--- a/config/endpoints/3_insee_adresse_etablissement.yml
+++ b/config/endpoints/3_insee_adresse_etablissement.yml
@@ -3,7 +3,7 @@
   position: 145
   path: '/v3/insee/sirene/etablissements/{siret}/adresse'
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
     Cette API délivre l&apos;adresse d&apos;un établissement, diffusible ou non-diffusible.
@@ -11,7 +11,7 @@
     ⚠️ Pour obtenir les informations générales d&apos;un établissement, utiliser l&apos;API `sirene/etablissements`.
     \n
     \n
-    **Établissements concernés&nbsp;:**
+    ###### Établissements concernés&nbsp;:
     \n
     \n
     Tous les établissements des unité légales suivantes sont disponibles&nbsp;:
@@ -35,7 +35,7 @@
     Leur diffusion à d&apos;autres administrations n&apos;est donc pas prévue.
     \n
     \n
-    **Périmètre géographique&nbsp;:**
+    ###### Périmètre géographique&nbsp;:
     \n
     \n
     La base Sirene concerne les établissements implantés en métropole, dans les DOM et dans les collectivités d&apos;Outre-Mer de Saint-Pierre-et-Miquelon, Saint-Barthélémy et Saint-Martin.
@@ -44,27 +44,27 @@
     ⚠️ Pour la Nouvelle-Calédonie, la Polynésie française, et Wallis-et-Futuna, seul le secteur public administratif, de l&apos;État ou des communes est répertorié ; ❌ les entreprises ne sont donc pas disponibles.
     \n
     \n
-    **Fraicheur de la donnée&nbsp;:**
+    ###### Fraicheur de la donnée&nbsp;:
     \n
     \n
     La mise a jour des données est faite quotidiennement entre 0h et 3h à l&apos;INSEE.<br>
     \n
     \n
-    **Pour en savoir plus&nbsp;:**
+    ###### Pour en savoir plus&nbsp;:
     \n
     \n
-    [Contexte juridique du Répertoire National d&apos;identification des entreprises et des établissements](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=134EFA0EE7BDCA89C2D6B31E02C48430.tplgfr30s_3?idSectionTA=LEGISCTA000006178890&cidTexte=LEGITEXT000005634379&dateTexte=20100904)"
+    [Contexte juridique du répertoire national d&apos;identification des entreprises et des établissements](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=134EFA0EE7BDCA89C2D6B31E02C48430.tplgfr30s_3?idSectionTA=LEGISCTA000006178890&cidTexte=LEGITEXT000005634379&dateTexte=20100904)"
     entities:
     - etablissements_entreprises
     - etablissements_associations
   opening: protected
   call_id: &insee_unites_legales_call_id SIRET
   parameters: &insee_unites_legales_parameters
-    - Numéro de SIRET de l&apos;établissement
+    - Numéro de SIRET de l'établissement
   use_cases: &insee_unites_legales_use_cases
     - Aides publiques
     - Marchés publics
-    - Préremplissage d&apos;un formulaire
+    - Préremplissage d'un formulaire
     - Détection de la fraude
   providers: &insee_unites_legales_providers
     - 'insee'
@@ -94,7 +94,7 @@
   position: 140
   path: '/v3/insee/sirene/etablissements/diffusibles/{siret}/adresse'
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
     Cette API délivre l&apos;adresse d&apos;un établissement, inscrits au répertoire Sirene et diffusibles commercialement.
@@ -106,7 +106,7 @@
     * les informations générales des établissements, appelables avec les API `/sirene/etablissements` et `/sirene/etablissements/diffusibles` ;
     \n
     \n
-    **Établissements concernés&nbsp;:**
+    ###### Établissements concernés&nbsp;:
     \n
     \n
     Les établissements des unités légales suivantes sont disponibles&nbsp;:
@@ -128,7 +128,7 @@
     * ❌ Les établissements des unités légales dîtes \"non-diffusibles\", c&apos;est-à-dire n&apos;ayant pas donné leur accord pour que leurs informations soient publiques et utilisées à des fins commerciales ne sont pas appelables par cette API.
     \n
     \n
-    **Périmètre géographique&nbsp;:**
+    ###### Périmètre géographique&nbsp;:
     \n
     \n
     La base Sirene concerne les établissements implantés en métropole, dans les DOM et dans les collectivités d&apos;Outre-Mer de Saint-Pierre-et-Miquelon, Saint-Barthélémy et Saint-Martin.
@@ -137,16 +137,16 @@
     ⚠️ Pour la Nouvelle-Calédonie, la Polynésie française, et Wallis-et-Futuna, seul le secteur public administratif, de l&apos;État ou des communes est répertorié ; ❌ les entreprises ne sont donc pas disponibles.
     \n
     \n
-    **Fraicheur de la donnée&nbsp;:**
+    ###### Fraicheur de la donnée&nbsp;:
     \n
     \n
     La mise a jour des données est faite quotidiennement entre 0h et 3h à l&apos;INSEE.<br>
     \n
     \n
-    **Pour en savoir plus&nbsp;:**
+    ###### Pour en savoir plus&nbsp;:
     \n
     \n
-    [Contexte juridique du Répertoire National d&apos;identification des entreprises et des établissements](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=134EFA0EE7BDCA89C2D6B31E02C48430.tplgfr30s_3?idSectionTA=LEGISCTA000006178890&cidTexte=LEGITEXT000005634379&dateTexte=20100904)"
+    [Contexte juridique du répertoire national d&apos;identification des entreprises et des établissements](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=134EFA0EE7BDCA89C2D6B31E02C48430.tplgfr30s_3?idSectionTA=LEGISCTA000006178890&cidTexte=LEGITEXT000005634379&dateTexte=20100904)"
     entities:
     - entreprises
     - associations

--- a/config/endpoints/3_insee_siege_social.yml
+++ b/config/endpoints/3_insee_siege_social.yml
@@ -3,7 +3,7 @@
   path: '/v3/insee/sirene/unites_legales/{siren}/siege'
   position: 135
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
     Cette API délivre les information générales d&apos;un siège social, dont l&apos;unité légale, diffusible ou \"non-diffusible\", est inscrite au répertoire Sirene.
@@ -11,10 +11,10 @@
     Pour obtenir l&apos;adresse du siège social, utiliser l&apos;API `sirene/etablissements/{siret}/adresse`.
     \n
     \n
-    **Établissements concernés&nbsp;:**
+    ###### Établissements concernés&nbsp;:
     \n
     \n
-    Tous les sièges sociaux des unité légales suivantes sont disponibles :
+    Tous les sièges sociaux des unité légales suivantes sont disponibles&nbsp;:
     \n
     * ✅ les sièges sociaux des personnes morales de droit privé (les entreprises). Toutes les entreprises immatriculées au registre du commerce et des sociétés (RCS) et au répertoire des métiers (RCM) figurent dans la base Sirene ;
     \n
@@ -35,7 +35,7 @@
     Leur diffusion à d&apos;autres administrations n&apos;est donc pas prévue.
     \n
     \n
-    **Périmètre géographique&nbsp;:**
+    ###### Périmètre géographique&nbsp;:
     \n
     \n
     La base Sirene concerne les unités légales implantées en métropole, dans les DOM et dans les collectivités d&apos;Outre-Mer de Saint-Pierre-et-Miquelon, Saint-Barthélémy et Saint-Martin.
@@ -44,13 +44,13 @@
     ⚠️ Pour la Nouvelle-Calédonie, la Polynésie française, et Wallis-et-Futuna, seul le secteur public administratif, de l&apos;État ou des communes est répertorié ; ❌ les entreprises ne sont donc pas disponibles.
     \n
     \n
-    **Fraicheur de la donnée&nbsp;:**
+    ###### Fraicheur de la donnée&nbsp;:
     \n
     \n
     La mise a jour des données est faite quotidiennement entre 0h et 3h à l&apos;INSEE.
     \n
     \n
-    **Pour en savoir plus&nbsp;:**
+    ###### Pour en savoir plus&nbsp;:
     \n
     \n
     [Contexte juridique du Répertoire National d&apos;identification des entreprises et des établissements](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=134EFA0EE7BDCA89C2D6B31E02C48430.tplgfr30s_3?idSectionTA=LEGISCTA000006178890&cidTexte=LEGITEXT000005634379&dateTexte=20100904)"
@@ -60,11 +60,11 @@
   opening: protected
   call_id: &insee_unites_legales_call_id SIRET
   parameters: &insee_unites_legales_parameters
-    - Numéro de SIREN de l&apos;unité légale
+    - Numéro de SIREN de l'unité légale
   use_cases: &insee_unites_legales_use_cases
-    - Aides publiques
     - Marchés publics
-    - Préremplissage d&apos;un formulaire
+    - Aides publiques
+    - Préremplissage d'un formulaire
     - Détection de la fraude
   providers: &insee_unites_legales_providers
     - 'insee'
@@ -103,7 +103,7 @@ même provisoirement, auprès de l&apos;INSEE à l&apos;adresse suivante : [http
   path: '/v3/insee/sirene/unites_legales/diffusibles/{siren}/siege'
   position: 130
   perimeter:
-    description: "**Type de données :**
+    description: "###### Type de données&nbsp;:
     \n
     \n
     Cette API délivre les information générales d&apos;un siège social, dont l&apos;unité légale est inscrite au répertoire Sirene et diffusible commercialement.
@@ -118,7 +118,7 @@ même provisoirement, auprès de l&apos;INSEE à l&apos;adresse suivante : [http
     * les adresses des sièges sociaux, appelables, avec le SIRET de l&apos;établissement, par l&apos;API `/sirene/etablissements/diffusibles/{siret}/adresse` ;
     \n
     \n
-    **Établissements concernés :**
+    ###### Établissements concernés&nbsp;:
     \n
     \n
     Les sièges sociaux des unités légales suivantes sont disponibles :
@@ -139,7 +139,7 @@ même provisoirement, auprès de l&apos;INSEE à l&apos;adresse suivante : [http
     \n
     * ❌ Les sièges sociaux des unités légales dîtes \"non-diffusibles\", c&apos;est à dire n&apos;ayant pas donné leur accord pour que leurs informations soient publiques et utilisées à des fins commerciales ne sont pas appelables par cette API.
     \n
-    **Périmètre géographique :**
+    ###### Périmètre géographique&nbsp;:
     \n
     \n
     La base Sirene concerne les unités légales implantées en métropole, dans les DOM et dans les collectivités d&apos;Outre-Mer de Saint-Pierre-et-Miquelon, Saint-Barthélémy et Saint-Martin.
@@ -148,13 +148,13 @@ même provisoirement, auprès de l&apos;INSEE à l&apos;adresse suivante : [http
     ⚠️ Pour la Nouvelle-Calédonie, la Polynésie française, et Wallis-et-Futuna, seul le secteur public administratif, de l&apos;État ou des communes est répertorié ; ❌ les entreprises ne sont donc pas disponibles.
     \n
     \n
-    **Fraicheur de la donnée :**
+    ###### Fraicheur de la donnée&nbsp;:
     \n
     \n
     La mise a jour des données est faite quotidiennement entre 0h et 3h à l&apos;INSEE.<br>
     \n
     \n
-    **Pour en savoir plus :**
+    ###### Pour en savoir plus&nbsp;:
     \n
     \n
     [Contexte juridique du Répertoire National d&apos;identification des entreprises et des établissements](https://www.legifrance.gouv.fr/affichCode.do;jsessionid=134EFA0EE7BDCA89C2D6B31E02C48430.tplgfr30s_3?idSectionTA=LEGISCTA000006178890&cidTexte=LEGITEXT000005634379&dateTexte=20100904)"

--- a/config/endpoints/4_ministere_interieur_rna.yml
+++ b/config/endpoints/4_ministere_interieur_rna.yml
@@ -7,7 +7,16 @@
     description: "**Type de données&nbsp;:**
     \n
     \n
-    Informations déclarées par l&apos;association en préfecture.
+    Informations déclarées par l&apos;association en Préfecture, entre autres&nbsp;:
+    \n
+    \n
+    - Titre de l'association, et description courte de ses activités ; 
+    \n
+    - Dates de dépôt du dossier de création de l'association à la Préfecture et date de publication au Journal Officiel si elle a eu lieu ;
+    \n
+    - Adresse du siège social ;
+    \n
+    - Informations sur les dirigeants.
     \n
     \n
     **Associations concernées&nbsp;:**
@@ -23,7 +32,7 @@
   use_cases:
     - Aides publiques
     - Marchés publics
-    - Préremplissage d&apos;un formulaire
+    - Préremplissage d'un formulaire
     - Détection de la fraude
   parameters:
     - Numéro de SIRET ou numéro RNA de l’association

--- a/config/endpoints/4_ministere_interieur_rna.yml
+++ b/config/endpoints/4_ministere_interieur_rna.yml
@@ -4,7 +4,7 @@
   # Position au sein de l'index
   position: 150
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
     Informations déclarées par l&apos;association en Préfecture, entre autres&nbsp;:
@@ -19,7 +19,7 @@
     - Informations sur les dirigeants.
     \n
     \n
-    **Associations concernées&nbsp;:**
+    ###### Associations concernées&nbsp;:
     \n
     \n
     Toutes les associations inscrites au répertoire national des associations (RNA)."
@@ -30,8 +30,8 @@
     - 'mi'
   opening: public
   use_cases:
-    - Aides publiques
     - Marchés publics
+    - Aides publiques
     - Préremplissage d'un formulaire
     - Détection de la fraude
   parameters:

--- a/config/endpoints/5_inpi_actes.yml
+++ b/config/endpoints/5_inpi_actes.yml
@@ -3,7 +3,7 @@
   path: '/v3/inpi/actes/{siren}'
   position: 160
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
     Tous les actes établis par les greffes depuis 1993 sont transmis. 
@@ -21,7 +21,7 @@ Ce qui représente environ 25 millions d’actes. Ces actes, fournis au format P
 Envoyez-nous votre demande détaillée en passant par le [support](https://entreprise.api.gouv.fr/support/}{:target=\"_blank\"})
     \n
     \n
-    **Fraicheur de la donnée&nbsp;:**
+    ###### Fraicheur de la donnée&nbsp;:
     \n
     \n
     Théoriquement, les actes sont transmis à l&apos;INPI par le greffe dans un délai de 24h."
@@ -33,9 +33,9 @@ Envoyez-nous votre demande détaillée en passant par le [support](https://entre
     - 'inpi'
   opening: public
   use_cases:
-    - Aides publiques
     - Marchés publics
+    - Aides publiques
     - Préremplissage d'un formulaire
     - Détection de la fraude
   parameters:
-    - Numéro de SIREN de la personne physique ou morale recherchée.
+    - Numéro de SIREN de l'unité légale.

--- a/config/endpoints/5_inpi_actes.yml
+++ b/config/endpoints/5_inpi_actes.yml
@@ -6,20 +6,25 @@
     description: "**Type de données&nbsp;:**
     \n
     \n
-    Tous les actes établis par les greffes depuis 1993 sont transmis par cet endpoint. 
-Ce qui représente environ 25 millions d’actes. Ces actes, fournis au format PDF, comportent : 
-- des informations générales ; 
-- des informations sur le capital social et sa répartition ; 
-- des informations sur les associés et tout ce qui est relatif à l’administration de la société.
+    Tous les actes établis par les greffes depuis 1993 sont transmis. 
+Ce qui représente environ 25 millions d’actes. Ces actes, fournis au format PDF, comportent&nbsp;: 
     \n
     \n
-    ℹ️ Dans le cas où un acte est manquant, l&apos;INPI peut essayer de numériser le document qui fait défaut.
+    - des informations générales, telles que la nature de l&apos;archive, la date de dépôt en greffe, et le code greffe  ; 
+    \n
+    - des informations sur le capital social et sa répartition ;
+    \n
+    - des informations sur les associés et tout ce qui est relatif à l’administration de la société.
+    \n
+    \n
+    ℹ️ Dans le cas où un acte est manquant, si celui-ci est postérieur à 1993, l&apos;INPI peut essayer de numériser le document qui fait défaut. 
+Envoyez-nous votre demande détaillée en passant par le [support](https://entreprise.api.gouv.fr/support/}{:target=\"_blank\"})
     \n
     \n
     **Fraicheur de la donnée&nbsp;:**
     \n
     \n
-    Théoriquement, les actes sont transmis à l’INPI par le greffe dans un délai de 24h."
+    Théoriquement, les actes sont transmis à l&apos;INPI par le greffe dans un délai de 24h."
     entities:
       - associations
       - entreprises
@@ -30,7 +35,7 @@ Ce qui représente environ 25 millions d’actes. Ces actes, fournis au format P
   use_cases:
     - Aides publiques
     - Marchés publics
-    - Préremplissage d&apos;un formulaire
+    - Préremplissage d'un formulaire
     - Détection de la fraude
   parameters:
     - Numéro de SIREN de la personne physique ou morale recherchée.

--- a/config/endpoints/6_fabnum_conventions_collectives.yml
+++ b/config/endpoints/6_fabnum_conventions_collectives.yml
@@ -7,14 +7,14 @@
     \n
     \n
     Cette API délivre la liste des différentes conventions de l&apos;établissement.
-    Les caractéristiques suivantes sont données&nbsp;:
+Les caractéristiques suivantes sont transmises&nbsp;:
     \n
     \n
-    - le titre et le titre court de la convention ;
+    - le titre, long et court de la convention ;
     \n
-    - l&apos;état en vigueur étendu ou non de la convention ;
+    - l&apos;état de la convention, étendu ou non, c'est-à-dire si la convention est applicable à tous les employeurs de la branche ou uniquement aux signataires ;
     \n
-    - son identifiant IDCC, numéro à 4 chiffres ;
+    - l&apos;identifiant IDCC, numéro à 4 chiffres ;
     \n
     - l&apos;URL Légifrance du texte en vigueur.
     \n
@@ -22,15 +22,15 @@
     **Établissements concernés&nbsp;:**
     \n
     \n
-    Les liens entre les établissements et les conventions collectives sont issues de la déclaration sociale nominative (DSN), le périmètre est donc restreint aux ✅ établissements ayant déclaré des salariés et ayant une convention.
+    Les liens entre les établissements et les conventions collectives sont issues de la déclaration sociale nominative (DSN), le périmètre est donc restreint aux ✅&nbsp;établissements ayant déclaré des salariés et ayant une convention.
     \n
-    ❌ Les sociétés unipersonnelles dont le gérant est assimilé salarié ne ressortent pas au travers de l&apos;API, même si la société en question est rattachée à une convention collective.
+    ❌ Les sociétés unipersonnelles dont le gérant est assimilé salarié ne sont pas concernées par cette API, même si la société en question est rattachée à une convention collective.
     \n
     \n
     **Fraicheur de la donnée&nbsp;:**
     \n
     \n
-    ⚠️ La fréquence de mise à jour d&apos;une des sources de données de cette API, le fichier fournie par la DARES, n’est pas précisée."
+    ⚠️ La fréquence de mise à jour du fichier fourni par la DARES (une des deux sources de cette API) n&apos;est pas précisée."
     entities:
       - associations
       - entreprises
@@ -39,14 +39,13 @@
     - 'fabsocial'
   opening: public
   use_cases:
-    - Aides publiques
     - Marchés publics
+    - Aides publiques
   parameters:
     - Numéro de SIRET de l&apos;établissement
   faq:
-    - q: "Quelles sont les sources des données de conventions collectives de de cette API ?"
-      a: "Cette API est fournie par la fabrique numérique des ministères sociaux
-      qui s&apos;appuie sur plusieurs sources de données&nbsp;:
+    - q: "Quelles sont les sources de données de cette API ?"
+      a: "Cette API est fournie par la fabrique numérique des ministères sociaux qui s&apos;appuie sur plusieurs sources de données&nbsp;:
       \n
       \n
       - les données d&apos;affiliation des établissements d&apos;entreprise aux conventions sont **issues de la [DARES](https://dares.travail-emploi.gouv.fr/}{:target=\"_blank\"})**,

--- a/config/endpoints/6_fabnum_conventions_collectives.yml
+++ b/config/endpoints/6_fabnum_conventions_collectives.yml
@@ -3,7 +3,7 @@
   path: '/v3/fabrique_numerique_ministeres_sociaux/conventions_collectives/{siret}'
   position: 170
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
     Cette API délivre la liste des différentes conventions de l&apos;établissement.
@@ -19,7 +19,7 @@ Les caractéristiques suivantes sont transmises&nbsp;:
     - l&apos;URL Légifrance du texte en vigueur.
     \n
     \n
-    **Établissements concernés&nbsp;:**
+    ###### Établissements concernés&nbsp;:
     \n
     \n
     Les liens entre les établissements et les conventions collectives sont issues de la déclaration sociale nominative (DSN), le périmètre est donc restreint aux ✅&nbsp;établissements ayant déclaré des salariés et ayant une convention.
@@ -27,14 +27,14 @@ Les caractéristiques suivantes sont transmises&nbsp;:
     ❌ Les sociétés unipersonnelles dont le gérant est assimilé salarié ne sont pas concernées par cette API, même si la société en question est rattachée à une convention collective.
     \n
     \n
-    **Fraicheur de la donnée&nbsp;:**
+    ###### Fraicheur de la donnée&nbsp;:
     \n
     \n
     ⚠️ La fréquence de mise à jour du fichier fourni par la DARES (une des deux sources de cette API) n&apos;est pas précisée."
     entities:
       - associations
       - entreprises
-  call_id: "SIREN"
+  call_id: "SIRET"
   providers:
     - 'fabsocial'
   opening: public

--- a/config/endpoints/7_cmafrance_rnm.yml
+++ b/config/endpoints/7_cmafrance_rnm.yml
@@ -3,22 +3,21 @@
   path: '/v3/rnm/entreprises/{siren}'
   position: 180
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
-    Cette API délivre des informations de référence fournies par la Chambre des Métiers et de l&apos;Artisanat France (CMA France)
- concernant les entreprises artisanales telles que&nbsp;:
+    Cette API délivre des informations de référence sur les entreprises artisanales, données fournies par la Chambre des Métiers et de l&apos;Artisanat France (CMA France), telles que&nbsp;:
     \n
     \n
-    - des informations générales et juridiques (nom de l&apos;entreprise, personne physique/morale, forme juridique, effectif, l&apos;origine du fond de commerce, activité permanente/saisonnière, activité ambulante, code du centre de formalité des entreprises (CFE) ayant fait l&apos;inscription et les déclarations, s&apos;il y en a, relatives à un redressement judiciaire ou une liquidation.)
+    - des informations générales et juridiques, telles que le nom de l&apos;entreprise, s&apos;il s&apos;agit personne physique ou morale, sa forme juridique, son effectif et l&apos;origine du fond de commerce ;
     \n
-    - le type d&apos;activité de l&apos;entreprise (code NAFA et secteur d&apos;activité (NAR)) ;
+    - des données définissant le type d&apos;activité de l&apos;entreprise, telles que le code NAFA, le secteur d&apos;activité (NAR), et l&apos;indication si l&apos;activité est permanente ou saisonnière et/ou ambulante ;
     \n
     - des informations géographiques, notamment l&apos;adresse ;
     \n
     - des informations sur les dirigeants ;
     \n
-    - les dates clés (immatriculation, radiation, début d&apos;activité …)
+    - les dates clés (immatriculation, radiation, début d&apos;activité …) ainsi que le code du centre de formalité des entreprises (CFE) ;
     \n
     - des informations en cas de double immatriculation ;
     \n
@@ -28,7 +27,7 @@
     Ces données sont également disponibles en [API publique et libre d&apos;accès sur api.gouv.fr](https://api.gouv.fr/les-api/api_rnm}{:target=\"_blank\"}).
     \n
     \n
-    **Entreprises concernées&nbsp;:**
+    ###### Entreprises concernées&nbsp;:
     \n
     \n
     Cette API couvre toutes les entreprises enregistrées au répertoire national des métiers (RNM).
@@ -37,7 +36,7 @@
     Sont obligatoirement immatriculées au répertoire des métiers&nbsp;:
     \n
     \n
-    - ✅ les entreprises individuelles et les sociétés qui n&apos;emploient pas plus de dix salariés et exercent à titre principal ou secondaire une activité artisanale de production, de transformation, de réparation ou de prestation de service figurant en annexe du décret du 2 avril 1998.
+    - ✅ les entreprises individuelles et les sociétés qui n&apos;emploient pas plus de dix salariés et exercent à titre principal ou secondaire une activité artisanale de production, de transformation, de réparation ou de prestation de service figurant en [annexe du décret du 2 avril 1998](https://www.legifrance.gouv.fr/loda/article_lc/LEGIARTI000021964896/2009-02-02/}{:target=\"_blank\"}).
     \n
     - ✅ Les personnes qui exercent l&apos;activité de fabrication de plats à consommer sur place peuvent également être immatriculées au répertoire des métiers.
     \n
@@ -48,10 +47,48 @@
     - ✅ les entreprises qui dépassent le seuil de dix salariés si leur dirigeant peut se prévaloir de la qualité d&apos;artisan, d&apos;artisan d&apos;art ou de maitre artisan.
     \n
     \n
-    **Fraicheur de la donnée&nbsp;:**
+    ###### Fraicheur de la donnée&nbsp;:**
     \n
     \n
-    "
+    La fraîcheur des données de cette API correspond à la date de mise à jour faite du répertoire RNM 
+suite aux nouvelles informations déclarées par l&apos;entrepreneur. Cette date est indiquée dans l&apos;API par la clé `rnm_date_mise_a_jour`. 
+Dans le cas où il n&apos;y a pas encore eu de changement répertorié, la date d&apos;import `rnm_date_import` fait alors référence.
+    \n
+    \n
+    {:.fr-highlight--caution}
+    > ⚠️ Cependant, les dates ci-dessus ne garantissent pas la fraicheur de toutes les données renvoyées, car leur mise à jour n&apos;est pas obligatoire.
+    > Les données d&apos;effectifs `effectif_salarie` et `effectif_apprenti` sont notamment à prendre avec vigilance car elles peuvent dater de la première déclaration.
+    \n
+    \n
+    **Liste des évènements qui doivent être obligatoirement déclarés&nbsp;:**
+    \n
+    \n
+    - changement d&apos;adresse ;
+    \n
+    - changement de nom commercial ;
+    \n
+    - changement d&apos;enseigne ;
+    \n
+    - modification d&apos;activité(s) de l&apos;entreprise ;
+    \n
+    - mise en location gérance, mention de conjoint collaborateur ;
+    \n
+    - ouverture ou fermeture d&apos;un établissement ;
+    \n
+    - changement de la forme juridique ;
+    \n
+    - changement de dirigeant ;
+    \n
+    - dissolution de la société ;
+    \n
+    - cessation temporaire ou totale d&apos;activité ;
+    \n
+    - régularisation d&apos;immatriculation pour les micro-entrepreneurs.
+    \n
+    \n
+    Il est à noter que **l&apos;entrepreneur n&apos;a pas d&apos;obligation légale à déclarer un changement d&apos;effectif**.
+De fait, l&apos;actualisation de cette donnée dépend donc du bon vouloir de l&apos;entrepreneur à revérifier tous les champs du formulaire
+au moment de sa déclaration d&apos;un événement dit obligatoire. Néanmoins, **généralement**, étant donné que toute modification du répertoire implique des coûts, **l&apos;entreprise met à jour l&apos;ensemble de ses données**."
     entities:
       - entreprises
   call_id: "SIREN"
@@ -59,66 +96,13 @@
     - 'cma'
   opening: public
   use_cases:
-    - Aides publiques
     - Marchés publics
-    - Préremplissage d&apos;un formulaire
+    - Aides publiques
+    - Préremplissage d'un formulaire
     - Détection de la fraude
   parameters:
-    - Numéro de SIREN de l&apos;entreprise
+    - Numéro de SIREN de l'entreprise
   faq:
-    - q: "Quelles sont les sources des données de conventions collectives de de cette API ?"
-      a: "\n
-      \n
-      ##### Du côté de l&apos;entreprise
-      \n
-      \n
-      Parmi les événements qui surviennent dans la vie d&apos;une entreprise artisanale,
-certains d&apos;entre eux doivent être obligatoirement déclarés par l&apos;entreprise à sa chambre de commerce et d&apos;artisanat,
-c&apos;est-à-dire son centre de formalité des entreprises. **Généralement**, étant donné que toute modification du répertoire implique des coûts,
-**l&apos;entreprise met à jour l&apos;ensemble de ses données**.
-      \n
-      \n
-      Voici la liste des évènements qui impliquent obligatoirement une déclaration :
-      \n
-      \n
-      - Changement d&apos;adresse ;
-      \n
-      - changement de nom commercial ;
-      \n
-      - changement d&apos;enseigne ;
-      \n
-      - modification d&apos;activité(s) de l&apos;entreprise ;
-      \n
-      - mise en location gérance, mention de conjoint collaborateur ;
-      \n
-      - ouverture ou fermeture d&apos;un établissement ;
-      \n
-      - changement de la forme juridique ;
-      \n
-      - changement de dirigeant ;
-      \n
-      - dissolution de la société ;
-      \n
-      - cessation temporaire ou totale d&apos;activité ;
-      \n
-      - régularisation d&apos;immatriculation pour les micro-entrepreneurs.
-      \n
-      \n
-      Il est à noter que **l&apos;entrepreneur n&apos;a pas d&apos;obligation légale à déclarer un changement d&apos;effectif**.
-De fait, l&apos;actualisation de cette donnée dépend donc du bon vouloir de l&apos;entrepreneur à revérifier tous les champs du formulaire
-au moment de sa déclaration d&apos;un événement dit obligatoire.
-      \n
-      \n
-      ##### Du côté de la réponse JSON
-      \n
-      \n
-      La fraîcheur des données communiquées par cette API correspond à la date de mise à jour faite dans le RNM
-suite aux nouvelles informations déclarées par l&apos;entrepreneur. Cette date est indiquée par la clé `rnm_date_mise_a_jour` dans la réponse JSON.
-      Dans le cas où il n&apos;y a pas encore eu de changement répertorié, la date d&apos;import `rnm_date_import` fait alors référence.
-      \n
-      \n
-      ⚠️ La fraicheur des données d&apos;effectifs `effectif_salarie` et `effectif_apprenti` est à
-prendre avec vigilance puisque leur mise à jour n&apos;est pas obligatoire."
     - q: "Qu&apos;est ce que les codes NAFA, NAR 4 et NAR 20 ?"
       a: "
       ###### Le code NAFA

--- a/config/endpoints/9_douanes_eori.yml
+++ b/config/endpoints/9_douanes_eori.yml
@@ -3,7 +3,7 @@
   path: '/v3/dgddi/eoris/{siret_or_eori}'
   position: 200
   perimeter:
-    description: "**Type de données&nbsp;:**
+    description: "###### Type de données&nbsp;:
     \n
     \n
     Cette API délivre le statut **actif ou non du numéro EORI** de l&apos;entreprise.
@@ -13,21 +13,21 @@ Si le numéro EORI n&apos;est plus actif, cela signifie que l&apos;entreprise n&
     La raison sociale et l&apos;adresse de l&apos;entreprise telles qu&apos;enregistrée auprès des douanes sont aussi précisées.
     \n
     \n
-    **Établissements concernés&nbsp;:**
+    ###### Établissements concernés&nbsp;:
     \n
     \n
-    L&apos;API `/numero_eori` couvre ✅ **toutes les entreprises faisant des
+    Cette API couvre ✅ **toutes les entreprises faisant des
     échanges commerciaux** entrant et sortant au sein de l&apos;Union Européenne.
-    Le périmètre des entreprises trouvables est cependant différent selon si l&apos;appel est effectué avec le numéro EORI ou le SIRET de l&apos;entreprise&nbps;:
+    Le périmètre des entreprises trouvables est cependant différent selon si l&apos;appel est effectué avec le numéro EORI ou le SIRET de l&apos;entreprise&nbsp;:
     \n
     \n
-    ##### Appel avec un numéro EORI&nbps;:
+    **Appel avec un numéro EORI&nbsp;:**
     \n
     \n
     À condition de connaître le numéro EORI de l&apos;entreprise recherchée, vous pouvez accéder au statut de l&apos;immatriculation de ✅ toutes les entreprises de la base des douanes.
     \n
     \n
-    ##### Appel avec un numéro de SIRET&bsp;::
+    **Appel avec un numéro de SIRET&nbsp;:**
     \n
     \n
     - Pour les ✅ entreprises ayant réalisé leur immatriculation EORI en France, vous pouvez utiliser le numéro de SIRET comme paramètre d&apos;appel.
@@ -38,7 +38,7 @@ Si le numéro EORI n&apos;est plus actif, cela signifie que l&apos;entreprise n&
     ℹ️ Plus d&apos;informations sur le site des [douanes](https://www.douane.gouv.fr/fiche/numero-eori-economic-operator-registration-and-identification}{:target=\"_blank\"}) ou sur le site de l&apos;[Union Européenne](https://ec.europa.eu/taxation_customs/business/customs-procedures/general-overview/economic-operators-registration-identification-number-eori_fr}{:target=\"_blank\"})."
     entities:
       - entreprises
-  call_id: "Numéro EORI / SIRET"
+  call_id: "N°EORI / SIRET"
   providers:
     - 'douanes'
   opening: public

--- a/config/endpoints/9_douanes_eori.yml
+++ b/config/endpoints/9_douanes_eori.yml
@@ -47,7 +47,7 @@ Si le numéro EORI n&apos;est plus actif, cela signifie que l&apos;entreprise n&
     - Marchés publics
     - Détection de la fraude
   parameters:
-    - Numéro EORI de l&apos;entreprise ou son SIRET si elle est immatriculée en France
+    - Numéro EORI de l'entreprise ou son SIRET si elle est immatriculée en France
   faq:
     - q: "À quoi ressemble un numéro EORI ?"
       a: "Pour les entreprises françaises ayant fait leur demande de numéro EORI auprès des douanes française celui-ci est FR+SIRET (par exemple : FR16002307300010).


### PR DESCRIPTION
Première relecture après création des fiches métiers.

- Cette PR transforme aussi tous les titres intermédiaires auparavant en gras, en utilisant un `<h6>`
- Elle retire également les `&apos;` dans les clés de type "texte court", qui apparaissait en html sur l'interface
