### PR TITLE
Revert "No more tracking on Sentry for incoming DataPass webhooks"

### DIFF
--- a/app/controllers/api/datapass_webhooks_controller.rb
+++ b/app/controllers/api/datapass_webhooks_controller.rb
@@ -1,4 +1,5 @@
 class API::DatapassWebhooksController < APIController
+  before_action :track_payload_through_sentry
   before_action :verify_hub_signature!
 
   def api_entreprise
@@ -42,6 +43,20 @@ class API::DatapassWebhooksController < APIController
 
   def event
     params[:event]
+  end
+
+  def track_payload_through_sentry
+    Sentry.set_context(
+      'DataPass webhook incoming payload',
+      payload: {
+        datapass_id: params[:data][:pass][:id],
+        event:
+      }
+    )
+    Sentry.capture_message(
+      'DataPass Incoming Payload',
+      level: 'info'
+    )
   end
 
   def verify_hub_signature!

--- a/spec/controllers/api/datapass_webhooks_controller_spec.rb
+++ b/spec/controllers/api/datapass_webhooks_controller_spec.rb
@@ -63,7 +63,25 @@ RSpec.describe API::DatapassWebhooksController, type: :controller do
         subject
       end
 
-      context 'when DatapassWebhook::APIEntreprise succeed' do
+      it 'tracks through Sentry the incoming payload' do
+        expect(Sentry).to receive(:set_context).with(
+          'DataPass webhook incoming payload',
+          payload: {
+            datapass_id: '9001',
+            event:
+          }
+        )
+        expect(Sentry).to receive(:capture_message).with(
+          'DataPass Incoming Payload',
+          {
+            level: 'info'
+          }
+        )
+
+        subject
+      end
+
+      context 'when DatapassWebhook succeed' do
         let(:success) { true }
 
         it 'renders 200' do


### PR DESCRIPTION
This reverts commit f553cc9392460451a8c227f305d1c0c49e6af764.

Logs less data, only datapass id/event.

Ref https://github.com/etalab/admin_api_entreprise/issues/699