### PR TITLE
Handling new datapass archive and revoke event

### DIFF
--- a/app/interactors/datapass_webhook/archive_or_delete_token.rb
+++ b/app/interactors/datapass_webhook/archive_or_delete_token.rb
@@ -1,0 +1,20 @@
+class DatapassWebhook::ArchiveOrDeleteToken < ApplicationInteractor
+  def call
+    return if %w[archive].exclude?(context.event)
+    return if token.blank?
+
+    if token.blacklisted?
+      return token.update!(
+        archived: true
+      )
+    end
+
+    token.delete
+  end
+
+  private
+
+  def token
+    context.authorization_request.token
+  end
+end

--- a/app/interactors/datapass_webhook/blacklist_token.rb
+++ b/app/interactors/datapass_webhook/blacklist_token.rb
@@ -1,0 +1,16 @@
+class DatapassWebhook::BlacklistToken < ApplicationInteractor
+  def call
+    return if %w[revoke].exclude?(context.event)
+    return if token.blank?
+
+    token.update!(
+      blacklisted: true
+    )
+  end
+
+  private
+
+  def token
+    context.authorization_request.token
+  end
+end

--- a/app/organizers/datapass_webhook/api_entreprise.rb
+++ b/app/organizers/datapass_webhook/api_entreprise.rb
@@ -8,6 +8,8 @@ module DatapassWebhook
       ::DatapassWebhook::FindOrCreateAuthorizationRequest,
       ::DatapassWebhook::CreateToken,
       ::DatapassWebhook::ArchivePreviousToken,
+      ::DatapassWebhook::BlacklistToken,
+      ::DatapassWebhook::ArchiveOrDeleteToken,
       ::DatapassWebhook::UpdateMailjetContacts,
       ::DatapassWebhook::ExtractMailjetVariables,
       ::DatapassWebhook::ScheduleAuthorizationRequestEmails

--- a/spec/interactors/datapass_webhook/archive_or_delete_token_spec.rb
+++ b/spec/interactors/datapass_webhook/archive_or_delete_token_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe DatapassWebhook::ArchiveOrDeleteToken, type: :interactor do
+  subject { described_class.call(datapass_webhook_params.merge(authorization_request:)) }
+
+  let(:authorization_request) { create(:authorization_request, tokens: [token]) }
+  let(:datapass_webhook_params) { build(:datapass_webhook, event:) }
+
+  let!(:token) { create(:token) }
+
+  context 'when event is archive' do
+    let(:event) { 'archive' }
+
+    context 'when token is already blacklisted' do
+      let(:token) { create(:token, blacklisted: true) }
+
+      it 'archives the given token' do
+        expect {
+          subject
+        }.to change { token.reload.archived }.to(true)
+      end
+    end
+
+    context 'when token is not yet blacklisted' do
+      it 'removes the given token' do
+        expect {
+          subject
+        }.to change { Token.all.count }
+      end
+    end
+  end
+
+  context 'when event is not archive' do
+    let(:event) { 'validate_application' }
+
+    it 'does not do anything' do
+      expect {
+        subject
+      }.not_to change { Token.where(archived: true).count }
+
+      expect {
+        subject
+      }.not_to change { Token.all.count }
+    end
+  end
+end

--- a/spec/interactors/datapass_webhook/blacklist_token_spec.rb
+++ b/spec/interactors/datapass_webhook/blacklist_token_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe DatapassWebhook::BlacklistToken, type: :interactor do
+  subject { described_class.call(datapass_webhook_params.merge(authorization_request:)) }
+
+  let(:authorization_request) { create(:authorization_request, tokens: [token]) }
+  let(:datapass_webhook_params) { build(:datapass_webhook, event:) }
+
+  let(:token) { create(:token) }
+
+  context 'when event is revoke' do
+    let(:event) { 'revoke' }
+
+    it 'blacklist the given token' do
+      expect {
+        subject
+      }.to change { token.reload.blacklisted }.to(true)
+    end
+  end
+
+  context 'when event is not revoke' do
+    let(:event) { %w[validate_application] }
+
+    it 'does not do anything' do
+      expect {
+        subject
+      }.not_to change { Token.where(blacklisted: true).count }
+    end
+  end
+end


### PR DESCRIPTION
closes #382

Blacklist current authorization request token on revoke event Delete current authorization request token on archive event if token is not blacklisted
Archive current authorization request token on archive event if token is blacklisted