### PR TITLE
Updating Authorization Request on revoke event

### DIFF
--- a/app/interactors/datapass_webhook/revoke_current_token.rb
+++ b/app/interactors/datapass_webhook/revoke_current_token.rb
@@ -3,7 +3,7 @@ class DatapassWebhook::RevokeCurrentToken < ApplicationInteractor
     return unless context.event == 'revoke'
     return unless token_already_exists?
 
-    context.authorization_request.blacklist!
+    context.authorization_request.revoke!
   end
 
   private

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -75,9 +75,9 @@ class AuthorizationRequest < ApplicationRecord
     update!(status: 'archived')
   end
 
-  def blacklist!
+  def revoke!
     token&.update!(blacklisted_at: Time.zone.now)
 
-    update!(status: 'blacklisted')
+    update!(status: 'revoked')
   end
 end

--- a/db/migrate/20231012152426_migrate_blacklisted_authorization_request_to_revoked.rb
+++ b/db/migrate/20231012152426_migrate_blacklisted_authorization_request_to_revoked.rb
@@ -1,0 +1,5 @@
+class MigrateBlacklistedAuthorizationRequestToRevoked < ActiveRecord::Migration[7.1]
+  def change
+    AuthorizationRequest.where(status: 'blacklisted').update_all(status: 'revoked')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_10_150356) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_12_152426) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "btree_gin"
   enable_extension "pgcrypto"

--- a/spec/interactors/datapass_webhook/revoke_current_token_spec.rb
+++ b/spec/interactors/datapass_webhook/revoke_current_token_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe DatapassWebhook::RevokeCurrentToken, type: :interactor do
     it 'does update the authorization request status' do
       expect {
         subject
-      }.to change { AuthorizationRequest.where(status: 'blacklisted').count }
+      }.to change { AuthorizationRequest.where(status: 'revoked').count }
     end
   end
 end


### PR DESCRIPTION
C'est un brainfart parce qu'on a rien qui gère dans le code les AR en status 'blacklisted'. C'est juste qu'entre le blacklist du token et le revoke de l'authorization request on mélangeais les termes.

Du coup en db on a des status revoked et des status blacklisted. On a dit qu'on ne conservait que les status qui était des states lié à datapass. Revoked it is donc.

Au moins c'est clair now

