### PR TITLE
Fixing margin for paragraphs right before lists

### DIFF
--- a/app/assets/stylesheets/api_entreprise.scss
+++ b/app/assets/stylesheets/api_entreprise.scss
@@ -3,6 +3,7 @@
  *= require dsfr
  *= require dsfr-extensions
  *= require dsfr-utility
+ *= require dsfr-corrections
  *= require commons
  *= require_self
  *= require_tree ./components

--- a/app/assets/stylesheets/api_particulier.scss
+++ b/app/assets/stylesheets/api_particulier.scss
@@ -3,6 +3,7 @@
  *= require dsfr
  *= require dsfr-extensions
  *= require dsfr-utility
+ *= require dsfr-corrections
  *= require commons
  *= require_self
  *= require_tree ./components

--- a/app/assets/stylesheets/dsfr-corrections.scss
+++ b/app/assets/stylesheets/dsfr-corrections.scss
@@ -1,0 +1,4 @@
+p + ul {
+  margin-top: -15px;
+  margin-bottom: 20px;
+}


### PR DESCRIPTION
We can't easily target p before ul because
it is generated by markdown_to_html

DSFR defaults to a big margin under p, we can't
target p before ul (https://stackoverflow.com/a/1132370/5372951) so instead we apply negative margin to any ul immediatly after p

slightly hacky but should work well


@skelz0r Je suis pas certain d'où mettre cette correction, aucun fichier ne me semble convenir donc j'ai crée un dsfr-corrections