### PR TITLE
DatapassWebhook::FindOrCreateAuthorizationRequest saves siret from webhook

### DIFF
--- a/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
+++ b/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
@@ -36,7 +36,8 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
     context.data['pass'].slice(
       'intitule',
       'description',
-      'status'
+      'status',
+      'siret'
     ).merge(authorization_request_attributes_for_current_event).merge(
       'last_update' => fired_at_as_datetime,
       'previous_external_id' => context.data['pass']['copied_from_enrollment_id']

--- a/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interac
     it { is_expected.to be_a_success }
     it { expect(subject.authorization_request).to an_instance_of(AuthorizationRequest) }
 
-    it 'creates a new authorization request with attributes, contacts and linked to user' do
+    it 'creates a new authorization request with attributes (including siret), contacts and linked to user' do
       expect {
         subject
       }.to change { user.reload.authorization_requests.count }.by(1)
@@ -77,6 +77,7 @@ RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interac
       authorization_request = user.authorization_requests.last
 
       expect(authorization_request.intitule).to eq(datapass_webhook_params['data']['pass']['intitule'])
+      expect(authorization_request.siret).to eq(datapass_webhook_params['data']['pass']['siret'])
       expect(authorization_request.previous_external_id).to eq(datapass_webhook_params['data']['pass']['copied_from_enrollment_id'])
       expect(authorization_request.contacts.count).to eq(2)
       expect(authorization_request.contact_technique.email).to match(/technique\d+@/)


### PR DESCRIPTION
Le premier qui passe peut merger imo.

Closes https://github.com/etalab/admin_api_entreprise/issues/386