### PR TITLE
Feature/api 1458 jai acces aux informations de bases sur mon habilitation

### DIFF
--- a/app/controllers/api_entreprise/authorization_requests_controller.rb
+++ b/app/controllers/api_entreprise/authorization_requests_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class APIEntreprise::AuthorizationRequestsController < APIEntreprise::AuthenticatedUsersController
+  include AuthorizationRequestsManagement
+
   def index
     @authorization_requests = current_user
       .authorization_requests

--- a/app/controllers/api_particulier/authorization_requests_controller.rb
+++ b/app/controllers/api_particulier/authorization_requests_controller.rb
@@ -1,0 +1,3 @@
+class APIParticulier::AuthorizationRequestsController < APIParticulier::AuthenticatedUsersController
+  include AuthorizationRequestsManagement
+end

--- a/app/controllers/concerns/authorization_requests_management.rb
+++ b/app/controllers/concerns/authorization_requests_management.rb
@@ -5,6 +5,7 @@ module AuthorizationRequestsManagement
     @authorization_request = current_user
       .authorization_requests
       .where(api:)
+      .viewable_by_users
       .find(params[:id])
 
     render 'shared/authorization_requests/show'

--- a/app/controllers/concerns/authorization_requests_management.rb
+++ b/app/controllers/concerns/authorization_requests_management.rb
@@ -11,7 +11,7 @@ module AuthorizationRequestsManagement
     render 'shared/authorization_requests/show'
   rescue ActiveRecord::RecordNotFound
     error_message(title: t('.error.title'))
-    
+
     redirect_current_user_to_homepage
   end
 

--- a/app/controllers/concerns/authorization_requests_management.rb
+++ b/app/controllers/concerns/authorization_requests_management.rb
@@ -1,0 +1,22 @@
+module AuthorizationRequestsManagement
+  extend ActiveSupport::Concern
+
+  def show
+    @authorization_request = current_user
+      .authorization_requests
+      .where(api:)
+      .find(params[:id])
+
+    render 'shared/authorization_requests/show'
+  rescue ActiveRecord::RecordNotFound
+    error_message(title: t('.error.title'))
+    
+    redirect_current_user_to_homepage
+  end
+
+  private
+
+  def api
+    namespace.slice(4..-1)
+  end
+end

--- a/app/helpers/authorization_request_helper.rb
+++ b/app/helpers/authorization_request_helper.rb
@@ -1,0 +1,15 @@
+module AuthorizationRequestHelper
+  def authorization_request_status_badge(authorization_request)
+    "<p class=\"fr-badge fr-badge--#{authorization_request_status_color(authorization_request)}\">#{authorization_request_status_label(authorization_request)}</p>".html_safe
+  end
+
+  private
+
+  def authorization_request_status_color(authorization_request)
+    I18n.t("shared.authorization_requests.status.color.#{authorization_request.status}")
+  end
+
+  def authorization_request_status_label(authorization_request)
+    I18n.t("shared.authorization_requests.status.label.#{authorization_request.status}")
+  end
+end

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -25,6 +25,7 @@ class AuthorizationRequest < ApplicationRecord
   scope :not_archived, -> { where.not(status: 'archived') }
   scope :archived, -> { where(status: 'archived') }
   scope :for_api, ->(api) { where(api:) }
+  scope :viewable_by_users, -> { where(status: %w[archived revoked validated]) }
 
   def token
     active_token || most_recent_token

--- a/app/views/shared/authorization_requests/show.html.erb
+++ b/app/views/shared/authorization_requests/show.html.erb
@@ -1,5 +1,23 @@
-<%= @authorization_request.id %>
-<br />
-<%= @authorization_request.intitule %>
-<br />
-<%= @authorization_request.demarche %>
+<div>
+  <%= authorization_request_status_badge(@authorization_request) %>
+
+  <% if @authorization_request.demarche.present? %>
+    <span class="fr-badge fr-text--xs">
+      <i class="fr-icon-attachment-line fr-icon--sm fr-pr-1v" aria-hidden="true"></i>
+      <%= @authorization_request.demarche %>
+    </span>
+  <% end %>
+
+  <h2 class="fr-h3 fr-mb-n0-5v"><%= @authorization_request.intitule %></h3>
+
+  <span class="fr-text--xs">
+    <b><%= t('.delivered_at', humanized_date: friendly_format_from_timestamp(@authorization_request.created_at)) %></b>
+    - 
+    <%= link_to t('.links.to_datapass', external_id: @authorization_request.external_id).html_safe, 
+      datapass_authorization_request_url(@authorization_request), 
+      id: :authorization_request_link,
+      class: %w(fr-link fr-text--xs), 
+      target: '_blank' 
+    %>
+  </span>
+</div>

--- a/app/views/shared/authorization_requests/show.html.erb
+++ b/app/views/shared/authorization_requests/show.html.erb
@@ -1,0 +1,5 @@
+<%= @authorization_request.id %>
+<br />
+<%= @authorization_request.intitule %>
+<br />
+<%= @authorization_request.demarche %>

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -4,6 +4,20 @@ fr:
       application:
         title: API Entreprise
   shared:
