### PR TITLE
[Fiche métier] Introduit un champ explicatif des évolutions par rapport à la version précédente

### DIFF
--- a/app/models/endpoint.rb
+++ b/app/models/endpoint.rb
@@ -13,7 +13,8 @@ class Endpoint < ApplicationAlgoliaSearchableActiveModel
     :use_cases_optional,
     :use_cases_forbidden,
     :keywords,
-    :opening
+    :opening,
+    :historique
 
   attr_writer :new_endpoint_uids, :old_endpoint_uids
 

--- a/app/views/api_entreprise/endpoints/show.html.erb
+++ b/app/views/api_entreprise/endpoints/show.html.erb
@@ -248,7 +248,7 @@
           </h2>
           <%= markdown_to_html(@endpoint.historique) %>
           <% if @endpoint.old_endpoints.any? %>
-            <p class="fr-text--bold fr-mb-1v"><%= t('.historique.old_endpoints.description') %></p>
+            <p class="fr-text--bold fr-mb-1v fr-mt-4w"><%= t('.historique.old_endpoints.description') %></p>
             <ul>
               <% @endpoint.old_endpoints.each do |endpoint| %>
                 <li>
@@ -256,7 +256,7 @@
                 </li>
               <% end %>
             </ul>
-            <p class="fr-text--sm fr-mt-4w fr-highlight"><%= t('.historique.old_endpoints.link_documentation').html_safe %></p>
+            <p class="fr-text--sm fr-mt-4w"><%= t('.historique.old_endpoints.link_documentation').html_safe %></p>
           <% end %>
         <% end %>
 

--- a/app/views/api_entreprise/endpoints/show.html.erb
+++ b/app/views/api_entreprise/endpoints/show.html.erb
@@ -246,18 +246,17 @@
           <h2 id="historique" class="fr-mt-md-5w fr-mt-8w">
             <%= t('.historique.title') %>
           </h2>
-
+          <%= markdown_to_html(@endpoint.historique) %>
           <% if @endpoint.old_endpoints.any? %>
-            <%= t('.historique.old_endpoints.description') %>
-
+            <p class="fr-text--bold fr-mb-1v"><%= t('.historique.old_endpoints.description') %></p>
             <ul>
               <% @endpoint.old_endpoints.each do |endpoint| %>
                 <li>
-                  <%= link_to endpoint.path, endpoint_path(uid: endpoint.uid) %>
+                  <%= link_to endpoint.uid, endpoint_path(uid: endpoint.uid) %>
                 </li>
               <% end %>
             </ul>
-            <p class="fr-text--sm fr-mt-4w"><%= t('.historique.old_endpoints.link_documentation').html_safe %></p>
+            <p class="fr-text--sm fr-mt-4w fr-highlight"><%= t('.historique.old_endpoints.link_documentation').html_safe %></p>
           <% end %>
         <% end %>
 

--- a/app/views/api_entreprise/endpoints/show.html.erb
+++ b/app/views/api_entreprise/endpoints/show.html.erb
@@ -253,10 +253,11 @@
             <ul>
               <% @endpoint.old_endpoints.each do |endpoint| %>
                 <li>
-                  <%= link_to endpoint.title, endpoint_path(uid: endpoint.uid) %>
+                  <%= link_to endpoint.path, endpoint_path(uid: endpoint.uid) %>
                 </li>
               <% end %>
             </ul>
+            <p class="fr-text--sm fr-mt-4w"><%= t('.historique.old_endpoints.link_documentation').html_safe %></p>
           <% end %>
         <% end %>
 

--- a/config/endpoints/15_urssaf_attestation_vigilance.yml
+++ b/config/endpoints/15_urssaf_attestation_vigilance.yml
@@ -138,6 +138,15 @@
     - q: &urssaf_attestations_faq_q3 L'API ne renvoie pas de pièce, peut-on considérer que l'entreprise n'est pas à jour ?
       a: &urssaf_attestations_faq_a3 |+
         Non, dans certain cas, l'API ne peut pas délivrer l'attestation, cela ne signifie pas que l'entreprise n'est pas à jour.
+  historique: |+
+    **Ce que change la V.4 par rapport à la V.3 :**
+    Ajout d'informations au format stucturé JSON : 
+    - Un statut `entity_status` permettant d'indiquer qu'une entité n'est pas à jour de ses cotisations ;
+    - Les dates de début et de fin de validité de l'attestation pour relancer un appel avant expiration de l'attestation ;
+    - Le code de sécurité de l'attestation.
+
+    **Ce qui ne change pas :**
+    À part l'ajout des champs précédents, rien n'a changé. L'attestation est toujours disponible en PDF par URL. Cette montée en version n'est pas dûe à une évolution de l'API de l'URSSAF, par conséquent, la V.3 est maintenue par API&nbsp;Entreprise.
 - uid: 'urssaf/v3/attestation_vigilance'
   position: 9001
   new_endpoint_uids:

