### PR TITLE
Export legacy token to file

### DIFF
--- a/app/services/token_export.rb
+++ b/app/services/token_export.rb
@@ -1,0 +1,92 @@
+require 'csv'
+
+class TokenExport
+  DIR = './tmp/token_export'.freeze
+
+  def initialize(filepath)
+    @filepath = filepath
+  end
+
+  def perform
+    FileUtils.mkdir_p(DIR)
+
+    @legacy_tokens = load_legacy_tokens
+    files_to_export = {}
+    tokens_to_export.find_each do |token|
+      export_filename = export_filename(token)
+      files_to_export[export_filename] ||= []
+      files_to_export[export_filename] << token_payload(token)
+    end
+
+    files_to_export.each_pair do |export_filename, tokens|
+      write_file(export_filename, tokens)
+    end
+  end
+
+  private
+
+  def tokens_to_export
+    Token
+      .includes(:authorization_request)
+      .where("extra_info->'legacy_token_id' IS NOT NULL")
+      .where(authorization_request: { status: 'validated' })
+  end
+
+  def write_file(filename, tokens)
+    file = Rails.root.join("#{DIR}/#{filename}.csv")
+
+    headers = %w[
+      siret
+      intitule
+      demandeur
+      datapass_id
+      nouveau_token
+      ancien_token
+    ]
+
+    CSV.open(file, 'w', write_headers: true, headers:, force_quotes: true) do |writer|
+      tokens.each do |token|
+        writer << token
+      end
+    end
+  end
+
+  def export_filename(token)
+    if token.authorization_request.demarche.present?
+      "demarche_#{token.authorization_request.demarche}"
+    elsif !token.authorization_request.contact_technique.nil?
+      "contact_technique_#{token.authorization_request.contact_technique.email}"
+    else
+      "demandeur_#{token.authorization_request.demandeur.email}"
+    end
+  end
+
+  def tokens
+    Token.includes(:authorization_request)
+  end
+
+  def token_payload(token)
+    [
+      token.authorization_request.siret,
+      token.intitule,
+      token.authorization_request.demandeur.email,
+      token.authorization_request.external_id,
+      token.rehash,
+      legacy_token(token)
+    ]
+  end
+
+  def legacy_token(token)
+    @legacy_tokens.each_pair do |legacy_token, params|
+      return legacy_token if params['token_id'] == token.id && params['legacy_token_id'] == token.extra_info['legacy_token_id']
+    end
+
+    nil
+  end
+
+  def load_legacy_tokens
+    YAML.load_file(
+      Rails.root.join(@filepath)
+    )
+  end
+end

--- a/spec/services/token_export_spec.rb
+++ b/spec/services/token_export_spec.rb
@@ -1,0 +1,71 @@
+require 'csv'
+
+RSpec.describe TokenExport, type: :service do
+  describe 'Token export process' do
+    subject(:token_export) { described_class.new('watever').perform }
+
+    let!(:user) { create(:user, :demandeur) }
+    let!(:token) do
+      create(
+        :token,
+        id: '12131415-1111-1111-1111-111111111110',
+        extra_info: { legacy_token_id: '11111111-1111-1111-1111-111111111111' },
+        authorization_request:
+      )
+    end
+    let!(:legacy_tokens) do
+      {
+        '1_scope' => {
+          'token_id' => '12131415-1111-1111-1111-111111111110',
+          'legacy_token_id' => '11111111-1111-1111-1111-111111111111',
+          'scopes' => ['scope1']
+        }
+      }
+    end
+
+    before do
+      allow(CSV).to receive(:open).and_return(true)
+      allow(YAML).to receive(:load_file).and_return(legacy_tokens)
+    end
+
+    describe 'export token for a demandeur' do
+      let!(:authorization_request) do
+        create(
+          :authorization_request,
+          status: 'validated',
+          demandeur_authorization_request_role: user.user_authorization_request_roles.first
+        )
+      end
+
+      it 'has a demandeur key' do
+        expect(subject["demandeur_#{user.email}"]).not_to be_nil
+      end
+    end
+
+    describe 'export token for a contact_technique' do
+      let!(:user_tech) { create(:user, :contact_technique) }
+
+      let!(:authorization_request) do
+        create(
+          :authorization_request, status: 'validated',
+          demandeur_authorization_request_role: user.user_authorization_request_roles.first,
+          contact_technique_authorization_request_role: user_tech.user_authorization_request_roles.first
+        )
+      end
+
+      it 'has a contact key' do
+        expect(subject["contact_technique_#{user_tech.email}"]).not_to be_nil
+      end
+    end
+
+    describe 'export token for a demarche' do
+      let!(:authorization_request) do
+        create(:authorization_request, status: 'validated', demandeur_authorization_request_role: user.user_authorization_request_roles.first, demarche: 1234)
+      end
+
+      it 'has a demarche key' do
+        expect(subject["demarche_#{authorization_request.demarche}"]).not_to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Petit edit par rapport au contenu du ticket : 

On abandonne le chiffrage, les fichiers seront distribués de facon sécurisé via <insérer une solution pour le nous du futur>.

Le script est à run une seule fois, donc est jetable, donc rien n'est réutilisable, c'est fait exprès. J'suis pas hyper fan du naming du fichier, mais à priori on va le jeter une fois que c'est fait donc j'ai flemmé là dessus.

L'utilisation se fait direct en console.

On peut binomer pour aller plus vite.


