### PR TITLE
Bugfix redirect to another host error

### DIFF
--- a/app/controllers/concerns/sessions_management.rb
+++ b/app/controllers/concerns/sessions_management.rb
@@ -18,7 +18,7 @@ module SessionsManagement
   def destroy
     logout_user
 
-    redirect_to oauth_logout_url
+    redirect_to oauth_logout_url, allow_other_host: true
   end
 
   def after_logout


### PR DESCRIPTION
Probably linked to the migration to rails 7.1

Closes https://errors.data.gouv.fr/organizations/sentry/issues/5062/