### PR TITLE
Provide Standard URL for new token file

### DIFF
--- a/app/controllers/api_particulier/new_tokens_controller.rb
+++ b/app/controllers/api_particulier/new_tokens_controller.rb
@@ -19,7 +19,7 @@ class APIParticulier::NewTokensController < APIParticulier::AuthenticatedUsersCo
   private
 
   def get_file_content(email)
-    file_path = Rails.root.join('./tmp/token_export')
+    file_path = Rails.root.join('./token_export')
 
     [
       "demarche_#{email}",

--- a/app/controllers/api_particulier/new_tokens_controller.rb
+++ b/app/controllers/api_particulier/new_tokens_controller.rb
@@ -1,0 +1,35 @@
+class APIParticulier::NewTokensController < APIParticulier::AuthenticatedUsersController
+  def download
+    file = get_file_content(current_user.email)
+
+    if file.present?
+      send_data file, filename: 'nouveaux_jetons.csv'
+    else
+      flash_message(
+        :error,
+        title: 'Erreur lors de la recherche',
+        description: 'Il n\'existe aucun nouveau jeton pour votre compte',
+        id: 'error-no-token'
+      )
+
+      redirect_to user_profile_path
+    end
+  end
+
+  private
+
+  def get_file_content(email)
+    file_path = Rails.root.join('./tmp/token_export')
+
+    [
+      "demarche_#{email}",
+      "contact_technique_#{email}",
+      "demandeur_#{email}"
+    ].each do |filename|
+      full_path = "#{file_path}/#{filename}.csv"
+      return File.read(full_path) if File.exist?(full_path)
+    end
+
+    nil
+  end
+end

--- a/app/services/token_export.rb
+++ b/app/services/token_export.rb
@@ -1,7 +1,7 @@
 require 'csv'
 
 class TokenExport
-  DIR = './tmp/token_export'.freeze
+  DIR = './token_export'.freeze
 
   def initialize(filepath)
     @filepath = filepath

--- a/config/routes/api_particulier.rb
+++ b/config/routes/api_particulier.rb
@@ -33,6 +33,7 @@ constraints(APIParticulierDomainConstraint.new) do
     get '/compte/apres-deconnexion', to: 'sessions#after_logout', as: :after_logout
 
     get '/compte', to: 'users#profile', as: :user_profile
+    get '/compte/nouveaux-jetons/telecharger', to: "new_tokens#download", as: :new_tokens_download
 
     post 'public/magic_link/create', to: 'public_token_magic_links#create'
     post '/compte/jetons/:id/partager', to: 'restricted_token_magic_links#create', as: :token_create_magic_link

--- a/spec/controllers/api_particulier/new_tokens_controller_spec.rb
+++ b/spec/controllers/api_particulier/new_tokens_controller_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe APIParticulier::NewTokensController do
+  subject(:new_tokens_download) { get :download }
+
+  describe 'GET #new_token' do
+    context 'when the user is not logged in' do
+      before { new_tokens_download }
+
+      it { is_expected.to have_http_status(:found) }
+    end
+
+    context 'when the user is logged in' do
+      before do
+        session[:current_user_id] = user_id
+      end
+
+      context 'when there is not matching csv file' do
+        let(:user_id) { '1234567890' }
+
+        it { is_expected.to have_http_status(:found) }
+      end
+
+      context 'when there is a matching csv file' do
+        before do
+          allow(File).to receive_messages(
+            read: true,
+            exist?: true
+          )
+        end
+
+        let!(:user) { create(:user) }
+        let(:user_id) { user.id }
+
+        it { is_expected.to have_http_status(:success) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Cette PR est dans la foulée de la PR de génération des fichiers.

Il fallait fournir une url unique pour N user cachée, derrière un login MCP qui renvoit le premier fichier matchant la nomenclature.
À jeter une fois que la migration des tokens sera terminée