### PR TITLE
Introduce proper logout on MonComptePro

### DIFF
--- a/app/controllers/concerns/sessions_management.rb
+++ b/app/controllers/concerns/sessions_management.rb
@@ -17,7 +17,14 @@ module SessionsManagement
 
   def destroy
     logout_user
-    redirect_to login_path
+
+    redirect_to oauth_logout_url
+  end
+
+  def after_logout
+    success_message(title: t('.success'))
+
+    redirect_to root_path
   end
 
   private
@@ -45,5 +52,13 @@ module SessionsManagement
 
   def auth_hash
     request.env['omniauth.auth']
+  end
+
+  def oauth_logout_url
+    "#{Rails.application.config.oauth_api_gouv_issuer}/oauth/logout?post_logout_redirect_uri=#{after_logout_url}&client_id=#{oauth_api_gouv_client_id}"
+  end
+
+  def oauth_api_gouv_client_id
+    Rails.configuration.public_send("oauth_api_gouv_client_id_#{namespace.gsub('api_', '')}")
   end
 end

--- a/app/views/api_entreprise/pages/home.html.erb
+++ b/app/views/api_entreprise/pages/home.html.erb
@@ -1,4 +1,5 @@
 <div id="homepage">
+  <%= render 'shared/pages/home_alerts' %>
   <%= render 'api_entreprise/pages/home/section_welcome' %>
   <%= render 'api_entreprise/pages/home/section_access' %>
   <%= render 'api_entreprise/pages/home/section_use_cases' %>

--- a/app/views/api_particulier/pages/home.html.erb
+++ b/app/views/api_particulier/pages/home.html.erb
@@ -1,4 +1,5 @@
 <div id="homepage">
+  <%= render 'shared/pages/home_alerts' %>
   <%= render 'api_particulier/pages/home/section_welcome' %>
   <%= render 'api_particulier/pages/home/section_access' %>
   <%# <%= render 'api_particulier/pages/home/section_use_cases' %>

--- a/app/views/shared/api_entreprise/header/_tools.html.erb
+++ b/app/views/shared/api_entreprise/header/_tools.html.erb
@@ -20,7 +20,7 @@
         </a>
       </li>
       <li>
-        <a class="fr-link fr-icon-<%= t('.links.sign_out.icon') %>" id="logout_button" href="<%= logout_path %>" target="_self" data-method="delete">
+        <a class="fr-link fr-icon-<%= t('.links.sign_out.icon') %>" id="logout_button" href="<%= logout_path %>" target="_self">
           <%= t('.links.sign_out.title') %>
         </a>
       </li>

--- a/app/views/shared/api_particulier/header/_tools.html.erb
+++ b/app/views/shared/api_particulier/header/_tools.html.erb
@@ -12,7 +12,7 @@
         </a>
       </li>
       <li>
-        <a class="fr-link fr-icon-<%= t('.links.sign_out.icon') %>" id="logout_button" href="<%= logout_path %>" target="_self" data-method="delete">
+        <a class="fr-link fr-icon-<%= t('.links.sign_out.icon') %>" id="logout_button" href="<%= logout_path %>" target="_self">
           <%= t('.links.sign_out.title') %>
         </a>
       </li>

--- a/app/views/shared/pages/_home_alerts.html.erb
+++ b/app/views/shared/pages/_home_alerts.html.erb
@@ -1,0 +1,7 @@
+<% if flash.any? %>
+  <div class="fr-container fr-mb-5w fr-mt-5w">
+    <turbo-frame id="alerts">
+      <%= render partial: 'shared/alerts' %>
+    </turbo-frame>
+  </div>
+<% end %>

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -98,6 +98,7 @@ search:
 ignore_missing:
   - 'api_entreprise.faq.categories'
   - 'api_entreprise.providers'
+  - '*.sessions_management.after_logout.*'
 # - 'errors.messages.{accepted,blank,invalid,too_short,too_long}'
 # - '{devise,simple_form}.*'
 
