### PR TITLE
Réduit le contenu de la pop up de transfert du jeton

### DIFF
--- a/config/locales/faq_entries.fr.yml
+++ b/config/locales/faq_entries.fr.yml
@@ -110,7 +110,7 @@ fr:
               - ❌ aux associations,
               - ❌ aux entreprises.
 
-              Il faut également être techniquement en mesure d’intégrer l’API Entreprise ([En savoir plus](<%= root_path %>))
+              Il faut également être techniquement en mesure d’intégrer l’API Entreprise, le détail des prérequis techniques est listé dans la [rubrique de l'espace développeur](<%= developers_path(anchor: 'prerequis-techniques') %>)
               **Pour vérifier votre éligibilité et faire une demande d’habilitation le cas échéant, suivez le lien suivant :**
 
               [Vérifier son éligibilité](https://api.gouv.fr/les-api/api-entreprise/demande-acces}{:target=\"_blank\"}){:.fr-btn fr-btn--secondary}
@@ -152,7 +152,7 @@ fr:
               - vous avez une **direction des systèmes d’information (DSI)** qui peut intégrer des APIs ;
               - ou si vous travaillez ou vous vous apprêtez à travailler avec une **équipe technique externe ou un éditeur de logiciel**, qui doit être en mesure d’intégrer API Entreprise.
 
-              Cette équipe technique doit être en mesure de mettre en place les [**fondamentaux techniques** listés dans cette rubrique de la documentation technique](<%= root_path %>).
+              Cette équipe technique doit être en mesure de mettre en place les [**fondamentaux techniques** listés dans cette rubrique de l'espace développeur](<%= developers_path(anchor: 'prerequis-techniques') %>).
 
               #### Prévoir les incidents et la résilience du service
 
@@ -292,7 +292,7 @@ fr:
           - question: "Comment transmettre le jeton d’accès en tout sécurité ?"
             answer: |+
               Actuellement, seule la personne ayant rempli la demande d’habilitation peut accéder au [compte utilisateur](<%= user_profile_path %>) et y récupérer le jeton d’accès. C’est pourquoi, il est fréquent que cette personne ait besoin ponctuellement de transmettre le jeton à une autre personne, notamment pour que l’équipe technique puisse intégrer l’API.
-              ⚠️ Comme expliqué [ici](<%= root_path %>), votre token vous est propre, il ne faut pas surtout pas le copier/coller dans un e-mail.
+              ⚠️ Comme expliqué [ici](<%= faq_index_path(anchor: 'qu-est-ce-qu-un-token-ou-jeton') %>), votre token vous est propre, il ne faut pas surtout pas le copier/coller dans un e-mail.
              
               **Pour transmettre votre jeton, vous devez utiliser la fonctionnalité prévue dans votre compte utilisateur sur API Entreprise** :
               - Cliquez sur le bouton "Transmettre le jeton" (blanc au contour bleu) situé juste en dessous de l’encadré du jeton.
@@ -346,7 +346,7 @@ fr:
             answer: |+
               Pour des **raisons de sécurité**, tous les jetons émis sont valables pour une **durée de 18 mois**. Au delà de ce délai, ils ne fonctionnent plus, et votre accès à l’API Entreprise est donc totalement arrêté.
 
-              En réalité, cette situation n’est pas censée arriver car API Entreprise a mis en place une [procédure simple de renouvellement de token](<%= root_path %>).
+              En réalité, cette situation n’est pas censée arriver car API Entreprise a mis en place une [procédure simple de renouvellement de token](<%= faq_index_path(anchor: 'comment-renouveler-mon-jeton-arrivant-a-expiration') %>).
 
 
 
@@ -451,7 +451,7 @@ fr:
 
               **Je n’ai pas effectué la demande d’habilitation** : Pour accéder à l'espace utilisateur, vous devez vous référer à la personne qui a effectué la demande d’habilitation.
 
-              _Vous faîtes partie du service technique et avez besoin du jeton d’accès car vous participez à l’intégration de l’API Entreprise ?_ Demandez au responsable du compte d’utiliser la fonctionnalité de transmission d'un lien d’accès temporaire au jeton. Pour en savoir plus, référez vous à la rubrique [Récupérer le jeton JWT 🔑](<%= root_path %>) de la documentation technique.
+              _Vous faîtes partie du service technique et avez besoin du jeton d’accès car vous participez à l’intégration de l’API Entreprise ?_ Demandez au responsable du compte d’utiliser la fonctionnalité de transmission d'un lien d’accès temporaire au jeton. Pour en savoir plus, référez vous à la rubrique [Récupérer le jeton JWT 🔑](<%= developers_path(anchor: 'récupérer-le-jeton-jwt') %>) de la documentation technique.
 
               _Dans certains cas spécifiques comme le départ du demandeur, un changement de poste, etc.,_ un transfert de compte peut être nécessaire.
               Une fonctionnalité est à disposition dans l'[espace utilisateur](<%= user_profile_path %>), onglet \"Compte utilisateur\". Cette opération nécessite l’accord explicite du demandeur et est instruite manuellement par nos services.

--- a/config/locales/faq_entries.fr.yml
+++ b/config/locales/faq_entries.fr.yml
@@ -292,14 +292,17 @@ fr:
           - question: "Comment transmettre le jeton d’accès en tout sécurité ?"
             answer: |+
               Actuellement, seule la personne ayant rempli la demande d’habilitation peut accéder au [compte utilisateur](<%= user_profile_path %>) et y récupérer le jeton d’accès. C’est pourquoi, il est fréquent que cette personne ait besoin ponctuellement de transmettre le jeton à une autre personne, notamment pour que l’équipe technique puisse intégrer l’API.
-
-              {:.fr-highlight.fr-highlight--caution}
-              > ⚠️ Comme expliqué [ici](<%= root_path %>), votre token vous est propre, il ne faut pas surtout pas le copier/coller dans un e-mail.
-
-              **Pour transmettre votre jeton, utilisez la fonctionnalité prévue dans votre compte utilisateur sur API Entreprise** :
+              ⚠️ Comme expliqué [ici](<%= root_path %>), votre token vous est propre, il ne faut pas surtout pas le copier/coller dans un e-mail.
+             
+              **Pour transmettre votre jeton, vous devez utiliser la fonctionnalité prévue dans votre compte utilisateur sur API Entreprise** :
               - Cliquez sur le bouton "Transmettre le jeton" (blanc au contour bleu) situé juste en dessous de l’encadré du jeton.
               - Une fenêtre s’ouvre alors, elle vous rappelle vos engagements, et vous permet d’indiquer une adresse e-mail.
               - En cliquant sur "Envoyer", un courriel sera transmis à cette adresse, avec, à l’intérieur, **un lien d’une durée de 4 heures, qui permettra à l’utilisateur de récupérer le jeton**.
+
+              {:.fr-highlight.fr-highlight--caution}
+              > ⚠️ Vous êtes responsable de votre clé d'accès au titre des engagements pris au moment de votre habilitation en signant nos <a href="https://entreprise.api.gouv.fr/cgu/">CGU</a>. L'utilisation de la fonctionnalité "Transmettre le jeton" a pour objectif de sécuriser l'envoi de votre jeton aux services techniques qui intègreront l'API Entreprise. Vous ne devez pas divulguer cet accès à des tiers non-habilités.
+              
+              Si vous avez divulgué votre jeton par erreur, le renouvellement d’un jeton est très facile et rapide. Écrivez rapidement à <a href="mailto:support@entreprise.api.gouv.fr">support@entreprise.api.gouv.fr</a>.
 
           - question: "Comment renouveler mon jeton arrivant à expiration ?"
             answer: |+

--- a/config/locales/faq_entries.fr.yml
+++ b/config/locales/faq_entries.fr.yml
@@ -113,7 +113,7 @@ fr:
               Il faut également être techniquement en mesure d’intégrer l’API Entreprise, le détail des prérequis techniques est listé dans la [rubrique de l'espace développeur](<%= developers_path(anchor: 'prerequis-techniques') %>)
               **Pour vérifier votre éligibilité et faire une demande d’habilitation le cas échéant, suivez le lien suivant :**
 
-              [Vérifier son éligibilité](https://api.gouv.fr/les-api/api-entreprise/demande-acces}{:target=\"_blank\"}){:.fr-btn fr-btn--secondary}
+              [Vérifier son éligibilité](https://api.gouv.fr/les-api/api-entreprise/demande-acces}{:target="_blank"}){:.fr-btn fr-btn--secondary}
 
               L’accès à l’API Entreprise est modéré et régulé par la DINUM, qui attribue des autorisations de récupération d’informations selon la nature des démarches à traiter (marchés publics, aides publiques,…).
 
@@ -293,7 +293,7 @@ fr:
             answer: |+
               Actuellement, seule la personne ayant rempli la demande d’habilitation peut accéder au [compte utilisateur](<%= user_profile_path %>) et y récupérer le jeton d’accès. C’est pourquoi, il est fréquent que cette personne ait besoin ponctuellement de transmettre le jeton à une autre personne, notamment pour que l’équipe technique puisse intégrer l’API.
               ⚠️ Comme expliqué [ici](<%= faq_index_path(anchor: 'qu-est-ce-qu-un-token-ou-jeton') %>), votre token vous est propre, il ne faut pas surtout pas le copier/coller dans un e-mail.
-             
+
               **Pour transmettre votre jeton, vous devez utiliser la fonctionnalité prévue dans votre compte utilisateur sur API Entreprise** :
               - Cliquez sur le bouton "Transmettre le jeton" (blanc au contour bleu) situé juste en dessous de l’encadré du jeton.
               - Une fenêtre s’ouvre alors, elle vous rappelle vos engagements, et vous permet d’indiquer une adresse e-mail.
@@ -301,7 +301,7 @@ fr:
 
               {:.fr-highlight.fr-highlight--caution}
               > ⚠️ Vous êtes responsable de votre clé d'accès au titre des engagements pris au moment de votre habilitation en signant nos <a href="https://entreprise.api.gouv.fr/cgu/">CGU</a>. L'utilisation de la fonctionnalité "Transmettre le jeton" a pour objectif de sécuriser l'envoi de votre jeton aux services techniques qui intègreront l'API Entreprise. Vous ne devez pas divulguer cet accès à des tiers non-habilités.
-              
+
               Si vous avez divulgué votre jeton par erreur, le renouvellement d’un jeton est très facile et rapide. Écrivez rapidement à <a href="mailto:support@entreprise.api.gouv.fr">support@entreprise.api.gouv.fr</a>.
 
           - question: "Comment renouveler mon jeton arrivant à expiration ?"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -192,9 +192,9 @@ fr:
   authorization_requests:
     index:
       title: "Vos demandes d'habilitation (%{count})"
-      new_cta: "Nouvelle demande d'autorisation API Entreprise"
+      new_cta: "Nouvelle demande d'habilitation API Entreprise"
       table:
-        caption: "Liste des demandes d'autorisation"
+        caption: "Liste des demandes d'habilitation"
         external_url: "Demande d'accès (numéro %{external_id})"
         status:
           draft: "Demande en brouillon 📝"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -153,17 +153,14 @@ fr:
         renew: Renouveler ou étendre mes droits
       magic_link:
         title: Transférer le jeton d'accès
-        description: Votre clé d'accès est privée et vous en êtes responsable au titre des engagements pris lors de la signature de nos <a href="https://entreprise.api.gouv.fr/cgu/">CGU</a>, notamment le fait de ne pas divulguer les accès à des tiers non-habilités. L'utilisation de la fonctionnalité "Transmettre le jeton" a pour objectif de sécuriser l'envoi de votre jeton d'accès aux services techniques qui intègreront l'API Entreprise.
+        description: Cette fonctionnalité vous permet d'envoyer un e-mail contenant un lien d'accès au jeton. L'URL transmise a une durée limitée de 4 heures.
           <br />
           <br />
-          Si vous avez divulgué votre jeton par erreur, le renouvellement d’un jeton est très facile et rapide. Écrivez rapidement à <a href="mailto:support@entreprise.api.gouv.fr">support@entreprise.api.gouv.fr</a>.
-          <br />
-          <br />
-          Adresse e-mail à laquelle un lien d'accès au jeton, d'une durée de 4 heures, sera envoyé.
+          Attention, nos <a href="https://entreprise.api.gouv.fr/cgu/">CGU</a> vous engagent ! Vous ne devez pas divulguer cet accès à des tiers non-habilités. Pour en savoir plus, consultez <a href='https://entreprise.api.gouv.fr/faq#comment-transmettre-le-jeton-d-acces-en-tout-securite' target='_blank'>cette rubrique de notre FAQ</a>.
         email:
-          label: E-mail du destinataire
+          label: Adresse e-mail du destinataire
           placeholder: jean@dupont.fr
-        cta: Envoyer
+        cta: Envoyer le lien d'accès au jeton
         confirm: Êtes-vous sûr de vouloir transférer votre jeton à cette adresse ?
     stats:
       title: "Cas d'usage du jeton : %{title}"


### PR DESCRIPTION
Cette PR vise à réduire le contenu affiché dans la pop up de transfert de jeton, en basculant une partie du contenu dans la FAQ.

J'ai glissé un commit de wording.