### PR TITLE
Simplification et amélioration de la mise à jour de base Samhain

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -68,12 +68,7 @@ set :shared_files, fetch(:shared_files, []).push(
 )
 
 def samhain_db_update
-  samhain_listfile = "/tmp/listfile-#{SecureRandom.hex(48)}"
-
-  comment %{Updating Samhain signature database}
-  command %{find "/var/www/admin_apientreprise_#{ENV['to']}" >#{samhain_listfile}}
-  command %{sudo /usr/local/sbin/update-samhain-db.sh #{samhain_listfile}}
-  command %{rm -f #{samhain_listfile}}
+  command %{sudo /usr/local/sbin/update-samhain-db.sh "/var/www/admin_apientreprise_#{ENV['to']}"}
 end
 
 # This task is the environment that is loaded for all remote run commands, such as


### PR DESCRIPTION
Comme pour les autres applications Rails, on bénéficie des [améliorations](https://github.com/etalab/very_ansible/pull/91) côté Ansible/Samhain pour simplifier la tâche de mise à jour de base Samhain. Elle est aussi plus efficace comme ça pour éviter les faux positifs.