### PR TITLE
Clean scopes tables

### DIFF
--- a/db/migrate/20230623074703_remove_scopes_tables.rb
+++ b/db/migrate/20230623074703_remove_scopes_tables.rb
@@ -1,0 +1,8 @@
+class RemoveScopesTables < ActiveRecord::Migration[7.0]
+  def up
+    drop_table :scopes, if_exists: true
+    drop_table :scopes_tokens, if_exists: true
+  end
+
+  def down; end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_21_113853) do
+ActiveRecord::Schema[7.0].define(version: 2023_06_23_074703) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pgcrypto"
@@ -41,11 +41,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_21_113853) do
     t.uuid "token_id"
     t.index ["access_token"], name: "index_magic_links_on_access_token", unique: true
     t.index ["token_id"], name: "index_magic_links_on_token_id"
-  end
-
-  create_table "scopes_tokens", id: false, force: :cascade do |t|
-    t.uuid "token_id", null: false
-    t.uuid "scope_id", null: false
   end
 
   create_table "tokens", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
Add if_exists constraint because `scopes` table exists in production (but not in local), which is strange because aa2aa7986098f65d5dca8884ec32e97bcfe432f6 already cleaned it.

It's not a big issue, no need to be conscious about this.

Closes https://github.com/etalab/admin_api_entreprise/issues/1104