### PR TITLE
Fiche metier api part

### DIFF
--- a/app/models/abstract_endpoint.rb
+++ b/app/models/abstract_endpoint.rb
@@ -7,6 +7,7 @@ class AbstractEndpoint < ApplicationAlgoliaSearchableActiveModel
     :provider_uids,
     :parameters,
     :perimeter,
+    :parameters_details,
     :data,
     :use_cases,
     :keywords

--- a/app/models/api_particulier/endpoint.rb
+++ b/app/models/api_particulier/endpoint.rb
@@ -6,6 +6,10 @@ class APIParticulier::Endpoint < AbstractEndpoint
   def use_cases_optional
     []
   end
+  
+  def maintenances
+    open_api_definition['x-maintenances']
+  end
 
   def collection?
     false

--- a/app/views/api_entreprise/endpoints/show.html.erb
+++ b/app/views/api_entreprise/endpoints/show.html.erb
@@ -28,7 +28,7 @@
             <%= t('.providers.description', count: @endpoint.providers.count) %>
           </div>
 
-          <p>
+          <p class="fr-text--lg fr-text--bold">
             <% @endpoint.providers.map do |provider| %>
               <%= t("providers.#{provider.name}") %>
             <% end.join(' & ') %>

--- a/app/views/api_particulier/endpoints/_details.html.erb
+++ b/app/views/api_particulier/endpoints/_details.html.erb
@@ -13,7 +13,7 @@
     Donnée structurée JSON
   </div>
 
-  <h3 class="fr-h6 fr-pt-2w fr-mb-1v">
+  <h3 class="fr-h6 fr-pt-4w fr-mb-1v">
     <%= t('.parameters.title', count: @endpoint.parameters.count) %>
   </h3>
 
@@ -24,8 +24,12 @@
       </li>
     <% end %>
   </ul>
+  <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" title="Détails des modalités d'appel" href="#parameters_details">
+  <%= t('.parameters.link') %>
+ </a>
+  
 
-  <h3 class="fr-h6 fr-pt-2w fr-mb-1v">
+  <h3 class="fr-h6 fr-pt-4w fr-mb-1v">
     <%= t('.availability.title') %>
   </h3>
   <a class="fr-pt-1v fr-link" title="API Entreprise Status Page" href="https://status.api.gouv.fr/" target="_blank">
@@ -39,7 +43,7 @@
     <% end %>
   </div>
 
-  <h3 class="fr-h5 fr-pt-2w">
+  <h3 class="fr-h5 fr-pt-4w">
     <%= t('.technical_specifications.title') %>
   </h3>
 

--- a/app/views/api_particulier/endpoints/_details.html.erb
+++ b/app/views/api_particulier/endpoints/_details.html.erb
@@ -25,6 +25,20 @@
     <% end %>
   </ul>
 
+  <h3 class="fr-h6 fr-pt-2w fr-mb-1v">
+    <%= t('.availability.title') %>
+  </h3>
+  <a class="fr-pt-1v fr-link" title="API Entreprise Status Page" href="https://status.api.gouv.fr/" target="_blank">
+    <%= t('.availability.link') %>
+  </a>
+  <div class="fr-pt-2w">
+    <% if @endpoint.maintenances.present? %>
+      <%= t('.availability.maintenance', from_hour: @endpoint.maintenances['from_hour'], to_hour: @endpoint.maintenances['to_hour']) %>
+    <% else %>
+      <%= t('.availability.no_maintenance') %>
+    <% end %>
+  </div>
+
   <h3 class="fr-h5 fr-pt-2w">
     <%= t('.technical_specifications.title') %>
   </h3>

--- a/app/views/api_particulier/endpoints/show.html.erb
+++ b/app/views/api_particulier/endpoints/show.html.erb
@@ -23,8 +23,8 @@
           <li>
               <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#cgu">Conditions d'utilisation de l'API</a>
           </li>
-      </ul>
-    </nav>
+        </ul>
+      </nav>
     </div>
 
     <div class="providers fr-col-md-<%= 12 - layout_main_bloc %> fr-col-12">
@@ -40,7 +40,7 @@
             <%= t('.providers.description', count: @endpoint.providers.count) %>
           </div>
 
-          <p>
+          <p class="fr-text--lg fr-text--bold">
             <% @endpoint.providers.map do |provider| %>
               <%= t("providers.#{provider.name}") %>
             <% end.join(' & ') %>

--- a/app/views/api_particulier/endpoints/show.html.erb
+++ b/app/views/api_particulier/endpoints/show.html.erb
@@ -21,10 +21,10 @@
               <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#donnees">Données distribuées</a>
           </li>
           <li>
