### PR TITLE
AuthorizationRequest: show - Added attestation block

### DIFF
--- a/app/controllers/api_entreprise/attestations_controller.rb
+++ b/app/controllers/api_entreprise/attestations_controller.rb
@@ -2,7 +2,11 @@ class APIEntreprise::AttestationsController < APIEntreprise::AuthenticatedUsersC
   before_action :authorize!
 
   def index
-    @tokens = current_user.tokens.active_for('entreprise')
+    @tokens = if params[:token_id].present?
+                current_user.tokens.where(id: params[:token_id])
+              else
+                current_user.tokens.active_for('entreprise')
+              end
 
     @best_token = attestations_scope_service.best_token_to_retrieve_attestations(@tokens)
   end

--- a/app/policies/token_policy.rb
+++ b/app/policies/token_policy.rb
@@ -18,6 +18,10 @@ class TokenPolicy < ApplicationPolicy
     demandeur? && token.day_left < 90
   end
 
+  def attestations_scopes?
+    (demandeur? || contact_metier?) && attestations_scope_service.attestations_scopes(token).any?
+  end
+
   private
 
   def demandeur?
@@ -34,5 +38,9 @@ class TokenPolicy < ApplicationPolicy
 
   def authorization_request
     @authorization_request ||= @token.authorization_request
+  end
+
+  def attestations_scope_service
+    @attestations_scope_service ||= AttestationsScopeService.new
   end
 end

--- a/app/views/shared/authorization_requests/show.html.erb
+++ b/app/views/shared/authorization_requests/show.html.erb
@@ -90,5 +90,25 @@
         </ul>
       </div>
     </div>
+
+    <% if policy(@main_token).attestations_scopes? %>
+      <div id="attestations_sociales_et_fiscales" class="fr-card__content">
+        <blockquote class="fr-highlight fr-m-0">
+          <div class="fr-card__title">
+            <h2 class="fr-h3 fr-mb-n0-5v">
+              <%= t('.attestations.title') %>
+            </h2>
+          </div>
+          <div class="fr-card__desc">
+            <p>
+              <%= t('.attestations.description') %>
+              <br />
+              <%= link_to t('.attestations.cta'), attestations_path(selected_token: @main_token.id),class: %w[fr-btn fr-btn--secondary fr-mt-2w] %>
+            </p>
+          </div>
+        </blockquote>
+      </div>
+    <% end %>
+
   </div>
 </div>

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -111,6 +111,10 @@ fr:
           to_datapass: "N<sup>o</sup>%{external_id}"
         main_token:
           title: "Jeton principal :"
+        attestations:
+          title: "Télécharger manuellement les attestations sociales et fiscales"
+          description: "Saississez manuellement le SIREN de l'unite légale recherchée et vous aurez directement accès aux PDF des attestations"
+          cta: "Utiliser l'inferface de téléchargement"
     api_entreprise:
       header:
         title: API Entreprise

--- a/spec/features/api_particulier/authorization_request_spec.rb
+++ b/spec/features/api_particulier/authorization_request_spec.rb
@@ -24,8 +24,10 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
   end
 
   let!(:token) do
-    create(:token, authorization_request:, exp:, blacklisted_at:)
+    create(:token, authorization_request:, exp:, blacklisted_at:, scopes:)
   end
+
+  let!(:scopes) { [] }
 
   let!(:banned_token) { create(:token, authorization_request:, exp:, blacklisted_at: 1.day.from_now) }
 
@@ -155,6 +157,20 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
             it 'does not displays the ask for prolongation modal button' do
               expect(page).not_to have_css('#ask-for-prolongation-token-modal-link')
             end
+
+            describe 'when the token has no attestations scopes' do
+              it 'does not display the attestations block' do
+                expect(page).not_to have_css('#attestations_sociales_et_fiscales')
+              end
+            end
+
+            describe 'when the token has attestations scopes' do
+              let!(:scopes) { %w[attestations_sociales attestations_fiscales] }
+
+              it 'displays the attestations block' do
+                expect(page).to have_css('#attestations_sociales_et_fiscales')
+              end
+            end
           end
 
           describe 'when the user is contact technique' do
@@ -193,6 +209,20 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
               click_link 'ask-for-prolongation-token-modal-link'
 
               expect(page).to have_content('Relancer le contact principal')
+            end
+
+            describe 'when the token has no attestations scopes' do
+              it 'does not display the attestations block' do
+                expect(page).not_to have_css('#attestations_sociales_et_fiscales')
+              end
+            end
+
+            describe 'when the token has attestations scopes' do
+              let!(:scopes) { %w[attestations_sociales attestations_fiscales] }
+
+              it 'does not display the attestations block' do
+                expect(page).not_to have_css('#attestations_sociales_et_fiscales')
+              end
             end
           end
 
@@ -234,6 +264,20 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
               click_link 'ask-for-prolongation-token-modal-link'
 
               expect(page).to have_content('Relancer le contact principal')
+            end
+
+            describe 'when the token has no attestations scopes' do
+              it 'does not display the attestations block' do
+                expect(page).not_to have_css('#attestations_sociales_et_fiscales')
+              end
+            end
+
+            describe 'when the token has attestations scopes' do
+              let!(:scopes) { %w[attestations_sociales attestations_fiscales] }
+
+              it 'displays the attestations block' do
+                expect(page).to have_css('#attestations_sociales_et_fiscales')
+              end
             end
           end
         end


### PR DESCRIPTION
Petit point : Je pense qu'il y a un refacto à faire sur l'ensemble du sujet attestation. Notament parce que désormais le point d'entrée c'est l'habilitation et non le menu et donc il faudrait que la page des attestations ne permette plus de choisir le token (ou à minima le pré-sélectionne). Et il y a pas mal de complexité inutile dans la facade et la policy.

Il y a aussi un travail de clean parce que pas mal de code existant n'est plus nécessaire dans cette nouvelle interface.

Cependant, étant donné que l'ancienne interface existe encore tant qu'on ne fait pas le remplacement, j'ai choisi de ne pas faire ce clean qui prendrais du temps maintenant alors qu'une fois le switch fait, il suffira d'appuyer sur delete.

Un ticket a été crée à ce sujet dans le projet linear.