### PR TITLE
Introduce real time status on endpoints

### DIFF
--- a/app/assets/stylesheets/components/api_status.scss
+++ b/app/assets/stylesheets/components/api_status.scss
@@ -1,0 +1,25 @@
+.api-status {
+  padding: 3px 12px;
+
+  color: white;
+
+  &::before {
+    font-weight: 900;
+  }
+}
+
+.api-status-up {
+  &::before {
+    content: 'UP';
+  }
+
+  background-color: var(--success);
+}
+
+.api-status-down {
+  &::before {
+    content: 'DOWN';
+  }
+
+  background-color: var(--error);
+}

--- a/app/models/abstract_endpoint.rb
+++ b/app/models/abstract_endpoint.rb
@@ -6,6 +6,7 @@ class AbstractEndpoint < ApplicationAlgoliaSearchableActiveModel
     :path,
     :beta,
     :novelty,
+    :ping_url,
     :new_version,
     :provider_uids,
     :parameters,
@@ -93,6 +94,14 @@ class AbstractEndpoint < ApplicationAlgoliaSearchableActiveModel
 
   def new_version?
     new_version.present? && new_version
+  end
+
+  def api_status
+    return if ping_url.blank?
+
+    @api_status_code ||= Net::HTTP.get_response(URI(ping_url)).code
+
+    @api_status_code == '200' ? 'up' : 'down'
   end
 
   def pending_status

--- a/app/views/api_entreprise/endpoints/_details.html.erb
+++ b/app/views/api_entreprise/endpoints/_details.html.erb
@@ -28,10 +28,15 @@
   <h3 class="fr-h6 fr-pt-2w fr-mb-1v">
     <%= t('.availability.title') %>
   </h3>
-  <a class="fr-pt-1v fr-link" title="API Entreprise Status Page" href="https://status.entreprise.api.gouv.fr" target="_blank">
+  <% if @endpoint.ping_url %>
+    <div class="fr-pb-1w">
+      <%= t('.availability.real_time') %> : <span class="api-status api-status-<%= @endpoint.api_status %>"></span>
+    </div>
+  <% end %>
+  <a class="fr-link" title="API Entreprise Status Page" href="https://status.entreprise.api.gouv.fr" target="_blank">
     <%= t('.availability.link') %>
   </a>
-  <div class="fr-pt-2w">
+  <div class="fr-pt-1w">
     <% if @endpoint.maintenances.present? %>
       <%= t('.availability.maintenance', from_hour: @endpoint.maintenances['from_hour'], to_hour: @endpoint.maintenances['to_hour']) %>
     <% else %>

--- a/app/views/api_particulier/endpoints/_details.html.erb
+++ b/app/views/api_particulier/endpoints/_details.html.erb
@@ -27,15 +27,20 @@
   <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" title="Détails des modalités d'appel" href="#parameters_details">
   <%= t('.parameters.link') %>
  </a>
-  
+
 
   <h3 class="fr-h6 fr-pt-4w fr-mb-1v">
     <%= t('.availability.title') %>
   </h3>
+  <% if @endpoint.ping_url %>
+    <div class="fr-pb-1w">
+      <%= t('.availability.real_time') %> : <span class="api-status api-status-<%= @endpoint.api_status %>"></span>
+    </div>
+  <% end %>
   <a class="fr-pt-1v fr-link" title="API Entreprise Status Page" href="https://statut.api.gouv.fr/history/api-particulier" target="_blank">
     <%= t('.availability.link') %>
   </a>
-  <div class="fr-pt-2w">
+  <div class="fr-pt-1w">
     <% if @endpoint.maintenances.present? %>
       <%= t('.availability.maintenance', from_hour: @endpoint.maintenances['from_hour'], to_hour: @endpoint.maintenances['to_hour']) %>
     <% else %>

--- a/config/endpoints/api_entreprise/15_urssaf_attestation_vigilance.yml
+++ b/config/endpoints/api_entreprise/15_urssaf_attestation_vigilance.yml
@@ -1,5 +1,6 @@
 ---
 - uid: 'urssaf/attestation_vigilance'
