### PR TITLE
Bannière bureau ouvert

### DIFF
--- a/app/views/shared/api_entreprise/header/_menu.html.erb
+++ b/app/views/shared/api_entreprise/header/_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="fr-header__menu fr-modal" id="modal-header-menu" aria-labelledby="fr-btn-menu-mobile-1">
-  
+
   <div class="fr-container">
     <button class="fr-link--close fr-link" aria-controls="modal-header-menu">
       Fermer
@@ -37,18 +37,17 @@
     <% end %>
   </div>
 
-    <div class="fr-notice fr-notice--info">
-      <div class="fr-container">
-        <div class="fr-notice__body">
-          <p class="fr-notice__title fr-text--regular">
+  <div class="fr-notice fr-notice--info">
+    <div class="fr-container">
+      <div class="fr-notice__body">
+        <p class="fr-notice__title fr-text--regular">
           <% if action_name == 'developers' || action_name == 'guide_migration' %>
-            <%= t('.banner_tech_migration', date: OpenBureauDate.new.next_date.strftime('%d/%m/%Y')).html_safe %>
-            <% else %>
-            <%= t('.banner_migration', date: OpenBureauDate.new.next_date.strftime('%d/%m/%Y')).html_safe %>
-            <% end %>
-          </p>
-        </div>
+            <%= t('.banner.tech_migration', date: OpenBureauDate.new.next_date.strftime('%d/%m/%Y')).html_safe %>
+          <% else %>
+            <%= t('.banner.default', date: OpenBureauDate.new.next_date.strftime('%d/%m/%Y')).html_safe %>
+          <% end %>
+        </p>
       </div>
-
+    </div>
   </div>
 </div>

--- a/app/views/shared/api_entreprise/header/_menu.html.erb
+++ b/app/views/shared/api_entreprise/header/_menu.html.erb
@@ -1,13 +1,5 @@
 <div class="fr-header__menu fr-modal" id="modal-header-menu" aria-labelledby="fr-btn-menu-mobile-1">
-  <div class="fr-notice fr-notice--info">
-    <div class="fr-container">
-      <div class="fr-notice__body">
-        <p class="fr-notice__title">
-          <%= t('.banner_migration', date: OpenBureauDate.new.next_date.strftime('%d/%m/%Y')).html_safe %>
-        </p>
-      </div>
-    </div>
-  </div>
+  
   <div class="fr-container">
     <button class="fr-link--close fr-link" aria-controls="modal-header-menu">
       Fermer
@@ -42,6 +34,17 @@
           </li>
         </ul>
       </nav>
+    <% end %>
+  </div>
+    <% if action_name == 'developers' || action_name == 'guide_migration' || action_name == 'endpoints' %>
+    <div class="fr-notice fr-notice--info">
+      <div class="fr-container">
+        <div class="fr-notice__body">
+          <p class="fr-notice__title">
+            <%= t('.banner_migration', date: OpenBureauDate.new.next_date.strftime('%d/%m/%Y')).html_safe %>
+          </p>
+        </div>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/api_entreprise/header/_menu.html.erb
+++ b/app/views/shared/api_entreprise/header/_menu.html.erb
@@ -36,15 +36,19 @@
       </nav>
     <% end %>
   </div>
-    <% if action_name == 'developers' || action_name == 'guide_migration' || action_name == 'endpoints' %>
+
     <div class="fr-notice fr-notice--info">
       <div class="fr-container">
         <div class="fr-notice__body">
-          <p class="fr-notice__title">
+          <p class="fr-notice__title fr-text--regular">
+          <% if action_name == 'developers' || action_name == 'guide_migration' %>
+            <%= t('.banner_tech_migration', date: OpenBureauDate.new.next_date.strftime('%d/%m/%Y')).html_safe %>
+            <% else %>
             <%= t('.banner_migration', date: OpenBureauDate.new.next_date.strftime('%d/%m/%Y')).html_safe %>
+            <% end %>
           </p>
         </div>
       </div>
-    <% end %>
+
   </div>
 </div>

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -26,8 +26,9 @@ fr:
           usages: "<strong>Cas d'usages</strong><br /> Fiches pratiques"
           developer: "<strong>Espace développeur</strong><br /> & spécifications techniques"
           ask_access: "<strong>Demander un accès</strong><br />🔑 Vérifier votre éligibilité"
