### PR TITLE
Ajout des erreurs sur les fiches métiers

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class Endpoint
   include ActiveModel::Model
 
@@ -144,3 +145,4 @@ class Endpoint
     @open_api_definition ||= OpenAPIDefinition.get(path)
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/app/views/endpoints/show.html.erb
+++ b/app/views/endpoints/show.html.erb
@@ -86,7 +86,7 @@
       <%= render partial: 'use_cases', locals: { id: 'use_cases_mobile', extra_classes: 'fr-hidden-md' } %>
       <%= render partial: 'details', locals: { id: 'use_cases_mobile', extra_classes: 'fr-mb-3w fr-hidden-md' } %>
 
-      <h2 id="donnees" class="fr-mt-md-5w">
+      <h2 id="donnees" class="fr-mt-md-5w fr-mt-8w">
         <%= t('.data.title') %>
       </h2>
 
@@ -173,7 +173,7 @@
       <% end %>
 
       <% if @endpoint.faq.any? %>
-        <h2 id="faq" class="fr-mt-md-5w">
+        <h2 id="faq" class="fr-mt-md-5w fr-mt-8w">
           <%= t('.faq.title') %>
         </h2>
 
@@ -196,7 +196,7 @@
         </div>
       <% end %>
 
-      <h2 id="cgu" class="fr-mt-md-5w">
+      <h2 id="cgu" class="fr-mt-md-5w fr-mt-8w">
         <%= t('.cgu.title') %>
       </h2>
 
@@ -237,6 +237,28 @@
 
         <%= link_to t('.cgu.cta'), cgu_path, id: 'cgu_link', class: %w(fr-btn fr-btn--secondary fr-btn--icon-right fr-fi-eye-line), data: { turbo_frame: 'main-modal-content', 'fr-opened': 'false' }, 'aria-controls': 'main-modal' %>
       </p>
+
+      <% if @endpoint.custom_provider_errors.any? %>
+        <h2 id="erreurs" class="fr-mt-md-5w fr-mt-8w">
+          <%= t(".provider_errors.title") %>
+        </h2>
+
+        <p>
+          <%= t(".provider_errors.description_html", provider_name: t("providers.#{@endpoint.providers[0]}")) %>
+        </p>
+
+        <ul>
+          <% @endpoint.custom_provider_errors.each do |error| %>
+            <li>
+              <strong><%= error['title'] %></strong> ( #<%= error['code'] %> ) : <%= error['detail'] %>
+            </li>
+          <% end %>
+        </ul>
+
+        <p>
+        <%= t(".provider_errors.others_in_swagger_html", link: link_to(t('.provider_errors.documentation_link'), developers_openapi_path(anchor: @endpoint.redoc_anchor), data: { turbo: false })) %>
+        </p>
+      <% end %>
     </div>
 
     <div class="fr-col-md-<%= 12 - layout_main_bloc %>">

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -265,6 +265,13 @@ fr:
       root_meta:
         title: "Métadonnées racine"
         description: "Les métadonnées sont des données généralement liées au contexte de la ressource : mise à jour chez le fournisseurs, informations système, etc..."
+      provider_errors:
+        title: "Erreurs spécifiques"
+        description_html: "Lorsque l'API ne peut pas retourner les informations demandées, un message d'erreur est transmis.
+          <br />
+          <br />Les erreurs, spécifiques à cette API et au fournisseur de données %{provider_name}, sont listées ici :"
+        others_in_swagger_html: "L'intégralité des messages d'erreurs relatifs à cette API est consultable dans la %{link}."
+        documentation_link: "documentation technique"
       faq:
         title: "Questions & réponses"
       cgu:

--- a/spec/features/endpoints/show_spec.rb
+++ b/spec/features/endpoints/show_spec.rb
@@ -27,6 +27,28 @@ RSpec.describe 'Endpoints show', type: :feature do
     end
   end
 
+  describe 'provider errors' do
+    before do
+      visit endpoint_path(uid:)
+    end
+
+    context 'with an endpoint which has no custom provider error' do
+      let(:uid) { 'fabrique_numerique_ministeres_sociaux/conventions_collectives' }
+
+      it 'does not display errors part' do
+        expect(page).not_to have_css('#erreurs')
+      end
+    end
+
+    context 'with an endpoint which has custom provider error' do
+      let(:uid) { 'urssaf/attestation_vigilance' }
+
+      it 'displays errors part' do
+        expect(page).to have_css('#erreurs')
+      end
+    end
+  end
+
   describe 'actions' do
     describe 'click on example', js: true do
       it 'opens modal with example' do

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -38,6 +38,21 @@ RSpec.describe Endpoint, type: :model do
       its(:root_meta) { is_expected.to have_key('date_derniere_mise_a_jour') }
 
       its(:collection?) { is_expected.to be false }
+
+      describe '#error_examples' do
+        subject { described_class.find(uid).error_examples('401') }
+
+        it { is_expected.to be_an_instance_of(Array) }
+
+        it 'contains error payload' do
+          element = subject.first
+
+          expect(element['errors'][0]).to be_present
+          expect(element['errors'][0]).to have_key('title')
+          expect(element['errors'][0]).to have_key('detail')
+          expect(element['errors'][0]).to have_key('code')
+        end
+      end
     end
 
     context 'with collection uid' do

--- a/spec/models/endpoint_spec.rb
+++ b/spec/models/endpoint_spec.rb
@@ -47,10 +47,10 @@ RSpec.describe Endpoint, type: :model do
         it 'contains error payload' do
           element = subject.first
 
-          expect(element['errors'][0]).to be_present
-          expect(element['errors'][0]).to have_key('title')
-          expect(element['errors'][0]).to have_key('detail')
-          expect(element['errors'][0]).to have_key('code')
+          expect(element).to be_present
+          expect(element).to have_key('title')
+          expect(element).to have_key('detail')
+          expect(element).to have_key('code')
         end
       end
     end


### PR DESCRIPTION
Ces erreurs sont propulsés à l'aide du fichier swagger (et sera donc toujours à jour avec le code en production).

Deux exemples: https://sandbox.dashboard.entreprise.api.gouv.fr/endpoints/urssaf/attestation_sociale et https://sandbox.dashboard.entreprise.api.gouv.fr/endpoints/insee/unites_legales

Chaque endpoint possède des erreurs

Il faut affiner les wordings et potentiellement l'UI.