### PR TITLE
Fix annoying timezone bug

### DIFF
--- a/app/services/open_bureau_date.rb
+++ b/app/services/open_bureau_date.rb
@@ -22,7 +22,7 @@ class OpenBureauDate
   end
 
   def before_open_bureau_time?
-    Time.zone.now < Time.parse('11:00 am')
+    Time.zone.now < '11:00 am'.in_time_zone(Time.zone)
   end
 
   def first_or_third_in_month?(tuesday)


### PR DESCRIPTION
Time.parse uses system clock for the timezone. If the system clock has a different timezone from our servers clock, the test will fail.

It is more resilient to instead use String#in_time_zone to rely on Rails set timezone instead of the computer's clock.