### PR TITLE
Revoke inactive Authorization Request without Datapass

### DIFF
--- a/db/migrate/20230922102926_revoking_not_used_authorization_request_with_no_datapass.rb
+++ b/db/migrate/20230922102926_revoking_not_used_authorization_request_with_no_datapass.rb
@@ -1,0 +1,32 @@
+class RevokingNotUsedAuthorizationRequestWithNoDatapass < ActiveRecord::Migration[7.0]
+  USED_AR_ID_WITH_NO_DATAPASS = %w[
+    14003128-5eed-4087-b04c-b4c6e5962040
+    61da2c91-1c49-4ac2-8012-efabac411b44
+    9991734e-317b-4110-8a38-aad86edce633
+    aec4345f-155a-47c7-9bc8-6acd671e945d
+    f7fe5da2-48cc-4675-8fad-25cba4ef0f33
+  ]
+
+  def up
+    not_used_ars_with_no_datapass = AuthorizationRequest
+      .where(external_id: nil)
+      .where.not(id: USED_AR_ID_WITH_NO_DATAPASS)
+
+    not_used_ars_with_no_datapass.find_each do |authorization_request|
+      authorization_request.blacklist!
+    end
+  end
+
+  def down
+    not_used_ars_with_no_datapass = AuthorizationRequest
+      .where(external_id: nil)
+      .where(status: 'blacklisted')
+      .where.not(id: USED_AR_ID_WITH_NO_DATAPASS)
+
+    not_used_ars_with_no_datapass.find_each do |authorization_request|
+      token&.update!(blacklisted: false)
+
+      update!(status: 'active')
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_12_084011) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_22_102926) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pgcrypto"


### PR DESCRIPTION
Les ids des actifs ont été récupéré sur metabase via la request : 

```
SELECT 
    ar.id
FROM 
    authorization_requests ar
INNER JOIN 
    tokens t on ar.id = t.authorization_request_model_id
INNER JOIN
    access_logs al on al.token_id = t.id
WHERE 
    ar.external_id IS NULL
AND
    al.timestamp > (CURRENT_DATE - INTERVAL '3 months')
GROUP BY ar.id
```