--- a/config/endpoints/4_ministere_interieur_v4.yml
+++ b/config/endpoints/4_ministere_interieur_v4.yml
@@ -2,9 +2,6 @@
 - uid: 'djepva/associations'
   path: '/v4/djepva/api-association/associations/{siren_or_rna}'
   position: 150
-  old_endpoint_uids:
-    - 'ministere_interieur/rna'
-    - 'ministere_interieur/documents_associations'
   perimeter: &association_perimeter
     entity_type_description: &association_entity_type_description |+
       Cette API concerne ✅ **les associations** inscrites au répertoire national des associations (RNA) et/ou au répertoire Sirene.
@@ -101,9 +98,11 @@
     - q: Une association utilisatrice de votre démarche s'est aperçue que ses informations ne sont plus à jour ?
       a: |+
         Vous pouvez l'orienter vers le [site officiel Le compte Asso](https://lecompteasso.associations.gouv.fr/declarer-un-changement-de-situation-de-mon-association/){:target="_blank"} où elle pourra déclarer son changement de situation.
-
 - uid: 'djepva/associations_open_data'
   path: '/v4/djepva/api-association/associations/open_data/{siren_or_rna}'
+  old_endpoint_uids:
+    - 'ministere_interieur/rna'
+    - 'ministere_interieur/documents_associations'
   position: 151
   perimeter: *association_perimeter
   call_id: *call_id
@@ -144,3 +143,15 @@
     - Portail GRU - Instruction des démarches
     - Détection de la fraude
   faq: *association_faq
+  historique: |+
+    **Ce que change la V.4 par rapport à la V.3 :**
+    - Nouvelle structure de donnée : cette API fait suite aux deux API V.3 et réunit au même endroit les informations et documents des associations en open data. L'API propose plus de données&nbsp;;
+    - Nouvelle API source et nouveau fournisseur de donnée : la DJEPVA au travers de l'[API association](https://www.associations.gouv.fr/les-api-et-autres-outils.html){:target="_blank"}
+    - Le SIREN en paramètre d'appel.
+
+    **Ce qui ne change pas:**
+    - Les informations concernent l'unité légale ET les établissements de l'association. Vous pouvez donc toujours retrouver les informations relatives à un SIRET&nbsp;;
+    - L'API distribue les données du RNA&nbsp;;
+    - La donnée est en open data.
+
+

--- a/config/endpoints/template.yml.example
+++ b/config/endpoints/template.yml.example
@@ -101,3 +101,9 @@
     - q: "Question ?"
       a: |+
         Réponse à la question. Le markdown GFM est supporté ici.
+  historique: |+
+    **Ce que change la V.4 par rapport à la V.3 :**
+    Texte
+
+    **Ce qui ne change pas :**
+    Texte

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -271,7 +271,7 @@ fr:
         historique:
           title: "Historique"
           old_endpoints:
-            description: "Cette API remplace les anciennes API V.3+ ci-dessous :"
+            description: "Documentations des anciennes API :"
             link_documentation: |-
               Plus d'informations sur la gestion de version API&nbsp;Entreprise dans cette <a href='https://entreprise.api.gouv.fr/developpeurs#gerer-les-evolutions-de-version' target='_blank'>documentation</a>.
         cgu:

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -271,7 +271,9 @@ fr:
         historique:
           title: "Historique"
           old_endpoints:
-            description: "Cette API remplace les anciennes API ci-dessous ci-dessous :"
+            description: "Cette API remplace les anciennes API V.3+ ci-dessous :"
+            link_documentation: |-
+              Plus d'informations sur la gestion de version API&nbsp;Entreprise dans cette <a href='https://entreprise.api.gouv.fr/developpeurs#gerer-les-evolutions-de-version' target='_blank'>documentation</a>.
         cgu:
           title: "Conditions d'utilisation des données"
           main_title_opening: "Ouverture de la donnée :"


### PR DESCRIPTION
- Introduit un nouveau champ pour expliquer la différence avec l'API précédente
- Change le libellé des liens vers les anciennes doc afin qu'on voit la mention V3 quand celle-ci y figure (J'ai pas réussi "techniquement" à mettre le titre de l'API  + l'uid) 
- Ajoute un lien vers la doc "gestion de version"

![image](https://user-images.githubusercontent.com/46896006/223483969-12c7e8e8-7ad1-49dc-83aa-c3ddc0172f9f.png)

