### PR TITLE
Retire l'icone des données ouvertes et change le label

### DIFF
--- a/app/views/endpoints/_endpoint.html.erb
+++ b/app/views/endpoints/_endpoint.html.erb
@@ -37,7 +37,7 @@
     <section class="metadata">
       <ul class="list-unstyled">
         <li>
-          <%= icon(t("endpoint.opening.#{endpoint.opening}.icon", raise: true)) %>
+          <%= icon(t("endpoint.opening.#{endpoint.opening}.icon", raise: true)) rescue nil %>
           <%= t("endpoint.opening.#{endpoint.opening}.name", raise: true) %>
         </li>
 

--- a/app/views/endpoints/show.html.erb
+++ b/app/views/endpoints/show.html.erb
@@ -213,7 +213,7 @@
         </h6>
 
         <div>
-          <%= icon(t("endpoint.opening.#{@endpoint.opening}.icon", raise: true)) %>
+          <%= icon(t("endpoint.opening.#{@endpoint.opening}", raise: true)) rescue nil %>
           <%= t("endpoint.opening.#{@endpoint.opening}.name", raise: true) %>
         </div>
 

--- a/config/locales/endpoint.fr.yml
+++ b/config/locales/endpoint.fr.yml
@@ -5,8 +5,7 @@ fr:
         name: Données protégées
         icon: ri-lock-fill
       public:
-        name: Données publiques
-        icon: ri-lock-unlock-fill
+        name: Données ouvertes
     perimeter:
       entities:
         entreprises:


### PR DESCRIPTION
- Retirer l'icône quand la donnée est ouverte afin que l'utilisateur repère en un coup d'oeil la donnée protégée.
- Change le terme "publiques" par "ouvertes" ... publiques pouvant être confondu avec "du service public"