### PR TITLE
DatapassWebhook::APIParticulier does not have a contact_metier

### DIFF
--- a/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
+++ b/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
@@ -19,8 +19,11 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
   end
 
   def create_or_update_contact(from_kind, to_kind)
-    contact = context.authorization_request.public_send("contact_#{to_kind}") || context.authorization_request.public_send("build_contact_#{to_kind}")
     contact_payload = contact_payload_for(from_kind)
+
+    return if contact_payload.blank?
+
+    contact = context.authorization_request.public_send("contact_#{to_kind}") || context.authorization_request.public_send("build_contact_#{to_kind}")
 
     contact.assign_attributes(
       last_name: contact_payload['family_name'],

--- a/spec/organizers/datapass_webhook/api_particulier_spec.rb
+++ b/spec/organizers/datapass_webhook/api_particulier_spec.rb
@@ -5,7 +5,13 @@ require 'rails_helper'
 RSpec.describe DatapassWebhook::APIParticulier, type: :interactor do
   subject { described_class.call(datapass_webhook_params) }
 
-  let(:datapass_webhook_params) { build(:datapass_webhook, event: 'validate_application', authorization_request_attributes: { scopes: { 'cnaf_quotient_familial' => true } }, extra_data: { 'external_token_id' => legacy_token_id }) }
+  let(:datapass_webhook_params) { build(:datapass_webhook, event: 'validate_application', authorization_request_attributes: { scopes: { 'cnaf_quotient_familial' => true }, team_members: team_members_payload }, extra_data: { 'external_token_id' => legacy_token_id }) }
+  let(:team_members_payload) do
+    [
+      build(:datapass_webhook_team_member_model, type: 'demandeur'),
+      build(:datapass_webhook_team_member_model, type: 'responsable_technique')
+    ]
+  end
   let(:legacy_token_id) { 'over-9000' }
 
   before do


### PR DESCRIPTION
Avoid to fail on contact creation because of contact metier missing
(does not exist on this API)