### PR TITLE
FIX Passenger issue with strscan

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,8 @@ gem "algoliasearch-rails"
 
 gem "scenic"
 
+gem "strscan", "3.0.1"
+
 group :development, :test do
   gem 'awesome_print'
   gem 'colorize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -483,7 +483,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    strscan (3.0.3)
+    strscan (3.0.1)
     super_diff (0.8.0)
       attr_extras (>= 6.2.4)
       diff-lcs
@@ -581,6 +581,7 @@ DEPENDENCIES
   sidekiq-cron
   simplecov
   simplecov-console
+  strscan (= 3.0.1)
   super_diff
   timecop
   turbo-rails


### PR DESCRIPTION
The commit 229ddea17674f9178ebf48f8cee7d2d6b82b6c70 introduces a bug on
Passenger:

```
App 2590953 output: Error: The application encountered the following
error: You have already activated strscan 3.0.1, but your Gemfile
requires strscan 3.0.3. Since strscan is a default gem, you can either
remove your dependency on it or try updating to a newer version of
bundler that supports strscan as a default gem. Gem::LoadError)()
```

A (temporary) workaround is to fix strscan to 3.0.1.

The issue seems to be this one:
https://github.com/phusion/passenger/issues/2409

According to these issues, the best workaround is to use
`PassengerPreloadBundler` in order to load right versions of gems.

Ref https://github.com/phusion/passenger/issues/2410#issuecomment-1011906640