### PR TITLE
Harden OmniAuth failure management

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,6 @@ Rails.application.routes.draw do
   end
   mount Sidekiq::Web => '/sidekiq'
 
-  get '/auth/failure', to: 'sessions#failure'
-
   draw(:api_entreprise)
   draw(:api_particulier)
 end

--- a/config/routes/api_entreprise.rb
+++ b/config/routes/api_entreprise.rb
@@ -17,6 +17,7 @@ constraints(APIEntrepriseDomainConstraint.new) do
     get '/stats', to: 'stats#index'
 
     get '/auth/api_gouv_entreprise/callback', to: 'sessions#create_from_oauth'
+    get '/auth/failure', to: 'sessions#failure'
 
     get '/compte/se-connecter', to: 'sessions#new', as: :login
     get '/compte/se-connecter/lien-magique', to: 'sessions#create_from_magic_link', as: :login_magic_link

--- a/config/routes/api_particulier.rb
+++ b/config/routes/api_particulier.rb
@@ -3,6 +3,7 @@ constraints(APIParticulierDomainConstraint.new) do
 
   scope module: :api_particulier do
     get '/auth/api_gouv_particulier/callback', to: 'sessions#create_from_oauth'
+    get '/auth/failure', to: 'sessions#failure'
     get '/robots.txt', to: ->(env) { [200, {}, URI.open('config/seo/api-particulier/robots.txt')] }
   end
 

--- a/spec/features/api_entreprise/signin_process_datapass_spec.rb
+++ b/spec/features/api_entreprise/signin_process_datapass_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe 'the signin process', app: :api_entreprise do
   context 'when API Gouv authentication fails' do
     before do
       OmniAuth.config.test_mode = true
-      OmniAuth.config.mock_auth[:api_gouv] = :invalid_credentials
+      OmniAuth.config.mock_auth[:api_gouv_entreprise] = :invalid_credentials
     end
 
     after { OmniAuth.config.test_mode = false }
@@ -98,6 +98,6 @@ RSpec.describe 'the signin process', app: :api_entreprise do
       expect(page).to have_current_path(login_path, ignore_query: true)
     end
 
-    it_behaves_like 'display alert', :info
+    it_behaves_like 'display alert', :error
   end
 end

--- a/spec/features/api_particulier/signin_process_datapass_spec.rb
+++ b/spec/features/api_particulier/signin_process_datapass_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'the signin process', app: :api_particulier do
   context 'when API Gouv authentication fails' do
     before do
       OmniAuth.config.test_mode = true
-      OmniAuth.config.mock_auth[:api_gouv] = :invalid_credentials
+      OmniAuth.config.mock_auth[:api_gouv_particulier] = :invalid_credentials
     end
 
     after { OmniAuth.config.test_mode = false }
@@ -87,6 +87,6 @@ RSpec.describe 'the signin process', app: :api_particulier do
       expect(page).to have_current_path(api_particulier_login_path, ignore_query: true)
     end
 
-    it_behaves_like 'display alert', :info
+    it_behaves_like 'display alert', :error
   end
 end


### PR DESCRIPTION
Previous test config was misconfigured, it was the error associated to an unknown user, which is not correct for this scenario.

Ref https://github.com/etalab/admin_api_entreprise/issues/1134