### PR TITLE
[Fiche métier] Ajoute infos details api

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -5,6 +5,7 @@ class Endpoint < ApplicationAlgoliaSearchableActiveModel
     :call_id,
     :parameters,
     :format,
+    :availability,
     :provider_uids,
     :perimeter,
     :extra_description,

--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -4,6 +4,7 @@ class Endpoint < ApplicationAlgoliaSearchableActiveModel
     :path,
     :call_id,
     :parameters,
+    :format,
     :provider_uids,
     :perimeter,
     :extra_description,

--- a/app/views/api_entreprise/endpoints/_details.html.erb
+++ b/app/views/api_entreprise/endpoints/_details.html.erb
@@ -25,6 +25,17 @@
     </div>
   <% end %>
 
+  <h6 class="fr-pt-2w fr-mb-1v">
+    <%= t('.availability.title') %>
+  </h6>
+  <a class="fr-pt-1v fr-link" href="https://status.entreprise.api.gouv.fr" target="_blank">
+    <%= t('.availability.link') %>
+  </a>
+  <div class="fr-pt-2w">
+    <%= t('.availability.opening_time.title') %> <%= markdown_to_html(@endpoint.availability['opening_time']) %>
+  </div>
+
+
   <h5 class="fr-pt-2w">
     <%= t('.technical_specifications.title') %>
   </h5>

--- a/app/views/api_entreprise/endpoints/_details.html.erb
+++ b/app/views/api_entreprise/endpoints/_details.html.erb
@@ -28,7 +28,7 @@
   <h6 class="fr-pt-2w fr-mb-1v">
     <%= t('.availability.title') %>
   </h6>
-  <a class="fr-pt-1v fr-link" href="https://status.entreprise.api.gouv.fr" target="_blank">
+  <a class="fr-pt-1v fr-link" alt="API Entreprise Status Page" href="https://status.entreprise.api.gouv.fr" target="_blank">
     <%= t('.availability.link') %>
   </a>
   <div class="fr-pt-2w">

--- a/app/views/api_entreprise/endpoints/_details.html.erb
+++ b/app/views/api_entreprise/endpoints/_details.html.erb
@@ -32,15 +32,13 @@
     <%= t('.availability.link') %>
   </a>
   <div class="fr-pt-2w">
-    <%= t('.availability.opening_time.title') %> <%= markdown_to_html(@endpoint.availability['opening_time']) %>
+    <span class="fr-text--bold"> <%= t('.availability.opening_time.title') %> </span><%= markdown_to_html(@endpoint.availability['opening_time']) %>
   </div>
 
-
+  <% if @endpoint.implemented? %>
   <h5 class="fr-pt-2w">
     <%= t('.technical_specifications.title') %>
   </h5>
-
-  <% if @endpoint.implemented? %>
     <%= link_to t('.technical_specifications.cta'), developers_openapi_path(anchor: @endpoint.redoc_anchor), data: { turbo: false }, class: %(fr-btn fr-btn--icon-right fr-icon-arrow-right-line) %>
   <% end %>
 

--- a/app/views/api_entreprise/endpoints/_details.html.erb
+++ b/app/views/api_entreprise/endpoints/_details.html.erb
@@ -1,13 +1,23 @@
 <% extra_classes ||= '' %>
 
 <div class="use-cases <%= extra_classes %>">
-  <h3 id="<%= id %>">
+  <h3 class="fr-mb-2v" id="<%= id %>">
     <%= t('.title') %>
   </h3>
 
-  <h5>
+  <h6 class="fr-pt-2w fr-mb-1v">
+    <%= t('.format.title') %>
+  </h6>
+
+  <% @endpoint.format.each do |format| %>
+    <div>
+      <%= format %>
+    </div>
+  <% end %>
+
+  <h6 class="fr-pt-2w fr-mb-1v">
     <%= t('.parameters.title', count: @endpoint.parameters.count) %>
-  </h5>
+  </h6>
 
   <% @endpoint.parameters.each do |parameter| %>
     <div>

