### PR TITLE
TokenExpirationNoticeJob can't send more than one email by batch

### DIFF
--- a/app/interactors/token/retrieve_expiring.rb
+++ b/app/interactors/token/retrieve_expiring.rb
@@ -6,7 +6,8 @@ class Token::RetrieveExpiring < ApplicationInteractor
       .not_blacklisted
       .where(archived: false)
       .joins(:authorization_request).where(authorization_request: { api: 'entreprise' })
-      .where("exp <= ? AND NOT days_left_notification_sent::jsonb @> '?'::jsonb", expiration_period, expire_in)
+      .where('exp <= ?', expiration_period)
+      .where('NOT EXISTS (SELECT 1 FROM jsonb_array_elements_text(tokens.days_left_notification_sent::jsonb) AS elem WHERE elem::integer <= ?)', expiration_period)
   end
 
   private

--- a/app/jobs/token_expiration_notice_job.rb
+++ b/app/jobs/token_expiration_notice_job.rb
@@ -1,12 +1,26 @@
 class TokenExpirationNoticeJob < ApplicationJob
   queue_as :default
 
-  def perform(*_args)
-    Token::SendExpirationNotices.call(expire_in: 90)
-    Token::SendExpirationNotices.call(expire_in: 60)
-    Token::SendExpirationNotices.call(expire_in: 30)
-    Token::SendExpirationNotices.call(expire_in: 14)
-    Token::SendExpirationNotices.call(expire_in: 7)
-    Token::SendExpirationNotices.call(expire_in: 0)
+  def perform
+    number_of_days_before_expiration.each do |number_of_days|
+      token_expiration_notice(number_of_days)
+    end
+  end
+
+  private
+
+  def token_expiration_notice(number_of_days)
+    Token::SendExpirationNotices.call(expire_in: number_of_days)
+  end
+
+  def number_of_days_before_expiration
+    [
+      0,
+      7,
+      14,
+      30,
+      60,
+      90
+    ]
   end
 end

--- a/spec/jobs/token_expiration_notice_job_spec.rb
+++ b/spec/jobs/token_expiration_notice_job_spec.rb
@@ -1,6 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe TokenExpirationNoticeJob do
+  include ActiveJob::TestHelper
+
   subject { described_class.perform_now }
 
   shared_examples 'sending expiration notices' do |nb_days|
@@ -20,4 +22,30 @@ RSpec.describe TokenExpirationNoticeJob do
   it_behaves_like 'sending expiration notices', 30
   it_behaves_like 'sending expiration notices', 60
   it_behaves_like 'sending expiration notices', 90
+
+  describe 'when there is a token with an expiration date in 7 days' do
+    let!(:token) { create(:token, exp: 7.days.from_now, days_left_notification_sent:) }
+
+    before do
+      clear_enqueued_jobs
+    end
+
+    context 'when none of the expiration notice has been sent' do
+      let(:days_left_notification_sent) { [] }
+
+      it 'sent the notification for 7 days' do
+        expect {
+          subject
+        }.to have_enqueued_job(ScheduleExpirationNoticeMailjetEmailJob).with(token, 7)
+      end
+
+      it 'only sent one email' do
+        expect {
+          subject
+        }.to change(enqueued_jobs, :size).by(1)
+
+        expect(token.reload.days_left_notification_sent).to eq([7])
+      end
+    end
+  end
 end

--- a/spec/jobs/token_expiration_notice_job_spec.rb
+++ b/spec/jobs/token_expiration_notice_job_spec.rb
@@ -14,9 +14,10 @@ RSpec.describe TokenExpirationNoticeJob do
     end
   end
 
-  it_behaves_like 'sending expiration notices', 90
-  it_behaves_like 'sending expiration notices', 60
-  it_behaves_like 'sending expiration notices', 30
-  it_behaves_like 'sending expiration notices', 14
   it_behaves_like 'sending expiration notices', 0
+  it_behaves_like 'sending expiration notices', 7
+  it_behaves_like 'sending expiration notices', 14
+  it_behaves_like 'sending expiration notices', 30
+  it_behaves_like 'sending expiration notices', 60
+  it_behaves_like 'sending expiration notices', 90
 end


### PR DESCRIPTION
TokenExpirationNoticeJob can't send more than one email by batch

Thanks to:

1. Reorder of the scheduling
2. Test on min element of already sent emails

It is impossible to send more than one email by batch on a specific
token.

Closes https://linear.app/pole-api/issue/API-1055/harden-la-gestion-des-relances-sur-les-expirations