### PR TITLE
Add a task to blacklist token

### DIFF
--- a/lib/tasks/token.rake
+++ b/lib/tasks/token.rake
@@ -1,0 +1,32 @@
+namespace :token do
+  desc 'Blacklist a token (and create a new one)'
+
+  task :blacklist, [:token_id] => :environment do |_, args|
+    token = JwtAPIEntreprise.find(args.token_id)
+
+    if token.blacklisted?
+      puts 'Token already blacklisted'
+      fail
+    end
+
+    copy = token.dup
+    copy.roles = token.roles
+    copy.save
+
+    token.update(blacklisted: true)
+
+    end_message(token)
+  end
+
+  private
+
+  def end_message(token)
+    puts 'New Token is available in user dashboard'
+    puts 'Token to blacklist:'
+    puts token.rehash
+    puts 'Add the token to the blaclist in Ansible'
+    puts '  ansible-vault edit secrets/siade_jwt_black_and_white_list.yml'
+    puts 'And deploy the file (leave few hours/days to the user to change token)'
+    puts '  ansible-playbook siade_production.yml --tags jwt-blacklist'
+  end
+end


### PR DESCRIPTION
Suite à la suppression de l'espace admin j'ai crée une tâche Rake.

Ce sera le script à lancer pour blacklister un jeton et en générer un nouveau (qui garde la même date de fin que le précédent)

Rappel le blacklist n'est pas automatique, il faut ensuite l'appliquer en production ce qui laisse aux gens le temps de réagir.

J'ai un cas en ce moment à traiter donc...