--- a/config/endpoints/10_dgfip_chiffres_affaires.yml
+++ b/config/endpoints/10_dgfip_chiffres_affaires.yml
@@ -31,6 +31,11 @@
 
       Pour chaque exercice, le chiffre d’affaires en euros et la date de fin de l’exercice sont transmis.
   opening: protected
+  format:
+    - Donnée structurée JSON 
+  availability: 
+    opening_time:
+      7jours/7 et 23h/24 (Opérations de maintenance toutes les nuits entre 1h et 2h)
   use_cases:
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/11_inpi_comptes_annuels_rncs.yml
+++ b/config/endpoints/11_inpi_comptes_annuels_rncs.yml
@@ -45,6 +45,11 @@
       {:.fr-highlight}
       > API Entreprise vous permet d'accéder à des données protégées : les comptes annuels confidentiels, qui représentent environ 45% des bilans déposés.
   opening: protected
+  format:
+    - Archive ZIP contenant des documents PDF et les métadonnées de ces documents dans un XML. 
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24 
   use_cases:
     - Marchés publics
     - Détection de la fraude

--- a/config/endpoints/12_bdf_bilans.yml
+++ b/config/endpoints/12_bdf_bilans.yml
@@ -40,6 +40,14 @@
 
       La Banque de France délivre également une évolution des montants de l’exercice concerné avec l’année N-1, quand les durées d’exercices sont identiques.
   opening: protected
+  format:
+    - Donnée structurée JSON 
+  availability: 
+    opening_time:
+      7 jours/7, de 8h à 23h.
+      <br />
+      <br />
+      Opérations de maintenance toutes les nuits entre 23h et 8h. Durant ce laps de temps, la base de données ou une partie de l'applicatif peut être affecté.
   use_cases:
     - Détection de la fraude
   use_cases_forbidden:

--- a/config/endpoints/13_dgfip_liasses_fiscales.yml
+++ b/config/endpoints/13_dgfip_liasses_fiscales.yml
@@ -48,6 +48,11 @@
       - Des informations sur le formulaire complêté par l'entreprise, à l'origine des données transmises ;
       - Les données de la déclaration.
   opening: protected
+  format:
+    - Donnée structurée JSON 
+  availability: 
+    opening_time:
+      7jours/7 et 23h/24 (Opérations de maintenance toutes les nuits entre 1h et 2h)
   use_cases:
     - Détection de la fraude
   use_cases_forbidden:

--- a/config/endpoints/14_dgfip_attestation_fiscale.yml
+++ b/config/endpoints/14_dgfip_attestation_fiscale.yml
@@ -40,6 +40,11 @@
   data:
     description: "Cette API délivre l'attestation de régularité fiscale d'une entreprise, au format PDF.
     L'attestation est **délivrée ✅ si l'entreprise est en règle de ses obligations** déclaratives et de paiement d'IS et de TVA."
+  format:
+    - URL vers l'attestation en PDF
+  availability: 
+    opening_time:
+      7jours/7 et 23h/24 (Opérations de maintenance toutes les nuits entre 1h et 2h)
   use_cases:
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/15_urssaf_attestation_vigilance.yml
+++ b/config/endpoints/15_urssaf_attestation_vigilance.yml
@@ -24,6 +24,11 @@
   call_id: "SIREN"
   parameters:
     - Numéro de SIREN de l'entreprise
+  format:
+    - URL vers l'attestation en PDF
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24
   use_cases:
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/16_msa_conformites_cotisations.yml
+++ b/config/endpoints/16_msa_conformites_cotisations.yml
@@ -50,6 +50,11 @@
       Depuis 2021, la conformité n'est délivrée que si la contribution annuelle de l'OETH (Obligation d’Emploi de Travailleur Handicapé) a été acquittée par l'entreprise. Cette compétence était auparavant attribuée à l'AGEFIPH.
 
   opening: protected
+  format:
+    - Donnée structurée JSON
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24
   use_cases:
     - Marchés publics
   use_cases_optional:

