### PR TITLE
Bugfix duplicate entries in documentation

### DIFF
--- a/app/views/api_entreprise/documentation/index.html.erb
+++ b/app/views/api_entreprise/documentation/index.html.erb
@@ -27,9 +27,9 @@
               <%= entry.title.html_safe %>
             </h2>
             <% if entry.introduction %>
-              <p data-algolia-search-documentation-hit-attribute="introduction_markdown" >
+              <div data-algolia-search-documentation-hit-attribute="introduction_markdown" >
                 <%= entry.introduction_markdown.html_safe %>
-              </p>
+              </div>
             <% end %>
           </div>
           <% entry.sections.each do |section| %>

--- a/config/locales/api_entreprise/documentation_entries.fr.yml
+++ b/config/locales/api_entreprise/documentation_entries.fr.yml
@@ -469,17 +469,11 @@ fr:
               Voici la liste des **fondamentaux techniques à mettre en place pour le bon fonctionnement de l’API Entreprise**&nbsp;:&nbsp;
 
               - ☑️ Être en mesure de gérer le protocole HTTPS ;
-
               - ☑️ Avoir une version de langage récente. Si vous utilisez Java, une version >= 1.8 est nécessaire (pour la gestion des certificats de +1024 bit, du TLS 1.2 minimum et des suites cryptographiques - ciphers) ;
-
               - ☑️ S’assurer que nos Autorités de Certification (AC) pour les certificats SSL sont autorisées par vos systèmes ;
-
               - ☑️ L'API Entreprise est uniquement accessible par internet. Si vous avez un pare-feu, il faut donc prévoir de whitelister l'adresse IP du service API Entreprise ;
-
               - ☑️ Il est interdit d'interroger l'API Entreprise depuis un site web en front-end, car le jeton d'accès serait alors divulgué. Il vous faut donc interroger nos API depuis une application en back-end. Nous n'autoriserons pas le CORS (CORS - Cross Origin Ressource Sharing) ;
-
               - ☑️ Prévoir non seulement les coûts de développement mais également les coûts de maintenance ;
-
               - ☑️ Être en capacité de gérer les mises à jour de l'API Entreprise.
 
           - anchor: 'specifications-generales'


### PR DESCRIPTION
`p` tag inside `p` tag is not HTML valid.
`p` tag inside `li` tag is not HTML valid either.

The main tag `p` inside view, because of the 2 reasons above, is directly clsoed by browser to make the HTML dom semantic correct.

Ref https://github.com/etalab/admin_api_entreprise/pull/688#issuecomment-1241611667