### PR TITLE
Add /stats for API Entreprise/Particulier

### DIFF
--- a/app/assets/stylesheets/commons.scss
+++ b/app/assets/stylesheets/commons.scss
@@ -60,5 +60,5 @@ summary {
   bottom: 0;
   right: 0;
   width: 100%;
-  height: 100%;
+  height: 102%;
 }

--- a/app/assets/stylesheets/commons.scss
+++ b/app/assets/stylesheets/commons.scss
@@ -45,3 +45,20 @@ turbo-frame {
 summary {
   text-decoration: underline 2px solid black;
 }
+
+.iframe-container {
+  position: relative;
+  width: 100%;
+  padding-bottom: 100%;
+  height: 0;
+}
+
+.responsive-iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/app/controllers/api_entreprise/stats_controller.rb
+++ b/app/controllers/api_entreprise/stats_controller.rb
@@ -1,0 +1,5 @@
+class APIEntreprise::StatsController < APIEntrepriseController
+  def index
+    render 'index'
+  end
+end

--- a/app/controllers/api_particulier/stats_controller.rb
+++ b/app/controllers/api_particulier/stats_controller.rb
@@ -1,0 +1,5 @@
+class APIParticulier::StatsController < APIParticulierController
+  def index
+    render 'index'
+  end
+end

--- a/app/views/api_entreprise/stats/index.html.erb
+++ b/app/views/api_entreprise/stats/index.html.erb
@@ -1,0 +1,8 @@
+<div class="iframe-container">
+  <iframe
+      id="stats-api-entreprise"
+      src="https://metabase.entreprise.api.gouv.fr/public/dashboard/e21aab06-f1f8-46ad-8102-55bc0feb1198"
+      class="responsive-iframe"
+      allowtransparency
+      ></iframe>
+</div>

--- a/app/views/api_particulier/stats/index.html.erb
+++ b/app/views/api_particulier/stats/index.html.erb
@@ -1,0 +1,8 @@
+<div class="iframe-container">
+  <iframe
+      id="stats-api-particulier"
+      src="https://metabase.entreprise.api.gouv.fr/public/dashboard/6de16a37-f4ad-495c-9dd9-60d2995e3e7f"
+      class="responsive-iframe"
+      allowtransparency
+      ></iframe>
+</div>

--- a/bin/deploy-sandbox
+++ b/bin/deploy-sandbox
@@ -8,5 +8,5 @@ fi
 
 server="dashboard.entreprise.api.gouv.fr"
 
-bundle exec mine deploy domain=$server branch=$branch to=sandbox
+bundle exec mina deploy domain=$server branch=$branch to=sandbox
 bundle exec mina seeds domain=$server branch=$branch to=sandbox

--- a/config/routes/api_entreprise.rb
+++ b/config/routes/api_entreprise.rb
@@ -12,6 +12,8 @@ constraints(APIEntrepriseDomainConstraint.new) do
     root to: redirect('/compte/se-connecter'), as: :dashboard_root, constraints: { subdomain: 'dashboard.entreprise.api' }
     root to: 'pages#home'
 
+    get '/stats', to: 'stats#index'
+
     get '/compte/se-connecter', to: 'sessions#new', as: :login
     delete '/compte/deconnexion', to: 'sessions#destroy', as: :logout
 

--- a/config/routes/api_particulier.rb
+++ b/config/routes/api_particulier.rb
@@ -2,6 +2,8 @@ constraints(APIParticulierDomainConstraint.new) do
   namespace :api_particulier, path: '' do
     get '/', to: redirect('https://api.gouv.fr/les-api/api-particulier', status: 302)
 
+    get '/stats', to: 'stats#index'
+
     get '/compte/se-connecter', to: 'sessions#new', as: :login
     delete '/compte/deconnexion', to: 'sessions#destroy', as: :logout
 

--- a/spec/features/api_entreprise/stats_spec.rb
+++ b/spec/features/api_entreprise/stats_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API Entreprise stats', app: :api_entreprise do
+  describe 'GET API Entreprise stats' do
+    before { visit stats_path }
+
+    it 'renders the stats page' do
+      expect(page).to have_selector('iframe#stats-api-entreprise')
+    end
+  end
+end

--- a/spec/features/api_particulier/stats_spec.rb
+++ b/spec/features/api_particulier/stats_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'API Entreprise stats', app: :api_particulier do
+  describe 'GET API Particulier stats' do
+    before { visit api_particulier_stats_path }
+
+    it 'renders the stats page' do
+      expect(page).to have_selector('iframe#stats-api-particulier')
+    end
+  end
+end


### PR DESCRIPTION
Il a été demandé qu'on remette une page de stats

Je n'ai pas réussi à avoir une iframe sans scroll bar...
Et je ne suis pas certain que mon tests soit des plus utile... J'aurai voulu testé le contenu de l'iframe mais sans succès 

Déployé ici : 
- https://sandbox.entreprise.api.gouv.fr/stats
- https://sandbox.particulier.api.gouv.fr/stats