-              <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#faq">Questions & réponses</a>
+              <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#faq">Q & R</a>
           </li>
           <li>
-              <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#cgu">Conditions d'utilisation de l'API</a>
+              <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#cgu">Conditions d'utilisation</a>
           </li>
         </ul>
       </nav>

--- a/app/views/api_particulier/endpoints/show.html.erb
+++ b/app/views/api_particulier/endpoints/show.html.erb
@@ -15,6 +15,9 @@
               <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#perimetre">Périmètre de l'API</a>
           </li>
           <li>
+              <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#parameters_details">Modalités d'appel</a>
+          </li>
+          <li>
               <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#donnees">Données distribuées</a>
           </li>
           <li>
@@ -103,6 +106,16 @@
       <%= render partial: 'use_cases', locals: { id: 'use_cases_mobile', extra_classes: 'fr-hidden-md' } %>
       <%= render partial: 'details', locals: { id: 'use_cases_mobile', extra_classes: 'fr-mb-3w fr-hidden-md' } %>
 
+      
+        <h2 id="parameters_details" class="fr-mt-md-5w fr-mt-8w">
+        <%= t('.parameters_details.title') %>
+        </h2>
+
+        <% if @endpoint.parameters_details.present? && @endpoint.parameters_details['description'].present? %>
+          <div>
+            <%= markdown_to_html(@endpoint.parameters_details['description']) %>
+          </div>
+        <% end %>
 
         <h2 id="donnees" class="fr-mt-md-5w fr-mt-8w">
           <%= t('.data.title') %>

--- a/app/views/api_particulier/endpoints/show.html.erb
+++ b/app/views/api_particulier/endpoints/show.html.erb
@@ -9,6 +9,22 @@
       <p class="fr-text--lead fr-mt-md-2w">
         <%= @endpoint.description %>
       </p>
+      <nav class="" role="navigation">
+      <ul class="">
+          <li>
+              <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#perimetre">Périmètre de l'API</a>
+          </li>
+          <li>
+              <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#donnees">Données distribuées</a>
+          </li>
+          <li>
+              <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#faq">Questions & réponses</a>
+          </li>
+          <li>
+              <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#cgu">Conditions d'utilisation de l'API</a>
+          </li>
+      </ul>
+    </nav>
     </div>
 
     <div class="providers fr-col-md-<%= 12 - layout_main_bloc %> fr-col-12">
@@ -33,11 +49,11 @@
       </div>
     </div>
   </div>
-
   <hr class="separator fr-unhidden-md fr-hidden">
 
   <div class="fr-grid-row">
     <div class="fr-col-md-<%= layout_main_bloc %> fr-col-12 fr-pt-2w fr-mt-md-0 fr-pr-md-2w fr-pr-0">
+
       <h2 id="perimetre">
         <%= t('.perimeter.title') %>
       </h2>

--- a/config/endpoints/api_particulier/cnaf_quotient_familial.yml
+++ b/config/endpoints/api_particulier/cnaf_quotient_familial.yml
@@ -23,6 +23,9 @@
       Les données sont **mises à jour en temps réel**, l'API étant reliée au système d'information de la Caisse nationale des allocations familiales.
 
       ⚠️ **Les informations obtenues sont représentatives de la situation connue par la CNAF et peuvent évoluer très fréquemment**. Le Quotient familial CAF est recalculé tous les mois, il peut être rétroactif et dépend de la situation du particulier et de l'état du droit. Il peut donc y avoir des écarts, notamment si la situation de la personne évolue entre temps : perte d'un emploi, évolution des ressources, arrivée d'un enfant, majorité d'un enfant, modification de la législation etc. Depuis que les allocations logement sont contemporaines (transmises très régulièrement), le QF est amené à évoluer lui aussi très fréquemment.
+  parameters_details:
+    description: |+
+      Lorem ipsum
   data:
     description: |+
       Cette API délivre la **composition familiale de l'allocataire et son quotient familial CAF**.

--- a/config/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -20,6 +20,9 @@
       - ❌ les données des étudiants boursiers étrangers.
     updating_rules_description: |+
       Les données sont **mises à jour une fois par an**, début septembre, une fois tous les étudiants inscrits.
+  parameters_details:
+    description: |+
+      Lorem ipsum
   data:
     description: |+
       Cette API **indique si un étudiant est boursier et permet de connaître le montant de la bourse** perçue grâce à l'échelon et la durée de versement.