-          banner_migration: "<strong>Nouvelle version de l'API</strong> : Bureau ouvert <a href='https://webconf.numerique.gouv.fr/APIEntreprise00Version3'>en visio</a> le %{date} à 10 heures. <a href='/faq#quand-et-pourquoi-un-bureau-ouvert'>En savoir plus ➜</a>"
-          banner_tech_migration: "<strong>Une question sur la migration vers la V3 ?</strong> Un tech et un métier vous répondent au bureau ouvert <a href='https://webconf.numerique.gouv.fr/APIEntreprise00Version3'>en visio</a> le %{date} à 10 heures. <a href='/faq#quand-et-pourquoi-un-bureau-ouvert'>En savoir plus ➜</a>"
+          banner:
+            default: "<strong>Nouvelle version de l'API</strong> : Bureau ouvert <a href='https://webconf.numerique.gouv.fr/APIEntreprise00Version3'>en visio</a> le %{date} à 10 heures. <a href='/faq#quand-et-pourquoi-un-bureau-ouvert'>En savoir plus ➜</a>"
+            tech_migration: "<strong>Une question sur la migration vers la V3 ?</strong> Un tech et un métier vous répondent au bureau ouvert <a href='https://webconf.numerique.gouv.fr/APIEntreprise00Version3'>en visio</a> le %{date} à 10 heures. <a href='/faq#quand-et-pourquoi-un-bureau-ouvert'>En savoir plus ➜</a>"
       newsletter_banner:
         title: "Abonnez-vous à nos lettres d’information"
         description: "Restez informés des dernières API disponibles, des nouvelles fonctionnalités et évolutions techniques, ou encore des opérations de maintenance et incidents."

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -26,7 +26,8 @@ fr:
           usages: "<strong>Cas d'usages</strong><br /> Fiches pratiques"
           developer: "<strong>Espace développeur</strong><br /> & spécifications techniques"
           ask_access: "<strong>Demander un accès</strong><br />🔑 Vérifier votre éligibilité"
-          banner_migration: "Une question sur la migration vers la V3 ? Un tech et un métier vous répondent au bureau ouvert <a href='https://webconf.numerique.gouv.fr/APIEntreprise00Version3'>en visio</a>. Prochaine date : le %{date} à 10 heures. <a href='/faq#quand-et-pourquoi-un-bureau-ouvert'>En savoir plus ➜</a>"
+          banner_migration: "<strong>Nouvelle version de l'API</strong> : Bureau ouvert <a href='https://webconf.numerique.gouv.fr/APIEntreprise00Version3'>en visio</a> le %{date} à 10 heures. <a href='/faq#quand-et-pourquoi-un-bureau-ouvert'>En savoir plus ➜</a>"
+          banner_tech_migration: "<strong>Une question sur la migration vers la V3 ?</strong> Un tech et un métier vous répondent au bureau ouvert <a href='https://webconf.numerique.gouv.fr/APIEntreprise00Version3'>en visio</a> le %{date} à 10 heures. <a href='/faq#quand-et-pourquoi-un-bureau-ouvert'>En savoir plus ➜</a>"
       newsletter_banner:
         title: "Abonnez-vous à nos lettres d’information"
         description: "Restez informés des dernières API disponibles, des nouvelles fonctionnalités et évolutions techniques, ou encore des opérations de maintenance et incidents."


### PR DESCRIPTION
### Ce que fait cette PR

- Déplace la bannière sous la barre de navigation / cf dsfr
- Un message légèrement différent selon l'espace concerné :

### Captures d'écran du résultat

**Espace développeur et guide de migration** : Parle spécifiquement de migration 

<img width="1167" alt="Capture d’écran 2022-10-11 à 16 47 30" src="https://user-images.githubusercontent.com/46896006/195124036-5757a6c5-c097-499e-a74e-0c903636a2af.png">

**Ailleurs sur le site** : Message plus court, annonce la nouvelle version de l'API

<img width="1168" alt="Capture d’écran 2022-10-11 à 16 47 23" src="https://user-images.githubusercontent.com/46896006/195124030-07a44dd4-c4c2-49c4-b360-cb42fb355224.png">

