### PR TITLE
[Fiche métier] Retire toute mention du terme version V.3

### DIFF
--- a/config/endpoints/api_entreprise/14_dgfip_attestation_fiscale.yml
+++ b/config/endpoints/api_entreprise/14_dgfip_attestation_fiscale.yml
@@ -152,13 +152,13 @@
 
         Plus d'informations disponibles dans le [BOFIP - Dispositions juridiques communes - Attestation de régularité fiscale](https://bofip.impots.gouv.fr/bofip/8485-PGP.html/identifiant%3DBOI-DJC-ARF-20161207){:target="_blank"}.
   historique: |+
-    **Ce que change la V.4 par rapport à la V.3 :**
+    **Ce que change cette nouvelle version de l'API par rapport à la précédente :**
     Ajout de nouvelles informations lorsque l'attestation est délivrée : 
     - Un champ `date_delivrance_attestation`, généralement la date de l'appel de l'attestation ;
     - Un champ `date_periode_analysee` indiquant la date butoire à laquelle la situation de l'entreprise a été analysée, ayant induit la délivrance de l'attestation.
 
     **Ce qui ne change pas :**
-    À part l'ajout des champs précédents, rien n'a changé. Cette montée en version n'est pas dûe à une évolution de l'API de la DGFIP, par conséquent, la V.3 est maintenue par API&nbsp;Entreprise.
+    À part l'ajout des champs précédents, rien n'a changé. Cette montée en version n'est pas dûe à une évolution de l'API de la DGFIP, par conséquent, la version précédente est maintenue par API&nbsp;Entreprise.
 - uid: 'dgfip/v3/attestations_fiscales'
   position: 9002
   new_endpoint_uids:

--- a/config/endpoints/api_entreprise/15_urssaf_attestation_vigilance.yml
+++ b/config/endpoints/api_entreprise/15_urssaf_attestation_vigilance.yml
@@ -139,14 +139,14 @@
       a: &urssaf_attestations_faq_a3 |+
         Non, dans certain cas, l'API ne peut pas délivrer l'attestation, cela ne signifie pas que l'entreprise n'est pas à jour.
   historique: |+
-    **Ce que change la V.4 par rapport à la V.3 :**
+    **Ce que change cette nouvelle version de l'API par rapport à la précédente :**
     Ajout d'informations au format stucturé JSON : 
     - Un statut `entity_status` permettant d'indiquer qu'une entité n'est pas à jour de ses cotisations ;
     - Les dates de début et de fin de validité de l'attestation pour relancer un appel avant expiration de l'attestation ;
     - Le code de sécurité de l'attestation.
 
     **Ce qui ne change pas :**
-    À part l'ajout des champs précédents, rien n'a changé. L'attestation est toujours disponible en PDF par URL. Cette montée en version n'est pas dûe à une évolution de l'API de l'URSSAF, par conséquent, la V.3 est maintenue par API&nbsp;Entreprise.
+    À part l'ajout des champs précédents, rien n'a changé. L'attestation est toujours disponible en PDF par URL. Cette montée en version n'est pas dûe à une évolution de l'API de l'URSSAF, par conséquent, la version précédente est maintenue par API&nbsp;Entreprise.
 - uid: 'urssaf/v3/attestation_vigilance'
   position: 9001
   new_endpoint_uids:

--- a/config/endpoints/api_entreprise/4_ministere_interieur_v4.yml
+++ b/config/endpoints/api_entreprise/4_ministere_interieur_v4.yml
@@ -147,8 +147,8 @@
     - Détection de la fraude
   faq: *association_faq
   historique: |+
-    **Ce que change la V.4 par rapport à la V.3 :**
-    - Nouvelle structure de donnée : cette API fait suite aux deux API V.3 et réunit au même endroit les informations et documents des associations en open data. L'API propose plus de données&nbsp;;
+    **Ce que change cette nouvelle version de l'API par rapport à la précédente :**
+    - Nouvelle structure de donnée : cette API réunit au même endroit les informations et documents des associations en open data. L'API propose plus de données&nbsp;;
     - Nouvelle API source et nouveau fournisseur de donnée : la DJEPVA au travers de l'[API association](https://www.associations.gouv.fr/les-api-et-autres-outils.html){:target="_blank"}
     - Le SIREN ou RNA en paramètre d'appel.
 

--- a/config/endpoints/template.entreprise.yml.example
+++ b/config/endpoints/template.entreprise.yml.example
@@ -102,7 +102,7 @@
       a: |+
         Réponse à la question. Le markdown GFM est supporté ici.
   historique: |+
-    **Ce que change la V.4 par rapport à la V.3 :**
+    **Ce que change cette nouvelle version de l'API par rapport à la précédente :**
     Texte
 
     **Ce qui ne change pas :**


### PR DESCRIPTION
Suite à notre discussion de ce matin @skelz0r et @Charlottecho concernant le fait de ne pas parler de V4, ni de V3 dans les historiques