### PR TITLE
Feature/api 1069 revoir la page qui liste les jetons

### DIFF
--- a/app/controllers/api_entreprise/tokens_controller.rb
+++ b/app/controllers/api_entreprise/tokens_controller.rb
@@ -2,8 +2,9 @@ class APIEntreprise::TokensController < APIEntreprise::AuthenticatedUsersControl
   before_action :extract_token, except: %i[index]
 
   def index
+    @active_tokens = current_user.tokens.active_for('entreprise').sort_by(&:exp).reverse
     authorization_requests = current_user.authorization_requests.with_tokens_for('entreprise')
-    @tokens = authorization_requests.map(&:token)
+    @inactive_tokens = authorization_requests.map(&:token).sort_by(&:exp).reverse - @active_tokens
   end
 
   def show; end

--- a/app/controllers/api_entreprise/tokens_controller.rb
+++ b/app/controllers/api_entreprise/tokens_controller.rb
@@ -2,7 +2,8 @@ class APIEntreprise::TokensController < APIEntreprise::AuthenticatedUsersControl
   before_action :extract_token, except: %i[index]
 
   def index
-    @tokens = current_user.tokens.active_for('entreprise')
+    authorization_requests = current_user.authorization_requests.with_tokens_for('entreprise')
+    @tokens = authorization_requests.map(&:token)
   end
 
   def show; end

--- a/app/lib/seeds.rb
+++ b/app/lib/seeds.rb
@@ -77,7 +77,8 @@ class Seeds
         intitule: 'Mairie de Lyon 2',
         external_id: 102,
         status: :validated,
-        first_submitted_at: 2.weeks.ago
+        first_submitted_at: 2.weeks.ago,
+        siret: '012345678901234'
       }
     )
   end
@@ -93,7 +94,8 @@ class Seeds
         intitule: 'Mairie de Strasbourg',
         external_id: 103,
         status: :validated,
-        first_submitted_at: 1.week.ago
+        first_submitted_at: 1.week.ago,
+        siret: '012345678901235'
       }
     )
   end
@@ -108,7 +110,8 @@ class Seeds
         intitule: 'Mairie de Paris',
         external_id: 104,
         status: :validated,
-        first_submitted_at: 1.week.ago
+        first_submitted_at: 1.week.ago,
+        siret: '012345678901236'
       }
     )
   end
@@ -125,7 +128,8 @@ class Seeds
         status: :validated,
         api: 'entreprise',
         first_submitted_at: 2.years.ago,
-        validated_at: 2.years.ago + 1.week
+        validated_at: 2.years.ago + 1.week,
+        siret: '012345678901237'
       }
     )
   end

