### PR TITLE
[API Particulier] Ajoute section demonstrateur en page d'accueil

### DIFF
--- a/app/assets/stylesheets/shared/pages/home/_section_demonstrateur.scss
+++ b/app/assets/stylesheets/shared/pages/home/_section_demonstrateur.scss
@@ -1,0 +1,5 @@
+#homepage #section-demonstrateur {
+    background-color: #E3E3FD;
+  }
+  
+  

--- a/app/views/api_entreprise/pages/home/_section_developers.html.erb
+++ b/app/views/api_entreprise/pages/home/_section_developers.html.erb
@@ -2,7 +2,7 @@
   <div class="fr-container fr-p-5w">
     <div class="fr-grid-row">
       <h2 class="fr-h3 fr-col-12"><%= t('.title').html_safe %></h2>
-      <p class="fr-col-12 fr-text--lead"><%= t('.description') %></p>
+      <p class="fr-col-12"><%= t('.description') %></p>
     </div>
 
     <div class="cards">

--- a/app/views/api_entreprise/pages/home/_section_howto.html.erb
+++ b/app/views/api_entreprise/pages/home/_section_howto.html.erb
@@ -4,7 +4,7 @@
       <div class="left-info fr-col-xl-8 fr-col-12 fr-pt-5w padding-left-container">
         <div class="left-info--text">
           <h2 class="fr-h3"><%= t('.title') %></h2>
-          <p class="fr-text--lead"><%= t('.description').html_safe %></p>
+          <p class="fr-text--lg"><%= t('.description').html_safe %></p>
           <a href="https://api.gouv.fr/les-api/api-entreprise/demande-acces" class="fr-link" target="_blank" rel="noopener"><%= t('.check_eligibity') %></a>
         </div>
 

--- a/app/views/api_entreprise/pages/home/_section_partners.html.erb
+++ b/app/views/api_entreprise/pages/home/_section_partners.html.erb
@@ -2,7 +2,7 @@
   <div class="fr-container--fluid">
     <div class="fr-grid-row provider-container">
       <h2 class="fr-h3 fr-ml-2v fr-col-12"><%= t('.title').html_safe %></h2>
-      <p class="fr-ml-2v fr-col-12 fr-text--lead"><%= t('.subtitle') %></p>
+      <p class="fr-ml-2v fr-col-12"><%= t('.subtitle') %></p>
 
       <div class="providers">
         <% @providers.each do |provider| %>

--- a/app/views/api_entreprise/pages/home/_section_welcome.html.erb
+++ b/app/views/api_entreprise/pages/home/_section_welcome.html.erb
@@ -7,7 +7,7 @@
     </div>
   </h1>
 
-  <span class="fr-h3 fr-text--lead">
+  <span class="fr-h3">
     <%= t('.subtitle').html_safe %>
   </span>
 

--- a/app/views/api_entreprise/pages/newsletter/_banner.html.erb
+++ b/app/views/api_entreprise/pages/newsletter/_banner.html.erb
@@ -1,6 +1,6 @@
 <div class="fr-background-yellow">
   <div class='fr-container fr-pt-7w fr-pb-9w'>
     <h1><%= t('.title') %></h1>
-    <p class="fr-text--lead"><%= t('.description').html_safe %></p>
+    <p><%= t('.description').html_safe %></p>
   </div>
 </div>

--- a/app/views/api_particulier/pages/home.html.erb
+++ b/app/views/api_particulier/pages/home.html.erb
@@ -2,6 +2,7 @@
   <%= render 'shared/pages/home_alerts' %>
   <%= render 'api_particulier/pages/home/section_welcome' %>
   <%= render 'api_particulier/pages/home/section_access' %>
+  <%= render 'api_particulier/pages/home/section_demonstrateur' %>
   <%= render partial: 'api_particulier/pages/newsletter/main' %>
   <%= render 'api_particulier/pages/home/section_partners' %>
   <%= render 'api_particulier/pages/home/section_developers' %>

--- a/app/views/api_particulier/pages/home/_section_demonstrateur.html.erb
+++ b/app/views/api_particulier/pages/home/_section_demonstrateur.html.erb
@@ -4,7 +4,7 @@
       <h2 class="fr-h3 fr-col-12"><%= t('.demo_title').html_safe %></h2>
       <p class="fr-col-12 fr-text--lead"><%= t('.demo_description') %></p>
     </div>
-     <a href="https://api-particulier-demonstrateur.osc-secnum-fr1.scalingo.io/" class="fr-btn fr-btn--lg fr-m-1w" target="_blank"><%= t('.demo_link_title') %></a>
+     <a href="https://demonstrateur.particulier.api.gouv.fr/" class="fr-btn fr-btn--lg fr-m-1w" target="_blank"><%= t('.demo_link_title') %></a>
     </div>
   </div>
 </section>