--- a/config/endpoints/17_probtp_conformites_cotisations_retraite.yml
+++ b/config/endpoints/17_probtp_conformites_cotisations_retraite.yml
@@ -25,6 +25,11 @@
     description: |+
       Cette API délivre l'attestation PROBTP au format PDF permettant de savoir si l'entreprise est à jour de ses cotisations retraite à la Protection Sociale du Bâtiment et des Travaux publics (PROBTP).
   opening: protected
+  format:
+    - Donnée structurée JSON
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24
   use_cases:
     - Marchés publics
   use_cases_optional:

--- a/config/endpoints/18_fntp_cartes_pro_travaux_publics.yml
+++ b/config/endpoints/18_fntp_cartes_pro_travaux_publics.yml
@@ -29,6 +29,11 @@
     description: |+
       Cette API délivre la carte professionnelle de travaux publics d'une entreprise, au format PDF, lorsque cette dernière est en règle de ses obligations sociales, administratives et juridiques.
   opening: public
+  format:
+    - URL vers le document en PDF
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24
   use_cases:
     - Marchés publics
   use_cases_optional:

--- a/config/endpoints/19_cnetp_attestations_cotisations_conges_payes_chomage_intemperies.yml
+++ b/config/endpoints/19_cnetp_attestations_cotisations_conges_payes_chomage_intemperies.yml
@@ -34,6 +34,11 @@
     description: |+
       Cette API permet d'obtenir au format PDF une attestation délivrée à l'entreprise sous réserve que celle-ci&nbsp; soit à jour de ses déclarations et du paiement de cotisations congés payés et chômage-intempéries.
   opening: protected
+  format:
+    - URL vers l'attestation en PDF
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24
   use_cases:
     - Marchés publics
   use_cases_optional:

--- a/config/endpoints/1_insee_etablissements.yml
+++ b/config/endpoints/1_insee_etablissements.yml
@@ -41,6 +41,9 @@
     - Numéro de SIRET de l'établissement
   format: &insee_etablissements_format
     - Donnée structurée JSON 
+  availability: 
+    opening_time: &insee_etablissements_opening_time
+      7jours/7 et 24h/24 
   use_cases:
     - Marchés publics
     - Aides publiques
@@ -147,6 +150,8 @@
     - Marchés publics
     - Aides publiques
   format: *insee_etablissements_format
+  availability: 
+    opening_time: *insee_etablissements_opening_time
   parameters: *insee_etablissements_parameters
   call_id: *insee_etablissements_call_id
   provider_uids: *insee_etablissements_provider_uids

--- a/config/endpoints/1_insee_etablissements.yml
+++ b/config/endpoints/1_insee_etablissements.yml
@@ -39,6 +39,8 @@
   call_id: &insee_etablissements_call_id SIRET
   parameters: &insee_etablissements_parameters
     - Numéro de SIRET de l'établissement
+  format: &insee_etablissements_format
+    - Donnée structurée JSON 
   use_cases:
     - Marchés publics
     - Aides publiques
@@ -144,6 +146,7 @@
     - Préremplissage d'un formulaire
     - Marchés publics
     - Aides publiques
+  format: *insee_etablissements_format
   parameters: *insee_etablissements_parameters
   call_id: *insee_etablissements_call_id
   provider_uids: *insee_etablissements_provider_uids

--- a/config/endpoints/20_agencebio_certifications_bio.yml
+++ b/config/endpoints/20_agencebio_certifications_bio.yml
@@ -50,7 +50,7 @@
       > ℹ️ L’accès aux certificats n’est pas direct comme pour les autres endpoints API Entreprise. Les documents sont accessibles en suivant le lien transmis, permettant de se rendre sur la page HTML de l’organisme certificateur, sur laquelle il est possible de télécharger le certificat.
   opening: public
   format:
-    - Donnée structurée JSON et URL de téléchargement du certificat en PDF
+    - Donnée structurée JSON et URL vers le certificat en PDF
   availability: 
     opening_time:
       7jours/7 et 24h/24