@@ -111,6 +112,7 @@ ignore_unused:
   - '*.sessions.create_from_oauth.*'
   - '*.sessions.create_from_magic_link.*'
   - '*.sessions.failure.*'
+  - '*.sessions.after_logout.*'
   - 'api_particulier.public_token_magic_links.show.*'
   - 'token_mailer.magic_link.link_description.*'
   - 'api_particulier.tokens.token.scope.*'

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -223,6 +223,8 @@ fr:
 
       failure:
         unknown: Une erreur inconnue est survenue, veuillez contacter le support.
+      after_logout:
+        success: Déconnexion réussie.
 
     public_token_magic_links:
       show:

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -216,6 +216,8 @@ fr:
           Si vous avez déjà déposé une demande d'habilitation et que celle-ci a été validée, veuillez vérifier que notre email de connexion sur MonComptePro correspond à l'email sur la demande d'habilitation."
       failure:
         unknown: Une erreur inconnue est survenue, veuillez contacter le support.
+      after_logout:
+        success: Déconnexion réussie.
     public_token_magic_links:
       show:
         error:

--- a/config/routes/api_entreprise.rb
+++ b/config/routes/api_entreprise.rb
@@ -20,7 +20,8 @@ constraints(APIEntrepriseDomainConstraint.new) do
 
     get '/compte/se-connecter', to: 'sessions#new', as: :login
     get '/compte/se-connecter/lien-magique', to: 'sessions#create_from_magic_link', as: :login_magic_link
-    delete '/compte/deconnexion', to: 'sessions#destroy', as: :logout
+    get '/compte/deconnexion', to: 'sessions#destroy', as: :logout
+    get '/compte/apres-deconnexion', to: 'sessions#after_logout', as: :after_logout
 
     get '/compte', to: 'users#profile', as: :user_profile
 

--- a/config/routes/api_particulier.rb
+++ b/config/routes/api_particulier.rb
@@ -24,7 +24,8 @@ constraints(APIParticulierDomainConstraint.new) do
 
     get '/compte/se-connecter', to: 'sessions#new', as: :login
     get '/compte/se-connecter/lien-magique', to: 'sessions#create_from_magic_link', as: :login_magic_link
-    delete '/compte/deconnexion', to: 'sessions#destroy', as: :logout
+    get '/compte/deconnexion', to: 'sessions#destroy', as: :logout
+    get '/compte/apres-deconnexion', to: 'sessions#after_logout', as: :after_logout
 
     get '/compte', to: 'users#profile', as: :user_profile
 

--- a/spec/features/api_particulier/logout_spec.rb
+++ b/spec/features/api_particulier/logout_spec.rb
@@ -1,8 +1,6 @@
-require 'rails_helper'
-
-RSpec.describe 'log out', app: :api_entreprise do
+RSpec.describe 'log out', app: :api_particulier do
   subject do
-    visit user_profile_path
+    visit api_particulier_user_profile_path
 
     click_link 'logout_button'
   end
@@ -11,7 +9,7 @@ RSpec.describe 'log out', app: :api_entreprise do
     login_as(create(:user))
 
     # rubocop:disable RSpec/AnyInstance
-    allow_any_instance_of(APIEntreprise::SessionsController).to receive(:oauth_logout_url).and_return(after_logout_path)
+    allow_any_instance_of(APIParticulier::SessionsController).to receive(:oauth_logout_url).and_return(after_logout_path)
     # rubocop:enable RSpec/AnyInstance
   end
 


### PR DESCRIPTION
Have to update MonComptePro configs with the new post logout redirect uris, which are domains with /compte/apres-deconnexion path: already done on tests, have to be done on staging and production (currently empty btw).

Moreover:

* We use a /compte/apres-deconnexion in order to keep a single entry for MonComptePro (no more update here), we can do whatever we want here
* Have to stub the actual method for the redirect: indeed, it's the browser which make the redirect, we can't use webmock here

Closes https://github.com/etalab/admin_api_entreprise/issues/707