### PR TITLE
API Particulier: swagger shows deprecated endpoints

### DIFF
--- a/app/views/shared/pages/redoc.html.erb
+++ b/app/views/shared/pages/redoc.html.erb
@@ -11,7 +11,7 @@
 
 <script>
   function initRedoc() {
-    var uri = '<%= openapi_without_deprecated_definition_path %>';
+    var uri = '<%= namespace == "api_particulier" ? openapi_definition_path : openapi_without_deprecated_definition_path %>';
 
     Redoc.init(
       uri,


### PR DESCRIPTION
Make API CAF v1 still available, even if deprecated: it's not the same logic as API Entreprise which has a lot of deprecated endpoints, but new version incrementaly enhanced.

Related https://github.com/etalab/admin_api_entreprise/pull/1087