### PR TITLE
Harden email management on creation through DataPass

### DIFF
--- a/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
+++ b/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
@@ -31,7 +31,7 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
   end
 
   def extract_user_from_contact_payload(contact_payload)
-    user = User.find_or_initialize_by(email: contact_payload['email'])
+    user = User.find_or_initialize_by_email(contact_payload['email'])
 
     user.assign_attributes(
       last_name: contact_payload['family_name'],

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
     uniqueness: { case_sensitive: false },
     format: { with: /#{EMAIL_FORMAT_REGEX}/ }
 
+  before_create :sanitize_email
+
   scope :added_since_yesterday, -> { where('created_at > ?', 1.day.ago) }
 
   def self.find_or_initialize_by_email(email)
@@ -18,7 +20,9 @@ class User < ApplicationRecord
   end
 
   def self.insensitive_find_by_email(email)
-    where('email ilike (?)', email).limit(1).first
+    return if email.blank?
+
+    where('email ilike (?)', email.strip).limit(1).first
   end
 
   def confirmed?
@@ -43,5 +47,11 @@ class User < ApplicationRecord
 
   def generate_pwd_renewal_token
     update(pwd_renewal_token: access_token_for(:pwd_renewal_token))
+  end
+
+  def sanitize_email
+    return if email.blank?
+
+    self.email = email.downcase.strip
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -78,14 +78,14 @@ RSpec.describe User do
       let!(:user) { create(:user, email:) }
 
       its(:id) { is_expected.to eq user.id }
-      its(:email) { is_expected.to eq email }
+      its(:email) { is_expected.to eq email.downcase }
     end
 
     context 'when email already exists with different case' do
       let!(:user) { create(:user, email: 'EMAIL_with@CASE.com') }
 
       its(:id) { is_expected.to eq user.id }
-      its(:email) { is_expected.to eq 'EMAIL_with@CASE.com' }
+      its(:email) { is_expected.to eq 'email_with@case.com' }
     end
   end
 end


### PR DESCRIPTION
Sometimes DataPass webhooks contains email with unclean emails (with uppercase or extra spaces), this commit normalize and harden email management.

Closes https://github.com/etalab/admin_api_entreprise/issues/1090