--- a/config/endpoints/api_particulier/mesri_student_status.yml
+++ b/config/endpoints/api_particulier/mesri_student_status.yml
@@ -39,6 +39,9 @@
       - Pour les petits établissements, le délai est probablement plus long.
 
       Des inscriptions peuvent avoir lieu toute l'année, et la transmission de ces informations par les établissements se fait elle aussi tout au long de l'année.
+  parameters_details:
+    description: |+
+      Lorem ipsum
   data:
     description: |+
       Cette API délivre la **liste des inscriptions et admissions d'un étudiant**, en précisant les dates de début et de fin d'études, le régime de formation et le l'établisssement.

--- a/config/endpoints/api_particulier/mesri_student_status.yml
+++ b/config/endpoints/api_particulier/mesri_student_status.yml
@@ -44,7 +44,7 @@
       Lorem ipsum
   data:
     description: |+
-      Cette API délivre la **liste des inscriptions et admissions d'un étudiant**, en précisant les dates de début et de fin d'études, le régime de formation et le l'établisssement.
+      Cette API délivre la **liste des inscriptions et admissions d'un étudiant**, en précisant les dates de début et de fin d'études, le régime de formation et le l'établisssement. L'obtention de ces informations permet d'éviter de demander un certificat étudiant.
   provider_uids:
     - 'mesr'
   keywords: []

--- a/config/endpoints/api_particulier/pole_emploi_statut.yml
+++ b/config/endpoints/api_particulier/pole_emploi_statut.yml
@@ -23,7 +23,9 @@
       Les données sont **mises à jour en temps réel**, l'API étant directement reliée au système d'information de Pôle emploi.
 
       Les informations obtenues sont représentatives de la situation à date du demandeur d'emploi. Par exemple, la catégorie d'inscription, donnée qui peut évoluer au cours du temps, est mise à jour en temps réel également.
-
+  parameters_details:
+    description: |+
+      Lorem ipsum
   data: 
     description: |+
       Pour les demandeurs d'emploi actuels, l'API renvoie la **date d'inscription et la catégorie** permettant de connaître la situation précise du demandeur, ainsi que des informations concernant le demandeur d'emploi.

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -104,7 +104,7 @@ fr:
           description: "Liste des cas d'usage où cette API est utile :"
 
       details:
-        title: "Détails de l'API"
+        title: "Synthèse de l'API"
         format:
           title: "Format de l'information"
         availability:
@@ -114,8 +114,8 @@ fr:
           no_maintenance: "Disponible 24h/24 et 7j/7"
         parameters:
           title:
-            one: "Identifiant d'appel"
-            other: "Identifiants d'appel"
+            one: "Modalité d'appel"
+            other: "Modalités d'appel"
         technical_specifications:
           title: "Spécifications techniques :"
           cta: "Consulter le swagger"

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -106,7 +106,7 @@ fr:
           description: "Liste des cas d'usage où cette API est utile :"
 
       details:
-        title: "Synthèse de l'API"
+        title: "Spécifications de l'API"
         format:
           title: "Format de l'information"
         availability:

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -118,6 +118,7 @@ fr:
           title:
             one: "Modalité d'appel"
             other: "Modalités d'appel"
+          link: "Détails des paramètres"
         technical_specifications:
           title: "Spécifications techniques :"
           cta: "Consulter le swagger"

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -104,7 +104,6 @@ fr:
         main:
           title: "Cas d'usage"
           description: "Liste des cas d'usage où cette API est utile :"
-
       details:
         title: "Spécifications de l'API"
         format:

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -88,6 +88,8 @@ fr:
           geographical_scope_title: "Périmètre géographique :"
           updating_rules_title: "Actualisation de la donnée :"
           know_more_title: "En savoir plus :"
+        parameters_details:
+          title: Modalités d'appel
         data:
           title: "Les données"
         attributes:

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -107,6 +107,11 @@ fr:
         title: "Détails de l'API"
         format:
           title: "Format de l'information"
+        availability:
+          title: "Disponibilité"
+          link: "Page de statut des API"
+          maintenance: "En maintenance tous les jours de %{from_hour} à %{to_hour}"
+          no_maintenance: "Disponible 24h/24 et 7j/7"
         parameters:
           title:
             one: "Identifiant d'appel"


### PR DESCRIPTION
Suite aux retours de @mazalaigue, cette PR introduit des modifications de l'UI de la fiche métier côté API Part : 
- Ajout d'un sommaire en début de page
- Ajoute de la dispo dans la synthèse
- Ajout d'une nouvelle partie pour préciser les modalités d'appel