### PR TITLE
Remove deprecated message due to Rails 7.1

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :memory_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false


### PR DESCRIPTION
```
DEPRECATION WARNING: Setting action_dispatch.show_exceptions to false is deprecated. Set to :none instead.
```