### PR TITLE
[Fiche métier] Tags cas d'usages cliquables

### DIFF
--- a/app/views/api_entreprise/endpoints/_use_cases.html.erb
+++ b/app/views/api_entreprise/endpoints/_use_cases.html.erb
@@ -13,9 +13,7 @@
     <ul class="fr-tags-group fr-mt-2w">
       <% @endpoint.use_cases.each do |use_case| %>
         <li class="fr-mb-1w">
-          <span class="fr-tag">
-            <%= use_case %>
-          </span>
+          <a href="/cas_usages/aides_publiques" class="fr-tag" target="_self"><%= use_case %></a>
         </li>
       <% end %>
     </ul>
@@ -29,9 +27,7 @@
     <ul class="fr-tags-group fr-mt-2w">
       <% @endpoint.use_cases_optional.each do |use_case| %>
         <li class="fr-mb-1w">
-          <span class="fr-tag">
-            <%= use_case %>
-          </span>
+          <a href="/cas_usages/aides_publiques" class="fr-tag" target="_self"><%= use_case %></a>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
Pour plus de lien entre les fiches métiers des API et les cas d'usages, rendre cliquables les cas d'usages de l'encadré à droite : 

![image](https://user-images.githubusercontent.com/46896006/216638474-17578405-1964-46fa-be09-67794d5a7b15.png)