+  ping_url: 'https://entreprise.api.gouv.fr/ping/urssaf/attestation_sociale'
   old_endpoint_uids:
     - 'urssaf/v3/attestation_vigilance'
   position: 260
@@ -149,6 +150,7 @@
     À part l'ajout des champs précédents, rien n'a changé. L'attestation est toujours disponible en PDF par URL. Cette montée en version n'est pas dûe à une évolution de l'API de l'URSSAF, par conséquent, la version précédente est maintenue par API&nbsp;Entreprise.
 - uid: 'urssaf/v3/attestation_vigilance'
   position: 9001
+  ping_url: 'https://entreprise.api.gouv.fr/ping/urssaf/attestation_sociale'
   new_endpoint_uids:
     - 'urssaf/attestation_vigilance'
   path: '/v3/urssaf/unites_legales/{siren}/attestation_vigilance'

--- a/config/endpoints/api_entreprise/15_urssaf_attestation_vigilance.yml
+++ b/config/endpoints/api_entreprise/15_urssaf_attestation_vigilance.yml
@@ -54,13 +54,13 @@
     - 'fraude'
   data: &urssaf_attestations_data
     description: |+
-      Cette API permet de : 
-      - **savoir si l'attestation de vigilance est délivrée par l'Urssaf** et obtenir l'URL de téléchargement de l'**attestation, au format PDF**. 
+      Cette API permet de :
+      - **savoir si l'attestation de vigilance est délivrée par l'Urssaf** et obtenir l'URL de téléchargement de l'**attestation, au format PDF**.
 
         {:.fr-highlight}
         >⚠️ La délivrance de l'attestation ne veut pas forcément dire que l'entité est jour de ses cotisations. L'attestation de vigilance est délivrée sous [certaines conditions](#faq_entry_0_endpoint_urssaf_attestation_vigilance) ; entre autres, si l'entreprise s'est acquitée de ses cotisations et contributions.
 
-      - **obtenir la date de début et de fin de validité de l'attestation**. L'attestation a une durée de validité légale de 6 mois à compter de la date d'analyse indiquée sur le document et qui est différente de la date de délivrance du document. [En&nbsp;savoir&nbsp;plus](#faq_entry_1_endpoint_urssaf_attestation_vigilance). 
+      - **obtenir la date de début et de fin de validité de l'attestation**. L'attestation a une durée de validité légale de 6 mois à compter de la date d'analyse indiquée sur le document et qui est différente de la date de délivrance du document. [En&nbsp;savoir&nbsp;plus](#faq_entry_1_endpoint_urssaf_attestation_vigilance).
 
         {:.fr-highlight.fr-highlight--example}
         >💡 Cette donnée structurée vous permet de reprogrammer automatiquement un appel avant la fin de validité du document
@@ -140,7 +140,7 @@
         Non, dans certain cas, l'API ne peut pas délivrer l'attestation, cela ne signifie pas que l'entreprise n'est pas à jour.
   historique: |+
     **Ce que change cette nouvelle version de l'API par rapport à la précédente :**
-    Ajout d'informations au format stucturé JSON : 
+    Ajout d'informations au format stucturé JSON :
     - Un statut `entity_status` permettant d'indiquer qu'une entité n'est pas à jour de ses cotisations ;
     - Les dates de début et de fin de validité de l'attestation pour relancer un appel avant expiration de l'attestation ;
     - Le code de sécurité de l'attestation.
@@ -162,12 +162,12 @@
   use_cases_forbidden: *urssaf_attestation_use_cases_forbidden
   provider_uids: *urssaf_attestation_provider_uids
   keywords: *urssaf_attestations_keywords