--- a/app/lib/seeds.rb
+++ b/app/lib/seeds.rb
@@ -102,7 +102,7 @@ class Seeds
     create_token(
       @scopes_entreprise.sample(2),
       'entreprise',
-      token_params: { blacklisted: true },
+      token_params: { blacklisted: true, exp: 14.months.ago },
       demandeur: @user,
       authorization_request_params: {
         intitule: 'Mairie de Paris',

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -22,7 +22,11 @@ class AuthorizationRequest < ApplicationRecord
   scope :submitted_at_least_once, -> { where.not(first_submitted_at: nil) }
 
   def token
-    active_token || tokens.first
+    active_token || latest_expiration_token
+  end
+
+  def latest_expiration_token
+    tokens.max_by(&:exp)
   end
 
   has_many :contacts_authorization_request_roles,

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -23,10 +23,10 @@ class AuthorizationRequest < ApplicationRecord
   scope :submitted_at_least_once, -> { where.not(first_submitted_at: nil) }
 
   def token
-    active_token || latest_expiration_token
+    active_token || most_recent_token
   end
 
-  def latest_expiration_token
+  def most_recent_token
     tokens.max_by(&:exp)
   end
 

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -19,6 +19,7 @@ class AuthorizationRequest < ApplicationRecord
 
   validates :api, inclusion: { in: %w[entreprise particulier] }
 
+  scope :with_tokens_for, ->(api) { where(api:).joins(:tokens) }
   scope :submitted_at_least_once, -> { where.not(first_submitted_at: nil) }
 
   def token

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -27,7 +27,7 @@ class AuthorizationRequest < ApplicationRecord
   end
 
   def most_recent_token
-    tokens.max_by(&:exp)
+    tokens.order(exp: :desc).limit(1).first
   end
 
   has_many :contacts_authorization_request_roles,

--- a/app/views/api_entreprise/tokens/_token.html.erb
+++ b/app/views/api_entreprise/tokens/_token.html.erb
@@ -22,6 +22,15 @@
       <div class="fr-card__desc">
         <ul>
           <li>
+            <%= t('.intitule', intitule: token.authorization_request.intitule) %>
+          </li>
+          <li>
+            <%= t('.siret', siret: token.authorization_request.siret) %>
+          </li>
+          <li> 
+            <%= t('.demandeur',  first_name: token.demandeur.first_name, last_name: token.demandeur.last_name, email: token.demandeur.email ) %>
+          </li>
+          <li>
             <%= t('.delivered_at', humanized_date: friendly_format_from_timestamp(token.iat)) %>
           </li>
           <li>
@@ -50,8 +59,19 @@
             <%= t('.token') %>
           </strong>
 
-          <br>
+          <span class="fr-text--sm fr-mb-0-5v pull-right">
+            <% if token.expired? %>
+              <%= link_to t('.expired'), token_path(token), class: %w(fr-tag fr-tag--sm fr-tag--purple-glycine fr-icon-arrow-right-line), data: { turbo_frame: '_top' } %>
+            <% elsif token.blacklisted? %>
+              <%= link_to t('.blacklisted'), token_path(token), class: %w(fr-tag fr-tag--sm fr-tag--purple-glycine fr-icon-arrow-right-line), data: { turbo_frame: '_top' } %>
+            <% elsif token.archived? %>
+              <%= link_to t('.archived'), token_path(token), class: %w(fr-tag fr-tag--sm fr-icon-arrow-right-line), data: { turbo_frame: '_top' } %>
+            <% else %>
+              <%= link_to t('.active'), token_path(token), class: %w(fr-tag fr-tag--sm fr-tag--green-emeraude fr-icon-arrow-right-line), data: { turbo_frame: '_top' } %>
+            <% end %>
+          </span>
 
+          <br>
           <input id="<%= dom_id(token, :token_hash) %>" class="fr-input" type="text" data-clipboard-target="source" readonly value="<%= token.rehash %>" />
         </div>
 

--- a/app/views/api_entreprise/tokens/index.html.erb
+++ b/app/views/api_entreprise/tokens/index.html.erb
@@ -1,8 +1,12 @@
 <% if @active_tokens.any? || @inactive_tokens.any? %>
-  <%= render partial: 'api_entreprise/tokens/user_tokens_list', 
-    locals: { subtitle: t('.active_title', count: @active_tokens.count), tokens: @active_tokens } %>
-  <%= render partial: 'api_entreprise/tokens/user_tokens_list', 
-    locals: { subtitle: t('.inactive_title', count: @inactive_tokens.count), tokens: @inactive_tokens } %>
+  <% if @active_tokens.any? %>
+    <%= render partial: 'api_entreprise/tokens/user_tokens_list', 
+      locals: { subtitle: t('.active_title', count: @active_tokens.count), tokens: @active_tokens } %>
+  <% end %>
+  <% if @inactive_tokens.any? %>
+    <%= render partial: 'api_entreprise/tokens/user_tokens_list', 
+      locals: { subtitle: t('.inactive_title', count: @inactive_tokens.count), tokens: @inactive_tokens } %>
+  <% end %>
 <% else %>
   <h2><%= t('.no_tokens') %></h2>
 <% end %>

--- a/app/views/api_entreprise/tokens/index.html.erb
+++ b/app/views/api_entreprise/tokens/index.html.erb
@@ -1,5 +1,8 @@
-<% if @tokens.any? %>
-  <%= render partial: 'api_entreprise/tokens/user_tokens_list', locals: { subtitle: t('.title', count: @tokens.count), tokens: @tokens } %>
+<% if @active_tokens.any? || @inactive_tokens.any? %>
+  <%= render partial: 'api_entreprise/tokens/user_tokens_list', 
+    locals: { subtitle: t('.active_title', count: @active_tokens.count), tokens: @active_tokens } %>
+  <%= render partial: 'api_entreprise/tokens/user_tokens_list', 
+    locals: { subtitle: t('.inactive_title', count: @inactive_tokens.count), tokens: @inactive_tokens } %>
 <% else %>
   <h2><%= t('.no_tokens') %></h2>
 <% end %>

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -39,7 +39,7 @@ fr:
       user_signed_in_side_menu:
         toggle: "Menu"
         profil: "Compte utilisateur"
-        tokens: "Jetons d'accès"
+        tokens: "Habilitations et jetons d'accès"
         download_attestations: 'Télécharger attestations'
 
   api_entreprise:
@@ -98,10 +98,14 @@ fr:
     tokens:
       index:
         no_tokens: "Aucun jeton d'accès pour cet utilisateur."
-        title:
-          zero: "Jetons d'accès"
-          one: "Jetons d'accès"
-          other: "Jetons d'accès (%{count})"
+        active_title:
+          zero: "Habilitation et jetons d'accès actif"
+          one: "Habilitation et jetons actif"
+          other: "Habilitations et jetons actif (%{count})"
+        inactive_title:
+          zero: "Habilitation et jetons d'accès inactif"
+          one: "Habilitation et jetons d'accès inactif"
+          other: "Habilitations et jetons inactif (%{count})"
 
       extract_token:
         error:

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -123,6 +123,13 @@ fr:
         continue: ⬜ Continuer
       token:
         title: "Cadre d'utilisation : %{intitule}"
+        intitule: "Intitulé : %{intitule}"
+        siret: "Siret : %{siret}"
+        demandeur: "Demandeur : %{first_name} %{last_name} - %{email}"
+        active: "actif"
+        archived: "archivé"
+        expired: "expiré"
+        blacklisted: "désactivé"
         links:
           datapass: Demande d'accès initiale (N° %{id})
           stats: Voir les statistiques

--- a/spec/factories/authorization_requests.rb
+++ b/spec/factories/authorization_requests.rb
@@ -14,7 +14,7 @@ FactoryBot.define do
     trait :with_multiple_tokens_one_valid do
       tokens do
         [
-          create(:token, :blacklisted, :not_archived),
+          create(:token, :blacklisted, :not_archived, :expiring_in_1_year),
           create(:token, :not_blacklisted, :not_archived)
         ]
       end

--- a/spec/models/authorization_request_spec.rb
+++ b/spec/models/authorization_request_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe AuthorizationRequest do
     end
 
     it 'returns the tokens that expires the latest' do
-      expect(authorization_request.latest_expiration_token).not_to eq(authorization_request.tokens.first.id)
+      expect(authorization_request.most_recent_token).not_to eq(authorization_request.tokens.first.id)
     end
   end
 

--- a/spec/models/authorization_request_spec.rb
+++ b/spec/models/authorization_request_spec.rb
@@ -18,6 +18,21 @@ RSpec.describe AuthorizationRequest do
     end
   end
 
+  describe '.with_tokens_for scope' do
+    subject { described_class.with_tokens_for('particulier') }
+
+    let!(:authorization_request) do
+      create(:authorization_request, :with_tokens, api: 'particulier')
+      create(:authorization_request, api: 'particulier')
+      create(:authorization_request)
+      create(:authorization_request)
+    end
+
+    it 'returns 1 token with api particulier' do
+      expect(subject.count).to eq(1)
+    end
+  end
+
   describe 'fetch token with the most recent expiration date' do
     let(:authorization_request) do
       create(:authorization_request, :with_multiple_tokens_one_valid)

--- a/spec/models/authorization_request_spec.rb
+++ b/spec/models/authorization_request_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe AuthorizationRequest do
     end
   end
 
+  describe 'fetch token with the most recent expiration date' do
+    let(:authorization_request) do
+      create(:authorization_request, :with_multiple_tokens_one_valid)
+    end
+
+    it 'returns the tokens that expires the latest' do
+      expect(authorization_request.latest_expiration_token).not_to eq(authorization_request.tokens.first.id)
+    end
+  end
+
   describe 'active_token associations' do
     let(:authorization_request) do
       create(:authorization_request, :with_multiple_tokens_one_valid)


### PR DESCRIPTION
Par rapport au ticket initial il reste ces questions à répondre : 

- Qu'est ce qu'on appelle le nom d'une administration ?
- Actuellement s'il n'y a pas de token actif, on affiche le plus 'récent'. Mais ils peuvent être archivé, expiré ou blacklisté. Est ce qu'on veut bien que ces 3 cas soient affiché ?
- Pour chacun de ces cas j'ai rajouté des badges pour que ce soit visible au user -> Est ce que ce sont les bonnes couleurs ? @DorineLam 

Ca se lit bien commit par commit
