### PR TITLE
API-862 Ajouter le bloc infolettre sur la page daccueil API Part

### DIFF
--- a/app/views/api_particulier/pages/newsletter/_main.html.erb
+++ b/app/views/api_particulier/pages/newsletter/_main.html.erb
@@ -1,10 +1,17 @@
 <section id="section-newsletter" class="fr-background-default-white fr-pt-6w">
   <div class="fr-container">
+    <% if action_name == 'home' %>
+      <div class="fr-grid-row">
+        <div class="fr-col-xs-12 fr-col-sm-12 fr-col-md-6 fr-col-lg-6 fr-col-xl-6">
+          <h2 class="fr-h3" id="newsletter-title"><%= t('.title').html_safe %></h2>
+        </div>
+      </div>
+    <% end %>
     <div class="fr-grid-row">
-      <div class="fr-col-12">
+      <div class="fr-col-xs-12 fr-col-sm-12 fr-col-md-6 fr-col-lg-6 fr-col-xl-6">
         <h3 class="fr-h4"><%= t('.newsletter_title').html_safe %></h3>
         <p><%= t('.newsletter_description').html_safe %></p>
-        <iframe data-w-type="embedded" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://redir.entreprise.api.gouv.fr/wgt/ls12/jhn/form?c=eb0fdf2c" width="100%" style="height: 0;"></iframe>
+        <iframe data-w-type="embedded" frameborder="0" scrolling="no" marginheight="0" marginwidth="0" src="https://redir.entreprise.api.gouv.fr/wgt/ls12/294/form?c=20fa0f47" width="100%"></iframe>
 
         <script type="text/javascript" src="https://app.mailjet.com/pas-nc-embedded-v1.js"></script>
       </div>

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -77,8 +77,9 @@ fr:
           title: Restez informé des nouveautés de l'API Particulier
           description: Recevez les dernières actualités de l'API Particulier et des informations sur les nouvelles API disponibles.
         main:
-          newsletter_description: Recevez les dernières actualités de l'API Particulier et des informations sur les nouvelles API disponibles.
-          newsletter_title: Inscrivez-vous à la newsletter
+          title: Abonnez-vous à nos lettres d'infos&nbsp;!
+          newsletter_title: 💌 Actualités et guides pratiques&nbsp;:&nbsp;
+          newsletter_description: Restez informé des dernières API disponibles, des nouvelles fonctionnalités et en cas de rupture de service majeure&nbsp;:&nbsp;
 
     endpoints:
       index:


### PR DESCRIPTION
J'ai commencé à initier cette issue, mais c'est pas prêt, je ne sais même pas comment ça se fait que le widget API particulier soit automatiquement le bon... C'est pas prêt donc :) 

<img width="1289" alt="image" src="https://github.com/etalab/admin_api_entreprise/assets/46896006/4363f11f-bc44-4cd1-bd0b-506a8e528912">