+    authorization_requests:
+      status:
+        color:
+          revoked: pink-tuile
+          archived: no-specific-color
+          validated: green-emeraude
+        label:
+          revoked: 📃 Habilitation révoquée
+          archived: 📃 Habilitation archivée
+          validated: 📃 Habilitation active
+      show:
+        delivered_at: "Délivré le : %{humanized_date}"
+        links:
+          to_datapass: "N<sup>o</sup>%{external_id}"
     api_entreprise:
       header:
         title: API Entreprise

--- a/config/routes/api_entreprise.rb
+++ b/config/routes/api_entreprise.rb
@@ -23,6 +23,7 @@ constraints(APIEntrepriseDomainConstraint.new) do
     get '/compte', to: 'users#profile', as: :user_profile
 
     get '/compte/demandes', to: 'authorization_requests#index', as: :authorization_requests
+    get '/compte/demandes/:id', to: 'authorization_requests#show', as: :authorization_requests_show
 
     get '/compte/telecharcher-documents', to: 'attestations#index', as: :attestations
     post '/compte/telecharcher-documents/rechercher-siret', to: 'attestations#search', as: :search_attestations

--- a/config/routes/api_particulier.rb
+++ b/config/routes/api_particulier.rb
@@ -35,6 +35,8 @@ constraints(APIParticulierDomainConstraint.new) do
     get '/compte', to: 'users#profile', as: :user_profile
     get '/compte/nouveaux-jetons/telecharger', to: "new_tokens#download", as: :new_tokens_download
 
+    get '/compte/demandes/:id', to: 'authorization_requests#show', as: :authorization_requests_show
+
     post 'public/magic_link/create', to: 'public_token_magic_links#create'
     post '/compte/jetons/:id/partager', to: 'restricted_token_magic_links#create', as: :token_create_magic_link
     get 'public/jetons/:access_token', to: 'public_token_magic_links#show', as: :token_show_magic_link

--- a/spec/features/api_particulier/authorization_request_spec.rb
+++ b/spec/features/api_particulier/authorization_request_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe 'displays authorization requests', app: :api_particulier do
+  subject(:go_to_authorization_requests_show) do
+    visit api_particulier_authorization_requests_show_path(id: authorization_request.id)
+  end
+
+  let!(:authenticated_user) { create(:user, :demandeur) }
+  let!(:non_authenticated_user) { create(:user, :demandeur) }
+  let!(:authorization_request) do
+    create(
+      :authorization_request,
+      demandeur_authorization_request_role: non_authenticated_user.user_authorization_request_roles.first,
+      api: 'entreprise'
+    )
+  end
+
+  describe 'when user is not authenticated' do
+    it 'redirects to the login' do
+      go_to_authorization_requests_show
+      expect(page).to have_current_path(api_particulier_login_path, ignore_query: true)
+    end
+  end
+
+  describe 'when user is authenticated' do
+    before do
+      login_as(authenticated_user)
+      go_to_authorization_requests_show
+    end
+
+    describe 'when authorization_request does not belong to current_user' do
+      it 'redirects to the profile' do
+        expect(page).to have_current_path(api_particulier_user_profile_path, ignore_query: true)
+      end
+    end
+
+    describe 'when authorization_request belongs to current_user' do
+      describe 'when it not viewable by users' do
+        let!(:authorization_request) do
+          create(
+            :authorization_request,
+            demandeur_authorization_request_role: authenticated_user.user_authorization_request_roles.first,
+            api: 'entreprise',
+            status: 'draft'
+          )
+        end
+
+        it 'redirects to the profile' do
+          expect(page).to have_current_path(api_particulier_user_profile_path, ignore_query: true)
+        end
+      end
+
+      describe 'when authorization_request is from api_entreprise' do
+        let!(:authorization_request) do
+          create(
+            :authorization_request,
+            demandeur_authorization_request_role: authenticated_user.user_authorization_request_roles.first,
+            api: 'entreprise',
+            status: 'validated'
+          )
+        end
+
+        it 'redirects to the profile' do
+          expect(page).to have_current_path(api_particulier_user_profile_path, ignore_query: true)
+        end
+      end
+
+      describe 'when authorization_request is from api_particulier' do
+        describe 'when the authorization request is valid' do
+          let!(:authorization_request) do
+            create(
+              :authorization_request,
+              demandeur_authorization_request_role: authenticated_user.user_authorization_request_roles.first,
+              api: 'particulier'
+            )
+          end
+
+          it 'diplays the page' do
+            expect(page).to have_current_path(api_particulier_authorization_requests_show_path(id: authorization_request.id), ignore_query: true)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/api_particulier/authorization_request_spec.rb
+++ b/spec/features/api_particulier/authorization_request_spec.rb
@@ -64,12 +64,28 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
       end
 
       describe 'when authorization_request is from api_particulier' do
