### PR TITLE
Fixed translation missing in case of failed authentication

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -110,6 +110,8 @@ ignore_unused:
   - 'api_entreprise.missing_endpoints.*'
   - 'api_entreprise.cas_usages_entries.*'
   - 'api_entreprise.contacts.contact.subtitle_*'
+  - 'api_entreprise.sessions.create.failure.*'
+  - 'api_entreprise.sessions.create.not_found.*'
 # - 'activerecord.attributes.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -54,7 +54,13 @@ fr:
           <br />
 
           Si vous avez besoin d'accéder au jeton d'accès mais que vous n'êtes pas cette personne, veuillez vous référer à <a href="https://entreprise.api.gouv.fr/faq/#compte-utilisateur" target="_blank">cette rubrique de la FAQ</a>.
-
+      create:
+        not_found:
+          title: Utilisateur inconnu
+          description: L'utilisateur Datapass n'est pas connu de nos services.
+        failure:
+          title: Authentification échouée
+          description: Echec de l'authentification. Veuillez vous rapprocher de nos services.
     users:
       user:
         title: "Compte utilisateur"


### PR DESCRIPTION
Suite au problème de cookie de tout à l'heure, je me rend compte que le flash message qui s'affiche en cas d'utilisateur inconnu ou en cas d'erreur indéterminée n'existe pas

Cette PR les rajoute