### PR TITLE
[Erreur contenu] Mise en exuergue API depréciée : Retire mention doc API Entreprise

### DIFF
--- a/app/views/api_particulier/endpoints/show.html.erb
+++ b/app/views/api_particulier/endpoints/show.html.erb
@@ -97,8 +97,11 @@
                 </li>
               <% end %>
             </ul>
+            <%#
             <p class="fr-text--sm fr-mt-2w">
-            <%= t('.deprecated.link_documentation').html_safe %></p>
+            <%= t('.deprecated.link_documentation').html_safe %>
+            <%#</p>
+            %>
           </p>
         </div>
       <% end %>

--- a/app/views/api_particulier/endpoints/show.html.erb
+++ b/app/views/api_particulier/endpoints/show.html.erb
@@ -97,11 +97,6 @@
                 </li>
               <% end %>
             </ul>
-            <%#
-            <p class="fr-text--sm fr-mt-2w">
-            <%= t('.deprecated.link_documentation').html_safe %>
-            <%#</p>
-            %>
           </p>
         </div>
       <% end %>

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -92,8 +92,8 @@ fr:
         deprecated:
           title: "Cette API est dépréciée"
           description: "Cette API est une ancienne version, nous vous invitons à utiliser ces API les plus récentes :"
-          link_documentation: |-
-            Plus d'informations sur la gestion de version API&nbsp;Entreprise dans cette <a href='https://entreprise.api.gouv.fr/developpeurs#gerer-les-evolutions-de-version' target='_blank'>documentation</a>.
+          #link_documentation: |-
+          # Plus d'informations sur la gestion de version API&nbsp;Particulier dans cette <a href='https://particulier.api.gouv.fr/developpeurs#gerer-les-evolutions-de-version' target='_blank'>documentation</a>.
         incoming:
           title: "Cette API est bientôt disponible, testez-là !"
           description: "Cette API est en cours de conception et va bientôt rejoindre le catalogue d'API Particulier."

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -92,8 +92,6 @@ fr:
         deprecated:
           title: "Cette API est dépréciée"
           description: "Cette API est une ancienne version, nous vous invitons à utiliser ces API les plus récentes :"
-          #link_documentation: |-
-          # Plus d'informations sur la gestion de version API&nbsp;Particulier dans cette <a href='https://particulier.api.gouv.fr/developpeurs#gerer-les-evolutions-de-version' target='_blank'>documentation</a>.
         incoming:
           title: "Cette API est bientôt disponible, testez-là !"
           description: "Cette API est en cours de conception et va bientôt rejoindre le catalogue d'API Particulier."


### PR DESCRIPTION
### Problème : 
<img width="731" alt="image" src="https://github.com/etalab/admin_api_entreprise/assets/46896006/6500127d-2fc5-43c5-bfa0-eaadbc1f49d7">


### Ce que cette PR propose : 

<img width="740" alt="image" src="https://github.com/etalab/admin_api_entreprise/assets/46896006/92cd6b67-cecc-4b2a-a256-be04ea9e669d">
