### PR TITLE
Ajout et utilisation de la colonne blacklisted_at

### DIFF
--- a/app/lib/seeds.rb
+++ b/app/lib/seeds.rb
@@ -103,7 +103,7 @@ class Seeds
     create_token(
       @scopes_entreprise.sample(2),
       'entreprise',
-      token_params: { blacklisted: true, exp: 14.months.ago },
+      token_params: { blacklisted_at: 6.months.ago, exp: 14.months.ago },
       demandeur: @user,
       authorization_request_params: {
         intitule: 'Mairie de Paris',

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -76,7 +76,7 @@ class AuthorizationRequest < ApplicationRecord
   end
 
   def blacklist!
-    token&.update!(blacklisted: true)
+    token&.update!(blacklisted_at: Time.zone.now)
 
     update!(status: 'blacklisted')
   end

--- a/db/migrate/20231010150356_token_add_blacklisted_at.rb
+++ b/db/migrate/20231010150356_token_add_blacklisted_at.rb
@@ -1,0 +1,10 @@
+class TokenAddBlacklistedAt < ActiveRecord::Migration[7.1]
+  def up
+    add_column :tokens, :blacklisted_at, :datetime, default: nil, null: true 
+    Token.where(blacklisted: true).update_all(blacklisted_at: Time.zone.now)
+  end
+
+  def down
+    remove_column :tokens, :blacklisted_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_22_102926) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_10_150356) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pgcrypto"
@@ -58,6 +58,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_22_102926) do
     t.uuid "authorization_request_model_id", null: false
     t.json "extra_info"
     t.jsonb "scopes", default: [], null: false
+    t.datetime "blacklisted_at"
     t.index ["access_request_survey_sent"], name: "index_tokens_on_access_request_survey_sent"
     t.index ["archived"], name: "index_tokens_on_archived"
     t.index ["blacklisted"], name: "index_tokens_on_blacklisted"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,4 +9,4 @@ if Rails.env.staging?
   seeds.create_scopes('entreprise')
 else
   seeds.perform
-end
+end 

--- a/lib/tasks/token.rake
+++ b/lib/tasks/token.rake
@@ -13,7 +13,7 @@ namespace :token do
     copy.iat = Time.zone.now.to_i
     copy.save
 
-    token.update(blacklisted: true)
+    token.update(blacklisted_at: Time.zone.now)
   end
 
   desc "Mark an API Particulier token (which has a legacy id) as migration token:mark_as_migrated\\['UUID'\\]"

--- a/spec/factories/tokens.rb
+++ b/spec/factories/tokens.rb
@@ -80,11 +80,11 @@ FactoryBot.define do
     end
 
     trait :not_blacklisted do
-      blacklisted { false }
+      blacklisted_at { nil }
     end
 
     trait :blacklisted do
-      blacklisted { true }
+      blacklisted_at { 1.month.ago }
     end
 
     trait :expired do

--- a/spec/interactors/datapass_webhook/revoke_current_token_spec.rb
+++ b/spec/interactors/datapass_webhook/revoke_current_token_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe DatapassWebhook::RevokeCurrentToken, type: :interactor do
     it 'does not archive current token' do
       expect {
         subject
-      }.not_to change { Token.where(blacklisted: true).count }
+      }.not_to change { Token.where.not(blacklisted_at: nil).count }
     end
   end
 
@@ -28,7 +28,7 @@ RSpec.describe DatapassWebhook::RevokeCurrentToken, type: :interactor do
     it 'does revoke current token' do
       expect {
         subject
-      }.to change { Token.where(blacklisted: true).count }
+      }.to change { Token.where.not(blacklisted_at: nil).count }
     end
 
     it 'does update the authorization request status' do

--- a/spec/organizers/token/send_expiration_notices_spec.rb
+++ b/spec/organizers/token/send_expiration_notices_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Token::SendExpirationNotices, type: :organizer do
     end
 
     it 'does not call the mailer for blacklisted tokens' do
-      blacklisted_token = create(:token, :expiring_within_3_month, blacklisted: true)
+      blacklisted_token = create(:token, :expiring_within_3_month, :blacklisted)
       # Expectations for sent notifications are needed, otherwise the code runs against the "dumb" double
       expect(ScheduleExpirationNoticeMailjetEmailJob).to receive(:perform_later).with(one_token_expired_within_3_month, days).and_call_original
       expect(ScheduleExpirationNoticeMailjetEmailJob).to receive(:perform_later).with(another_token_expired_within_3_month, days).and_call_original


### PR DESCRIPTION
Première partie de l'utilisation du nouveau champ `blacklisted_at`.

La très bonne pratique aurait voulue que je continue d'écrire sur les 2 colonnes en même temps, mais bon ... voilà (ceci est un argument)

En follow up : 
- Une PR sur siade pour utiliser ce champs à la place du champ blacklisted
- Une PR sur admin pour changer la tache rake et mettre le blacklisting à +1 mois
- Une PR sur admin pour retirer les champs blacklisted et archived