+        describe 'when the authorization request is not viewable by user' do
+          let!(:authorization_request) do
+            create(
+              :authorization_request,
+              demandeur_authorization_request_role: authenticated_user.user_authorization_request_roles.first,
+              status: 'draft',
+              api: 'particulier'
+            )
+          end
+
+          it 'redirects to the profile' do
+            expect(page).to have_current_path(api_particulier_user_profile_path, ignore_query: true)
+          end
+        end
+
         describe 'when the authorization request is valid' do
           let!(:authorization_request) do
             create(
               :authorization_request,
               demandeur_authorization_request_role: authenticated_user.user_authorization_request_roles.first,
-              api: 'particulier'
+              api: 'particulier',
+              status: 'validated',
             )
           end
 

--- a/spec/features/api_particulier/authorization_request_spec.rb
+++ b/spec/features/api_particulier/authorization_request_spec.rb
@@ -64,33 +64,31 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
       end
 
       describe 'when authorization_request is from api_particulier' do
+        let!(:authorization_request) do
+          create(
+            :authorization_request,
+            demandeur_authorization_request_role: authenticated_user.user_authorization_request_roles.first,
+            api: 'particulier',
+            status:
+          )
+        end
+
         describe 'when the authorization request is not viewable by user' do
-          let!(:authorization_request) do
-            create(
-              :authorization_request,
-              demandeur_authorization_request_role: authenticated_user.user_authorization_request_roles.first,
-              status: 'draft',
-              api: 'particulier'
-            )
-          end
+          let(:status) { 'draft' }
 
           it 'redirects to the profile' do
             expect(page).to have_current_path(api_particulier_user_profile_path, ignore_query: true)
           end
         end
 
-        describe 'when the authorization request is valid' do
-          let!(:authorization_request) do
-            create(
-              :authorization_request,
-              demandeur_authorization_request_role: authenticated_user.user_authorization_request_roles.first,
-              api: 'particulier',
-              status: 'validated',
-            )
-          end
+        describe 'when the authorization request is validated' do
+          let(:status) { 'validated' }
 
-          it 'diplays the page' do
+          it 'diplays basic information on the page' do
             expect(page).to have_current_path(api_particulier_authorization_requests_show_path(id: authorization_request.id), ignore_query: true)
+            expect(page).to have_content('Habilitation active')
+            expect(page).to have_link(href: datapass_authorization_request_url(authorization_request))
+            expect(page).to have_content(friendly_format_from_timestamp(authorization_request.created_at))
           end
         end
       end

--- a/spec/models/authorization_request_spec.rb
+++ b/spec/models/authorization_request_spec.rb
@@ -33,6 +33,27 @@ RSpec.describe AuthorizationRequest do
     end
   end
 
+  describe '.viewable_by_users scope' do
+    subject { described_class.viewable_by_users }
+
+    let!(:viewable_authorization_requests) do
+      [
+        create(:authorization_request, :with_tokens, api: 'particulier', status: 'archived'),
+        create(:authorization_request, api: 'particulier', status: 'revoked'),
+        create(:authorization_request, status: 'validated')
+      ]
+    end
+
+    let!(:not_viewable_authorization_request) do
+      create(:authorization_request, status: 'draft')
+    end
+
+    it 'returns viewable authorization requests' do
+      expect(subject).to include(*viewable_authorization_requests)
+      expect(subject).not_to include(not_viewable_authorization_request)
+    end
+  end
+
   describe 'fetch token with the most recent expiration date' do
     let(:authorization_request) do
       create(:authorization_request, :with_multiple_tokens_one_valid)


### PR DESCRIPTION
Initialisation du travail sur la partie admin des habilitations.

La page est cachée et pour y accéder il faut aller sur l'url : `/compte/habilitation/datapass_id`
ATTENTION : il faut être sur le site particulier pour accéder aux habilitations de api-particulier, et sur entreprise pour le site de api-entreprise.

En local pour particulier : http://particulier.api.localtest.me:3000/compte/demandes/2649c7b6-d1a3-4a47-a1a6-b354a21dfefb
En local pour entreprise : http://entreprise.api.localtest.me:3000/compte/demandes/0c87cef2-747d-4949-8798-b5f84e3a440a

Voici un petit screen de la page et des différents états : 
J'ai changé un peu le visuel sur le badge de status. Je ne trouvais pas l'icone proposé et jje trouvais que finalement les états présent dans le DSFR était pas mal.
Je n'ai pas afficher l'information concernant l'éditeur parce que nous n'avons pas l'infos. À noter dans un ticket annexe si jamais la PR est validée as is.


![image](https://github.com/etalab/admin_api_entreprise/assets/9677688/9a6c79d8-35a8-46cd-97d9-243d0cb1ba47)
![image](https://github.com/etalab/admin_api_entreprise/assets/9677688/8a95327d-04a1-421c-8316-3a4f2181f51d)
![image](https://github.com/etalab/admin_api_entreprise/assets/9677688/d3be2841-68fb-44a2-a62b-68c36676f81d)