-  data: 
+  data:
     description: |+
       Cette API permet de **savoir si l'attestation de vigilance est délivrée par l'Urssaf** ou refusée. En cas de délivrance de l'attestation l'API transmet une **URL de téléchargement de l'attestation, au format PDF**.
 
       L'attestation de vigilance est **délivrée sous [certaines conditions](#faq_entry_0_endpoint_urssaf_attestation_vigilance)** ; entre autres, si l'entreprise s'est acquitée de ses cotisations et contributions.
-      
+
       Elle a une **durée de validité légale de 6 mois** à compter de la date d'analyse indiquée sur le document et qui est différente de la date de délivrance du document. [En&nbsp;savoir&nbsp;plus](#faq_entry_1_endpoint_urssaf_attestation_vigilance).
 
       <section class="fr-accordion">

--- a/config/endpoints/api_entreprise/1_insee_etablissements.yml
+++ b/config/endpoints/api_entreprise/1_insee_etablissements.yml
@@ -2,6 +2,7 @@
 - uid: 'insee/etablissements'
   position: 105
   path: '/v3/insee/sirene/etablissements/{siret}'
+  ping_url: 'https://entreprise.api.gouv.fr/ping/insee/sirene'
   perimeter:
     entity_type_description: &insee_etablissements_entity_type_description |+
       Cette API concerne les établissements inscrits au répertoire Sirene, qu'ils soient **"diffusibles" ou ["non-diffusibles"](#faq_entry_1_endpoint_insee_etablissements)** :
@@ -94,20 +95,20 @@
 
         **État administratif de l'unité légale&nbsp;:**
         L'état administratif de l'unité légale peut être "actif" ou "cessé".
-        L'unité légale est toujours active, sauf si une déclaration de cessation administrative a été déposée et prise en compte par l'Insee. 
+        L'unité légale est toujours active, sauf si une déclaration de cessation administrative a été déposée et prise en compte par l'Insee.
         L'état administratif indique si une unité légale est active ou cessée.
 
         **État administratif d'un établissement&nbsp;:**
         Il peut être "actif" ou "fermé". Lors de son inscription au répertoire Sirene, un établissement est, sauf exception, à l'état "actif". Le passage à l'état "fermé" découle de la prise en compte d'une déclaration de fermeture. Un établissement fermé peut être rouvert.
 
         **Cas particuliers&nbsp;:**
-        - **une unité légale est active alors que tous ses établissements sont fermés**. Il s'agit alors d'une entité active d'un point de vue administratif mais n'ayant pas d'activité économique. Cette situation regroupe : 
+        - **une unité légale est active alors que tous ses établissements sont fermés**. Il s'agit alors d'une entité active d'un point de vue administratif mais n'ayant pas d'activité économique. Cette situation regroupe :
            - Les sociétés en sommeil, c'est-à-dire faire reconnaître par une formalité leur état en sommeil afin de ne plus avoir certaines obligations fiscales ;
            - Les sociétés présumées inactives, identifiées par l’Insee pour des besoins statistiques.
-           
+
            La distinction "en sommeil" ou "présumée inactive" n'est pas une information transmise par l'Insee.
         - **une unité légale est cessée alors qu'un établissement est actif**. Cette situation est une erreur à signaler au pôle du répertoire Sirene à l'Insee. Une unité légale cessée ne peut avoir d'établissements actifs.
-        
+
     - q: &insee_etablissements_faq_q2 Qu'est-ce qu'un "non-diffusible" ?
       a: &insee_etablissements_faq_a2 |+
 
@@ -142,6 +143,7 @@
 
 - uid: 'insee/etablissements_diffusibles'
   position: 100
+  ping_url: 'https://entreprise.api.gouv.fr/ping/insee/sirene'
   path: '/v3/insee/sirene/etablissements/diffusibles/{siret}'
   perimeter:
     entity_type_description: |+

--- a/config/endpoints/api_entreprise/3_insee_adresse_etablissement.yml
+++ b/config/endpoints/api_entreprise/3_insee_adresse_etablissement.yml
@@ -1,6 +1,7 @@
 ---
 - uid: 'insee/adresse_etablissements'
   position: 145
