### PR TITLE
Ajout d'un champ API aux demandes Datapass

### DIFF
--- a/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
+++ b/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
@@ -43,7 +43,8 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
       'siret'
     ).merge(authorization_request_attributes_for_current_event).merge(
       'last_update' => fired_at_as_datetime,
-      'previous_external_id' => context.data['pass']['copied_from_enrollment_id']
+      'previous_external_id' => context.data['pass']['copied_from_enrollment_id'],
+      'api' => context.api
     )
   end
 

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -9,6 +9,8 @@ class AuthorizationRequest < ApplicationRecord
 
   validates :external_id, uniqueness: true, allow_blank: true
 
+  validates :api, inclusion: { in: %w[entreprise particulier] }, allow_blank: true
+
   has_many :contacts, dependent: :destroy_async
 
   has_one :contact_technique,

--- a/app/organizers/datapass_webhook/api_entreprise.rb
+++ b/app/organizers/datapass_webhook/api_entreprise.rb
@@ -1,5 +1,9 @@
 module DatapassWebhook
   class APIEntreprise < ApplicationOrganizer
+    before do
+      context.api = 'entreprise'
+    end
+
     organize ::DatapassWebhook::FindOrCreateUser,
       ::DatapassWebhook::FindOrCreateAuthorizationRequest,
       ::DatapassWebhook::CreateToken,

--- a/app/organizers/datapass_webhook/api_particulier.rb
+++ b/app/organizers/datapass_webhook/api_particulier.rb
@@ -6,6 +6,8 @@ module DatapassWebhook
           'legacy_token_id' => context.data['external_token_id']
         }
       }
+
+      context.api = 'particulier'
     end
 
     organize ::DatapassWebhook::FindOrCreateUser,

--- a/db/migrate/20220908134459_add_api_to_authorization_requests.rb
+++ b/db/migrate/20220908134459_add_api_to_authorization_requests.rb
@@ -1,0 +1,5 @@
+class AddAPIToAuthorizationRequests < ActiveRecord::Migration[7.0]
+  def change
+    add_column :authorization_requests, :api, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_07_01_142311) do
+ActiveRecord::Schema[7.0].define(version: 2022_09_08_134459) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pgcrypto"
@@ -58,6 +58,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_07_01_142311) do
     t.uuid "user_id", null: false
     t.string "previous_external_id"
     t.string "siret"
+    t.string "api"
     t.index ["external_id"], name: "index_authorization_requests_on_external_id", unique: true, where: "(external_id IS NOT NULL)"
   end
 

--- a/spec/organizers/datapass_webhook/api_entreprise_spec.rb
+++ b/spec/organizers/datapass_webhook/api_entreprise_spec.rb
@@ -25,10 +25,12 @@ RSpec.describe DatapassWebhook::APIEntreprise, type: :interactor do
     }.to change(User, :count).by(1)
   end
 
-  it 'creates an authorization request' do
+  it 'creates an authorization request with entreprise api' do
     expect {
       subject
     }.to change(AuthorizationRequest, :count).by(1)
+
+    expect(subject.authorization_request.api).to eq('entreprise')
   end
 
   it 'creates token for API Entreprise and stores id in token_id' do

--- a/spec/organizers/datapass_webhook/api_particulier_spec.rb
+++ b/spec/organizers/datapass_webhook/api_particulier_spec.rb
@@ -26,10 +26,12 @@ RSpec.describe DatapassWebhook::APIParticulier, type: :interactor do
     }.to change(User, :count).by(1)
   end
 
-  it 'creates an authorization request' do
+  it 'creates an authorization request with particulier api' do
     expect {
       subject
     }.to change(AuthorizationRequest, :count).by(1)
+
+    expect(subject.authorization_request.api).to eq('particulier')
   end
 
   it 'creates token for API Particulier, with legacy token id in extra infos' do


### PR DESCRIPTION
Plus simple pour faire les disjonctions que de passer par les scopes de jetons.

Post merge de cette PR, on pourra migrer tous les existants (impossible en l'état car des jetons n'ont pas de scope related https://github.com/etalab/admin_api_entreprise/issues/684 donc impossible de savoir avec la db) et mettre une contrainte sur le champ.

On pourra aussi flip/harden le `Token#api`