### PR TITLE
Ajoute lien vers la visio

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -40,7 +40,7 @@ fr:
         catalogue: "<strong>Catalogue des API</strong><br /> & documentation des données"
         developer: "<strong>Espace développeur</strong><br /> & spécifications techniques"
         ask_access: "<strong>Demander un accès</strong><br />🔑 Vérifier votre éligibilité"
-        banner_migration: Une question sur la migration vers la V3 ? Un tech et un métier vous répondent au <a href='/faq#quand-et-pourquoi-un-bureau-ouvert'>bureau ouvert du %{date} à 10 heures</a>.
+        banner_migration: Une question sur la migration vers la V3 ? Un tech et un métier vous répondent au bureau ouvert <a href='https://webconf.numerique.gouv.fr/APIEntreprise00Version3'>en visio</a>. Prochaine date : le %{date} à 10 heures. <a href='/faq#quand-et-pourquoi-un-bureau-ouvert'>En savoir plus ➜</a>
     footer:
       tagline: API Entreprise, un <strong>service de l'écosystème des API et de la circulation des données</strong> au sein des administrations.
       external_links:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -40,7 +40,7 @@ fr:
         catalogue: "<strong>Catalogue des API</strong><br /> & documentation des données"
         developer: "<strong>Espace développeur</strong><br /> & spécifications techniques"
         ask_access: "<strong>Demander un accès</strong><br />🔑 Vérifier votre éligibilité"
-        banner_migration: Une question sur la migration vers la V3 ? Un tech et un métier vous répondent au bureau ouvert <a href='https://webconf.numerique.gouv.fr/APIEntreprise00Version3'>en visio</a>. Prochaine date : le %{date} à 10 heures. <a href='/faq#quand-et-pourquoi-un-bureau-ouvert'>En savoir plus ➜</a>
+        banner_migration: "Une question sur la migration vers la V3 ? Un tech et un métier vous répondent au bureau ouvert <a href='https://webconf.numerique.gouv.fr/APIEntreprise00Version3'>en visio</a>. Prochaine date : le %{date} à 10 heures. <a href='/faq#quand-et-pourquoi-un-bureau-ouvert'>En savoir plus ➜</a>"
     footer:
       tagline: API Entreprise, un <strong>service de l'écosystème des API et de la circulation des données</strong> au sein des administrations.
       external_links:


### PR DESCRIPTION
Les questions de la FAQ ne s'ouvrent pas automatiquement, il est donc difficile d'accéder au lien de la visio.  En attedant de résoudre le problème, cette PR propose de mettre le lien direct sur le bandeau