--- a/config/endpoints/20_agencebio_certifications_bio.yml
+++ b/config/endpoints/20_agencebio_certifications_bio.yml
@@ -49,6 +49,11 @@
       {:.fr-highlight}
       > ℹ️ L’accès aux certificats n’est pas direct comme pour les autres endpoints API Entreprise. Les documents sont accessibles en suivant le lien transmis, permettant de se rendre sur la page HTML de l’organisme certificateur, sur laquelle il est possible de télécharger le certificat.
   opening: public
+  format:
+    - Donnée structurée JSON et URL de téléchargement du certificat en PDF
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24
   use_cases_optional:
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/21_ademe_certifications_rge.yml
+++ b/config/endpoints/21_ademe_certifications_rge.yml
@@ -42,6 +42,11 @@
         - _Céquami_ délivre des certifications à des professionnels à même de proposer des travaux de rénovation lourde dans le cadre d'une rénovation énergétique globale du logement.
         - _Certibat_ délivre des certifications aux professionnels du bâtiment en mesure de réaliser des offres globales de rénovation énergétique
   opening: public
+  format:
+    - Donnée structurée JSON et URL vers le certificat en PDF
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24
   use_cases_optional:
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/22_qualibat_certifications_batiment.yml
+++ b/config/endpoints/22_qualibat_certifications_batiment.yml
@@ -52,6 +52,11 @@
 
       [**Source : Qualibat**](https://www.qualibat.com/){:target="_blank"}
   opening: public
+  format:
+    - URL vers le certificat en PDF
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24
   use_cases_optional:
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/23_opqibi_certifications_ingenierie.yml
+++ b/config/endpoints/23_opqibi_certifications_ingenierie.yml
@@ -35,6 +35,11 @@
       > Une qualification probatoire est attribuée à une entreprise nouvellement créée ou en cours de diversification qui ne dispose pas encore de référence ou en nombre insuffisant mais satisfait aux critères légaux, administratifs, juridiques et moyens.
 
   opening: public
+  format:
+    - Donnée structurée JSON et URL vers le certificat en PDF
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24
   use_cases_optional:
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/24_inpi_brevets.yml
+++ b/config/endpoints/24_inpi_brevets.yml
@@ -29,6 +29,11 @@
       
       Il vous est possible d'augmenter ou de réduire le nombre de brevets pour lesquels les informations sont renvoyées, en paramétrant la requête avec un nombre entre 1 et 20.
   opening: public
+  format:
+    - Donnée structurée JSON
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24
   use_cases:
     - Marchés publics
   use_cases_optional:

--- a/config/endpoints/25_inpi_marques.yml
+++ b/config/endpoints/25_inpi_marques.yml
@@ -28,6 +28,11 @@
       
       Il vous est possible d'augmenter ou de réduire le nombre de marques pour lesquelles les informations sont renvoyées, en paramétrant la requête avec un nombre entre 1 et 20.
   opening: public
+  format:
+    - Donnée structurée JSON
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24
   use_cases_optional:
     - Aides publiques
     - Préremplissage d'un formulaire

--- a/config/endpoints/26_inpi_modeles.yml
+++ b/config/endpoints/26_inpi_modeles.yml
@@ -29,6 +29,11 @@
       
       Il vous est possible d'augmenter ou de réduire le nombre de dessins & modèles pour lesquels les informations sont renvoyées, en paramétrant la requête avec un nombre entre 1 et 20.
   opening: public
+  format:
+    - Donnée structurée JSON
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24
   use_cases_optional:
     - Aides publiques
     - Préremplissage d'un formulaire

--- a/config/endpoints/2_infogreffe_extrait_rcs.yml
+++ b/config/endpoints/2_infogreffe_extrait_rcs.yml
@@ -46,6 +46,11 @@
       
       
   opening: public
+  format:
+    - Donnée structurée JSON 
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24 
   use_cases:
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/2_infogreffe_mandataires_sociaux.yml
+++ b/config/endpoints/2_infogreffe_mandataires_sociaux.yml
@@ -31,6 +31,11 @@
       - S'il s'agit de personnes morales : le numéro de SIREN, la raison sociale et le nom du greffe seront précisés ;
       - S'il s'agit de personnes physiques : le nom, le prénom, la date de naissance, ainsi que le lieu de naissance de la personne physique seront indiqués.
   opening: protected
+  format:
+    - Donnée structurée JSON 
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24 
   use_cases:
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/3_insee_adresse_etablissement.yml
+++ b/config/endpoints/3_insee_adresse_etablissement.yml
@@ -39,6 +39,11 @@
   call_id: &insee_adresse_etablissement_call_id SIRET
   parameters: &insee_adresse_etablissement_parameters
     - Numéro de SIRET de l'établissement
+  format: &insee_adresse_etablissement_format
+    - Donnée structurée JSON 
+  availability: 
+    opening_time: &insee_adresse_etablissement_opening_time
+      7jours/7 et 24h/24 
   use_cases_optional:
     - Marchés publics
     - Aides publiques
@@ -121,6 +126,9 @@
     - entreprises
     - associations
   opening: public
+  format: *insee_adresse_etablissement_format
+  availability: 
+    opening_time: *insee_adresse_etablissement_opening_time
   use_cases:
     - Préremplissage d'un formulaire
   use_cases_optional:

--- a/config/endpoints/3_insee_siege_social.yml
+++ b/config/endpoints/3_insee_siege_social.yml
@@ -39,6 +39,11 @@
   call_id: &insee_siege_social_call_id SIREN
   parameters: &insee_siege_social_parameters
     - Numéro de SIREN de l'unité légale
+  format: &insee_siege_social_format
+    - Donnée structurée JSON 
+  availability: 
+    opening_time: &insee_siege_social_opening_time
+      7jours/7 et 24h/24 
   use_cases:
     - Détection de la fraude
   use_cases_optional:
@@ -146,6 +151,9 @@
     know_more_description: *insee_siege_social_know_more_description
     entities: *insee_siege_entities
   opening: public
+  format: *insee_siege_social_format
+  availability: 
+    opening_time: *insee_siege_social_opening_time
   use_cases:
     - Préremplissage d'un formulaire
   use_cases_optional:

--- a/config/endpoints/3_insee_unites_legales.yml
+++ b/config/endpoints/3_insee_unites_legales.yml
@@ -36,6 +36,11 @@
   call_id: &insee_unites_legales_call_id SIREN
   parameters: &insee_unites_legales_parameters
     - Numéro de SIREN de l'unité légale
+  format: &insee_unites_legales_format
+    - Donnée structurée JSON 
+  availability: 
+    opening_time: &insee_unites_legales_opening_time
+      7jours/7 et 24h/24 
   use_cases_optional:
     - Marchés publics
     - Aides publiques
@@ -152,6 +157,9 @@
     - entreprises
     - associations
   opening: public
+  format: *insee_unites_legales_format
+  availability: 
+    opening_time: *insee_unites_legales_opening_time
   use_cases:
     - Détection de la fraude
     - Préremplissage d'un formulaire

--- a/config/endpoints/4_ministere_interieur_documents_associations.yml
+++ b/config/endpoints/4_ministere_interieur_documents_associations.yml
@@ -26,6 +26,11 @@
       ⚠️ Le type et le nombre de documents délivrés varient selon l'association.
 
   opening: public
+  format:
+    - URL vers documents PDF
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24 
   use_cases:
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/4_ministere_interieur_rna.yml
+++ b/config/endpoints/4_ministere_interieur_rna.yml
@@ -27,6 +27,11 @@
       > Vous pouvez l'orienter vers le [site officiel Le compte Asso](https://lecompteasso.associations.gouv.fr/declarer-un-changement-de-situation-de-mon-association/){:target="_blank"} où elle pourra déclarer son changement de situation.
 
   opening: public
+  format:
+    - Donnée structurée JSON 
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24 
   use_cases:
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/5_inpi_actes.yml
+++ b/config/endpoints/5_inpi_actes.yml
@@ -23,6 +23,11 @@
       ℹ️ Dans le cas où un acte est manquant, si celui-ci est postérieur à 1993, l'INPI peut essayer de numériser le document qui fait défaut.
       Envoyez-nous votre demande détaillée en passant par le [support](<%= faq_index_path %>)
   opening: public
+  format:
+    - Donnée structurée JSON 
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24 
   use_cases:
     - Marchés publics
     - Préremplissage d'un formulaire

--- a/config/endpoints/6_fabnum_conventions_collectives.yml
+++ b/config/endpoints/6_fabnum_conventions_collectives.yml
@@ -32,6 +32,11 @@
       - l'identifiant IDCC, numéro à 4 chiffres ;
       - l'URL Légifrance du texte en vigueur.
   opening: public
+  format:
+    - Donnée structurée JSON 
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24 
   use_cases:
     - Marchés publics
   use_cases_optional:

--- a/config/endpoints/7_cmafrance_rnm.yml
+++ b/config/endpoints/7_cmafrance_rnm.yml
@@ -49,6 +49,11 @@
       - des informations en cas de double immatriculation ;
       - des informations spécifiques au RNM (identifiants, dates d'import et date de mise à jour des données).
   opening: public
+  format:
+    - Donnée structurée JSON 
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24 
   use_cases:
     - Marchés publics
     - Aides publiques

--- a/config/endpoints/8_urssaf_effectifs.yml
+++ b/config/endpoints/8_urssaf_effectifs.yml
@@ -20,6 +20,11 @@
   call_id: "SIREN"
   parameters:
     - Numéro de SIREN de l'unité légale ou numéro de SIRET de l'établissement
+  format:
+    - Donnée structurée JSON 
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24 
   use_cases:
     - Détection de la fraude
   use_cases_forbidden:

--- a/config/endpoints/9_douanes_eori.yml
+++ b/config/endpoints/9_douanes_eori.yml
@@ -33,6 +33,11 @@
       > ⚠️ Une réponse **statut inactif peut être un faux négatif** : Si vous utilisez le SIRET d'une entreprise dont vous ne connaissez pas le pays d'immatriculation, il se peut que le statut inactif corresponde au fait que l'appel ne fonctionne pas (dans le cas où l'entreprise n'a pas été immatriculée en France). 
 
   opening: public
+  format:
+    - Donnée structurée JSON 
+  availability: 
+    opening_time:
+      7jours/7 et 24h/24 
   use_cases:
     - Détection de la fraude
   use_cases_optional:

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -286,14 +286,16 @@ fr:
           description: "Liste des cas d'usage où cette API est peut être utile :"
       details:
         title: "Détails de l'API"
+        format: 
+          title: "Format de l'information"
         parameters:
           title:
-            one: "Paramètre"
-            other: "Paramètres"
+            one: "Indentifiant d'appel"
+            other: "Indentifiants d'appel"
         availability:
           title: "Disponibilité"
         technical_specifications:
-          title: "Spécifications techniques"
+          title: "Spécifications techniques :"
           cta: "Consulter le swagger"
       property:
         array:

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -295,8 +295,8 @@ fr:
           link: "Page de statut des API"
         parameters:
           title:
-            one: "Indentifiant d'appel"
-            other: "Indentifiants d'appel"
+            one: "Identifiant d'appel"
+            other: "Identifiants d'appel"
         technical_specifications:
           title: "Spécifications techniques :"
           cta: "Consulter le swagger"

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -288,12 +288,15 @@ fr:
         title: "Détails de l'API"
         format: 
           title: "Format de l'information"
+        availability:
+          title: "Disponibilité"
+          opening_time:
+              title: "Horaires de fonctionnement :"
+          link: "Page de statut des API"
         parameters:
           title:
             one: "Indentifiant d'appel"
             other: "Indentifiants d'appel"
-        availability:
-          title: "Disponibilité"
         technical_specifications:
           title: "Spécifications techniques :"
           cta: "Consulter le swagger"


### PR DESCRIPTION
Cette PR ajoute des informations dans la partie de droite de la fiche métier : 
- Le format de l'information transmise par l'API
- Les horaires standards de fonctionnement
- Le lien vers la page de statut.

**Capture d'écran du rendu :**
![Capture d’écran 2022-09-20 à 19 10 46](https://user-images.githubusercontent.com/46896006/191321687-5fd6caca-0a1a-4fcd-9d5b-3002310f48de.png)