+  ping_url: 'https://entreprise.api.gouv.fr/ping/insee/sirene'
   path: '/v3/insee/sirene/etablissements/{siret}/adresse'
   perimeter:
     entity_type_description: |+
@@ -110,6 +111,7 @@
         À partir de mars 2024, le fonctionnement des non-diffusibles commerciaux évolue, certaines données seront disponibles pour du pré-remplissage et les personnes morales pourront décider de passer en diffusion partielle. Lire notre publication du 14/12/2022 : [🦸&nbsp;**Le futur des “non-diffusibles”**](https://entreprise.api.gouv.fr/blog/insee-non-diffusibles).
 - uid: 'insee/adresse_etablissements_diffusibles'
   position: 140
+  ping_url: 'https://entreprise.api.gouv.fr/ping/insee/sirene'
   path: '/v3/insee/sirene/etablissements/diffusibles/{siret}/adresse'
   perimeter:
     entity_type_description: |+

--- a/config/endpoints/api_entreprise/3_insee_siege_social.yml
+++ b/config/endpoints/api_entreprise/3_insee_siege_social.yml
@@ -1,6 +1,7 @@
 ---
 - uid: 'insee/siege_social'
   path: '/v3/insee/sirene/unites_legales/{siren}/siege_social'
+  ping_url: 'https://entreprise.api.gouv.fr/ping/insee/sirene'
   position: 135
   perimeter:
     entity_type_description: |+
@@ -94,17 +95,17 @@
 
         **État administratif de l'unité légale&nbsp;:**
         L'état administratif de l'unité légale peut être "actif" ou "cessé".
-        L'unité légale est toujours active, sauf si une déclaration de cessation administrative a été déposée et prise en compte par l'Insee. 
+        L'unité légale est toujours active, sauf si une déclaration de cessation administrative a été déposée et prise en compte par l'Insee.
         L'état administratif indique si une unité légale est active ou cessée.
 
         **État administratif d'un établissement&nbsp;:**
         Il peut être "actif" ou "fermé". Lors de son inscription au répertoire Sirene, un établissement est, sauf exception, à l'état "actif". Le passage à l'état "fermé" découle de la prise en compte d'une déclaration de fermeture. Un établissement fermé peut être rouvert.
 
         **Cas particuliers&nbsp;:**
-        - **une unité légale est active alors que tous ses établissements sont fermés**. Il s'agit alors d'une entité active d'un point de vue administratif mais n'ayant pas d'activité économique. Cette situation regroupe : 
+        - **une unité légale est active alors que tous ses établissements sont fermés**. Il s'agit alors d'une entité active d'un point de vue administratif mais n'ayant pas d'activité économique. Cette situation regroupe :
            - Les sociétés en sommeil, c'est-à-dire faire reconnaître par une formalité leur état en sommeil afin de ne plus avoir certaines obligations fiscales ;
            - Les sociétés présumées inactives, identifiées par l’Insee pour des besoins statistiques.
-           
+
            La distinction "en sommeil" ou "présumée inactive" n'est pas une information transmise par l'Insee.
         - **une unité légale est cessée alors qu'un établissement est actif**. Cette situation est une erreur à signaler au pôle du répertoire Sirene à l'Insee. Une unité légale cessée ne peut avoir d'établissements actifs.
 
@@ -146,6 +147,7 @@
 
 - uid: 'insee/siege_social_diffusibles'
   path: '/v3/insee/sirene/unites_legales/diffusibles/{siren}/siege_social'
+  ping_url: 'https://entreprise.api.gouv.fr/ping/insee/sirene'
   position: 130
   perimeter:
     entity_type_description: |+

--- a/config/endpoints/api_entreprise/3_insee_unites_legales.yml
+++ b/config/endpoints/api_entreprise/3_insee_unites_legales.yml
@@ -2,6 +2,7 @@
 - uid: 'insee/unites_legales'
   path: '/v3/insee/sirene/unites_legales/{siren}'
   position: 125
+  ping_url: 'https://entreprise.api.gouv.fr/ping/insee/sirene'
   perimeter:
     entity_type_description: |+
       Cette API concerne les unités légales inscrites au répertoire Sirene, qu'elles soient **"diffusibles" ou ["non-diffusibles"](#faq_entry_3_endpoint_insee_unites_legales)** :
@@ -92,17 +93,17 @@
 
         **État administratif de l'unité légale&nbsp;:**
         L'état administratif de l'unité légale peut être "actif" ou "cessé".
-        L'unité légale est toujours active, sauf si une déclaration de cessation administrative a été déposée et prise en compte par l'Insee. 
+        L'unité légale est toujours active, sauf si une déclaration de cessation administrative a été déposée et prise en compte par l'Insee.
         L'état administratif indique si une unité légale est active ou cessée.
 
         **État administratif d'un établissement&nbsp;:**
         Il peut être "actif" ou "fermé". Lors de son inscription au répertoire Sirene, un établissement est, sauf exception, à l'état "actif". Le passage à l'état "fermé" découle de la prise en compte d'une déclaration de fermeture. Un établissement fermé peut être rouvert.
 
         **Cas particuliers&nbsp;:**
-        - **une unité légale est active alors que tous ses établissements sont fermés**. Il s'agit alors d'une entité active d'un point de vue administratif mais n'ayant pas d'activité économique. Cette situation regroupe : 
+        - **une unité légale est active alors que tous ses établissements sont fermés**. Il s'agit alors d'une entité active d'un point de vue administratif mais n'ayant pas d'activité économique. Cette situation regroupe :
            - Les sociétés en sommeil, c'est-à-dire faire reconnaître par une formalité leur état en sommeil afin de ne plus avoir certaines obligations fiscales ;
            - Les sociétés présumées inactives, identifiées par l’Insee pour des besoins statistiques.
-           
+
            La distinction "en sommeil" ou "présumée inactive" n'est pas une information transmise par l'Insee.
         - **une unité légale est cessée alors qu'un établissement est actif**. Cette situation est une erreur à signaler au pôle du répertoire Sirene à l'Insee. Une unité légale cessée ne peut avoir d'établissements actifs.
 
@@ -160,6 +161,7 @@
 - uid: 'insee/unites_legales_diffusibles'
   path: '/v3/insee/sirene/unites_legales/diffusibles/{siren}'
   position: 120
+  ping_url: 'https://entreprise.api.gouv.fr/ping/insee/sirene'
   perimeter:
     entity_type_description: |+
       Cette API concerne les unités légales inscrites au répertoire Sirene et **"diffusibles" commercialement** :

--- a/config/endpoints/api_particulier/cnaf_quotient_familial.yml
+++ b/config/endpoints/api_particulier/cnaf_quotient_familial.yml
@@ -3,11 +3,12 @@
   new_endpoint_uids:
     - 'cnaf-msa/quotient_familial_v2'
   path: '/api/v2/composition-familiale'
+  ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
   position: 100
   perimeter:
     entity_type_description: |+
       {:.fr-highlight.fr-highlight--caution}
-      > ⚠️ **Cette API ne sera plus en production à partir de janvier 2025**. Les données seront intégrées dans l'[API CNAF MSA](https://particulier.api.gouv.fr/catalogue/cnaf-msa/quotient_familial_v2) à partir de janvier 2024. 
+      > ⚠️ **Cette API ne sera plus en production à partir de janvier 2025**. Les données seront intégrées dans l'[API CNAF MSA](https://particulier.api.gouv.fr/catalogue/cnaf-msa/quotient_familial_v2) à partir de janvier 2024.
 
       Cette API concerne les **allocataires de la majorité des régimes** :
       - ✅ le régime général ;

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -331,6 +331,7 @@ fr:
           title: "Format de l'information"
         availability:
           title: "Disponibilité"
+          real_time: "Temps réel"
           link: "Page de statut des API"
           maintenance: "En maintenance tous les jours de %{from_hour} à %{to_hour}"
           no_maintenance: "Disponible 24h/24 et 7j/7"

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -135,6 +135,7 @@ fr:
           title: "Format de l'information"
         availability:
           title: "Disponibilité"
+          real_time: "Temps réel"
           link: "Page de statut des API"
           maintenance: "En maintenance tous les jours de %{from_hour} à %{to_hour}"
           no_maintenance: "Disponible 24h/24 et 7j/7"

--- a/spec/features/api_entreprise/endpoints/show_spec.rb
+++ b/spec/features/api_entreprise/endpoints/show_spec.rb
@@ -1,9 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe 'Endpoints show', app: :api_entreprise do
-  let(:uid) { api_entreprise_example_uid }
-
   let(:endpoint) { APIEntreprise::Endpoint.find(uid) }
+  let(:uid) { api_entreprise_example_uid }
+  let(:api_status) { 200 }
+
+  before do
+    stub_request(:get, endpoint.ping_url).to_return(status: api_status) if endpoint.ping_url
+  end
 
   it 'displays basic information, with attributes data' do
     visit endpoint_path(uid:)
@@ -14,6 +18,28 @@ RSpec.describe 'Endpoints show', app: :api_entreprise do
 
     within('#property_attribute_type') do
       expect(page).to have_content(endpoint.attributes['type']['description'])
+    end
+  end
+
+  describe 'real time status' do
+    before do
+      visit endpoint_path(uid:)
+    end
+
+    context 'when endpoint is up' do
+      let(:api_status) { 200 }
+
+      it 'displays UP status' do
+        expect(page).to have_css('.api-status-up')
+      end
+    end
+
+    context 'when endpoint is down' do
+      let(:api_status) { 502 }
+
+      it 'displays UP status' do
+        expect(page).to have_css('.api-status-down')
+      end
     end
   end
 

--- a/spec/features/api_particulier/endpoints/show_spec.rb
+++ b/spec/features/api_particulier/endpoints/show_spec.rb
@@ -1,9 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe 'Endpoints show', app: :api_particulier do
-  let(:uid) { api_particulier_example_uid }
-
   let(:endpoint) { APIParticulier::Endpoint.find(uid) }
+  let(:uid) { api_particulier_example_uid }
+  let(:api_status) { 200 }
+
+  before do
+    stub_request(:get, endpoint.ping_url).to_return(status: api_status) if endpoint.ping_url
+  end
 
   it 'displays basic information, with attributes data' do
     visit endpoint_path(uid:)
@@ -11,6 +15,28 @@ RSpec.describe 'Endpoints show', app: :api_particulier do
     expect(page).to have_content(endpoint.title)
 
     expect(page).to have_css('#property_attribute_allocataires')
+  end
+
+  describe 'real time status' do
+    before do
+      visit endpoint_path(uid:)
+    end
+
+    context 'when endpoint is up' do
+      let(:api_status) { 200 }
+
+      it 'displays UP status' do
+        expect(page).to have_css('.api-status-up')
+      end
+    end
+
+    context 'when endpoint is down' do
+      let(:api_status) { 502 }
+
+      it 'displays UP status' do
+        expect(page).to have_css('.api-status-down')
+      end
+    end
   end
 
   describe 'each endpoint' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -67,6 +67,10 @@ RSpec.configure do |config|
     example.run_with_retry retry: example.metadata[:retry] || 3
   end
 
+  config.before(:each, type: :feature) do
+    stub_request(:get, %r{api\.gouv\.fr/ping}).to_return(status: 200)
+  end
+
   config.before do
     Rails.cache.clear
   end


### PR DESCRIPTION
Implement for both API Particulier (caf v1) and API Entreprise (INSEE Sirene)

More to come later

Closes https://linear.app/pole-api/issue/API-1174/integrer-le-statut-de-lapi-sur-la-page-du-catalogue