### PR TITLE
Fixing duplicate introduction in documentation

### DIFF
--- a/app/views/api_entreprise/documentation/index.html.erb
+++ b/app/views/api_entreprise/documentation/index.html.erb
@@ -26,11 +26,9 @@
             <h2 data-algolia-search-documentation-hit-attribute="title" id="<%= entry.anchor %>">
               <%= entry.title.html_safe %>
             </h2>
-            <% if entry.introduction %>
-              <p data-algolia-search-documentation-hit-attribute="introduction_markdown" >
-                <%= entry.introduction_markdown.html_safe %>
-              </p>
-            <% end %>
+            <p data-algolia-search-documentation-hit-attribute="introduction_markdown" >
+              <%= params[:disable_search].blank? ? nil : entry.introduction_markdown.html_safe %>
+            </p>
           </div>
           <% entry.sections.each do |section| %>
             <div data-algolia-search-documentation-hit="<%= dom_id(section) %>" id="<%= section.id %>">


### PR DESCRIPTION
Ugly hack. We don't know why the introduction is duplicated when search is on with faceting (only for entries with empty 'sections').

We could remove the display of the introduction (algolia will return the entry anyway) - but then if we disable search, no introduction. 

This hack remove the display in case of search. The result is sent back/displayed by algolia anyway. Or just display the introduction if search is disabled.