--- a/app/views/api_particulier/pages/home/_section_demonstrateur.html.erb
+++ b/app/views/api_particulier/pages/home/_section_demonstrateur.html.erb
@@ -1,0 +1,10 @@
+<section id="section-demonstrateur">
+  <div class="fr-container fr-p-5w center">
+    <div class="fr-grid-row">
+      <h2 class="fr-h3 fr-col-12"><%= t('.demo_title').html_safe %></h2>
+      <p class="fr-col-12 fr-text--lead"><%= t('.demo_description') %></p>
+    </div>
+     <a href="https://api-particulier-demonstrateur.osc-secnum-fr1.scalingo.io/" class="fr-btn fr-btn--lg fr-m-1w" target="_blank"><%= t('.demo_link_title') %></a>
+    </div>
+  </div>
+</section>

--- a/app/views/api_particulier/pages/home/_section_demonstrateur.html.erb
+++ b/app/views/api_particulier/pages/home/_section_demonstrateur.html.erb
@@ -5,7 +5,7 @@
       <p class="fr-col-12 fr-text--lead"><%= t('.demo_description') %></p>
     </div>
     <div>
-     <a href="https://demonstrateur.particulier.api.gouv.fr/" class="fr-btn fr-btn--lg fr-m-1w" target="_blank"><%= t('.demo_link_title') %></a>
+     <%= link_to t('.demo_link_title'), t('.demo_link'), class: %w[fr-btn fr-btn--lg fr-m-1w], target: '_blank' %>
     </div>
   </div>
 </section>

--- a/app/views/api_particulier/pages/home/_section_demonstrateur.html.erb
+++ b/app/views/api_particulier/pages/home/_section_demonstrateur.html.erb
@@ -4,6 +4,7 @@
       <h2 class="fr-h3 fr-col-12"><%= t('.demo_title').html_safe %></h2>
       <p class="fr-col-12 fr-text--lead"><%= t('.demo_description') %></p>
     </div>
+    <div>
      <a href="https://demonstrateur.particulier.api.gouv.fr/" class="fr-btn fr-btn--lg fr-m-1w" target="_blank"><%= t('.demo_link_title') %></a>
     </div>
   </div>

--- a/app/views/api_particulier/pages/home/_section_developers.html.erb
+++ b/app/views/api_particulier/pages/home/_section_developers.html.erb
@@ -2,7 +2,7 @@
   <div class="fr-container fr-p-5w">
     <div class="fr-grid-row">
       <h2 class="fr-h3 fr-col-12"><%= t('.title').html_safe %></h2>
-      <p class="fr-col-12 fr-text--lead"><%= t('.description') %></p>
+      <p class="fr-col-12"><%= t('.description') %></p>
     </div>
 
     <div class="cards">

--- a/app/views/api_particulier/pages/home/_section_partners.html.erb
+++ b/app/views/api_particulier/pages/home/_section_partners.html.erb
@@ -4,7 +4,7 @@
       <h2 class="fr-h3 fr-ml-2v fr-col-12">
         <%= t('.title').html_safe %>
       </h2>
-      <p class="fr-ml-2v fr-col-12 fr-text--lead">
+      <p class="fr-ml-2v fr-col-12">
         <%= t('.subtitle') %>
       </p>
 

--- a/app/views/api_particulier/pages/home/_section_welcome.html.erb
+++ b/app/views/api_particulier/pages/home/_section_welcome.html.erb
@@ -7,7 +7,7 @@
     </div>
   </h1>
 
-  <span class="fr-h3 fr-text--lead">
+  <span class="fr-h3">
     <%= t('.subtitle').html_safe %>
   </span>
 

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -58,7 +58,12 @@ fr:
           card_developers_title: Un espace développeur
           card_developers_description: Spécifications techniques générales et dédiées à chaque API, Swagger, Kit de mise en production,&nbsp;...
           link_faq: "Qu'est-ce qu'une API ?"
-
+        section_demonstrateur:
+          demo_title: Inspirez-vous avec le démonstrateur API Particulier 💡
+          demo_description: |-
+              Parcourez des exemples d'interfaces fictives pour comprendre comment API Particulier peut simplifier vos démarches en ligne :
+          demo_link: https://api-particulier-demonstrateur.osc-secnum-fr1.scalingo.io/
+          demo_link_title: Consulter le démonstrateur
         section_partners:
           title: Ils partagent les données au travers d’API Particulier&nbsp;:&nbsp;
           subtitle: Découvrez les API de chaque fournisseur de données.

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -62,7 +62,7 @@ fr:
           demo_title: Inspirez-vous avec le démonstrateur API Particulier 💡
           demo_description: |-
               Parcourez des exemples d'interfaces fictives pour comprendre comment API Particulier peut simplifier vos démarches en ligne :
-          demo_link: https://api-particulier-demonstrateur.osc-secnum-fr1.scalingo.io/
+          demo_link: https://demonstrateur.particulier.api.gouv.fr
           demo_link_title: Consulter le démonstrateur
         section_partners:
           title: Ils partagent les données au travers d’API Particulier&nbsp;:&nbsp;


### PR DESCRIPTION
Ajout d'un section en page d'accueil : 
<img width="1179" alt="image" src="https://github.com/etalab/admin_api_entreprise/assets/46896006/49bfdda3-b3cd-4fe6-999d-fec4b56e3b51">


