### PR TITLE
Remove phone_number from user creation from OAuth login

### DIFF
--- a/app/interactors/user/find_or_create_through_oauth.rb
+++ b/app/interactors/user/find_or_create_through_oauth.rb
@@ -16,8 +16,7 @@ class User
       {
         last_name: user_params['family_name'],
         first_name: user_params['given_name'],
-        email: api_gouv_email,
-        phone_number: user_params['phone_number']
+        email: api_gouv_email
       }
     end
 

--- a/app/lib/omni_auth/strategies/api_gouv_abstract.rb
+++ b/app/lib/omni_auth/strategies/api_gouv_abstract.rb
@@ -10,7 +10,7 @@ module OmniAuth::Strategies
       }
     }
 
-    option :scope, 'openid email profile phone'
+    option :scope, 'openid email profile'
 
     uid { raw_info['sub'] }
 

--- a/spec/features/api_entreprise/signin_process_datapass_spec.rb
+++ b/spec/features/api_entreprise/signin_process_datapass_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe 'the signin process', app: :api_entreprise do
           email: user.email,
           family_name: user.last_name,
           given_name: user.first_name,
-          phone_number: user.phone_number,
           sub: user.oauth_api_gouv_id || unknown_api_gouv_id
         }
       })
@@ -33,7 +32,7 @@ RSpec.describe 'the signin process', app: :api_entreprise do
 
           latest_user = User.last
 
-          %w[email first_name last_name phone_number].each do |attr|
+          %w[email first_name last_name].each do |attr|
             expect(latest_user.send(attr)).to eq(user.send(attr))
           end
 

--- a/spec/features/api_particulier/signin_process_datapass_spec.rb
+++ b/spec/features/api_particulier/signin_process_datapass_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe 'the signin process', app: :api_particulier do
           email: user.email,
           family_name: user.last_name,
           given_name: user.first_name,
-          phone_number: user.phone_number,
           sub: user.oauth_api_gouv_id || unknown_api_gouv_id
         )
       })
@@ -33,7 +32,7 @@ RSpec.describe 'the signin process', app: :api_particulier do
 
           latest_user = User.last
 
-          %w[email first_name last_name phone_number].each do |attr|
+          %w[email first_name last_name].each do |attr|
             expect(latest_user.send(attr)).to eq(user.send(attr))
           end
 

--- a/spec/organizers/api_entreprise/user/oauth_login_spec.rb
+++ b/spec/organizers/api_entreprise/user/oauth_login_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe APIEntreprise::User::OAuthLogin, type: :organizer do
       email: user.email,
       family_name: user.last_name,
       given_name: user.first_name,
-      phone_number: user.phone_number,
       sub: user.oauth_api_gouv_id || unknown_api_gouv_id
     )
   end
@@ -36,7 +35,7 @@ RSpec.describe APIEntreprise::User::OAuthLogin, type: :organizer do
 
       latest_user = User.last
 
-      %w[email first_name last_name phone_number].each do |attr|
+      %w[email first_name last_name].each do |attr|
         expect(latest_user.send(attr)).to eq(user.send(attr))
       end
     end

--- a/spec/organizers/api_particulier/user/oauth_login_spec.rb
+++ b/spec/organizers/api_particulier/user/oauth_login_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe APIParticulier::User::OAuthLogin, type: :organizer do
       email: user.email,
       family_name: user.last_name,
       given_name: user.first_name,
-      phone_number: user.phone_number,
       sub: user.oauth_api_gouv_id || unknown_api_gouv_id
     )
   end
@@ -36,7 +35,7 @@ RSpec.describe APIParticulier::User::OAuthLogin, type: :organizer do
 
       latest_user = User.last
 
-      %w[email first_name last_name phone_number].each do |attr|
+      %w[email first_name last_name].each do |attr|
         expect(latest_user.send(attr)).to eq(user.send(attr))
       end
     end


### PR DESCRIPTION
This field is not required by us and will be remove in near future from our provider (MonComptePro).