### PR TITLE
Feature/api 1465 je peux utiliser le sommaire pour naviguer dans la page

### DIFF
--- a/app/controllers/api_entreprise/authorization_requests_controller.rb
+++ b/app/controllers/api_entreprise/authorization_requests_controller.rb
@@ -3,6 +3,8 @@
 class APIEntreprise::AuthorizationRequestsController < APIEntreprise::AuthenticatedUsersController
   include AuthorizationRequestsManagement
 
+  layout :resolve_layout
+
   def index
     @authorization_requests = current_user
       .authorization_requests
@@ -13,5 +15,16 @@ class APIEntreprise::AuthorizationRequestsController < APIEntreprise::Authentica
       .order(
         first_submitted_at: :desc
       )
+  end
+
+  private
+
+  def resolve_layout
+    case action_name
+    when 'index'
+      'api_entreprise/authenticated_user'
+    else
+      'api_entreprise/application'
+    end
   end
 end

--- a/app/views/shared/authorization_requests/_breadcrumb.html.erb
+++ b/app/views/shared/authorization_requests/_breadcrumb.html.erb
@@ -1,0 +1,15 @@
+<nav role="navigation" class="fr-breadcrumb fr-mb-0" aria-label="vous êtes ici :">
+  <button class="fr-breadcrumb__button" aria-expanded="false" aria-controls="breadcrumb-1">Voir le fil d’Ariane</button>
+  <div class="fr-collapse" id="breadcrumb-1">
+    <ol class="fr-breadcrumb__list">
+      <li>
+        <%= link_to t('.index'), user_profile_path, class: %w(fr-breadcrumb__link) %>
+      </li>
+      <li>
+        <a class="fr-breadcrumb__link" aria-current="page">
+          <%= t('.current_page', datapass_id: authorization_request.external_id).html_safe %>
+        </a>
+      </li>
+    </ol>
+  </div>
+</nav>

--- a/app/views/shared/authorization_requests/_side_menu.html.erb
+++ b/app/views/shared/authorization_requests/_side_menu.html.erb
@@ -1,0 +1,36 @@
+<nav id="side_menu" class="fr-sidemenu fr-sidemenu--sticky fr-mb-8v" aria-labelledby="fr-sidemenu-title">
+  <div class="fr-sidemenu__inner fr-pl-0">
+    <button
+      class="fr-sidemenu__btn"
+      hidden
+      aria-controls="fr-sidemenu-wrapper"
+      aria-expanded="false"
+    >
+      <%= t('.menu') %>
+    </button>
+    <div class="fr-collapse" id="fr-sidemenu-wrapper">
+      <div class="fr-sidemenu__title" id="fr-sidemenu-title">
+        <%= t('.title') %>
+      </div>
+      <ul class="fr-sidemenu__list">
+        <li class="fr-sidemenu__item">
+          <a class="fr-sidemenu__link" id="habilitation_main_token_infos_link" href="#habilitation_main_token_infos" target="_self">
+            <%= t('.active_tokens') %>
+          </a>
+        </li>
+        <% if policy(@main_token).attestations_scopes? %>
+          <li class="fr-sidemenu__item">
+            <a class="fr-sidemenu__link" id="attestations_sociales_et_fiscales_link" href="#attestations_sociales_et_fiscales" target="_self">
+              <%= t('.attestations') %>
+            </a>
+          </li>
+        <% end %>
+        <li class="fr-sidemenu__item">
+          <a class="fr-sidemenu__link" id="habilitation_contacts_infos_link" href="#habilitation_contacts_infos" target="_self" >
+            <%= t('.contacts') %>
+          </a >
+        </li>
+      </ul>
+    </div>
+  </div>
+</nav>

--- a/app/views/shared/authorization_requests/show.html.erb
+++ b/app/views/shared/authorization_requests/show.html.erb
@@ -1,238 +1,246 @@
-<article class="article">
-  <header id="habilitation_main_info" class="fr-pb-8v">
-    <div>
-      <%= authorization_request_status_badge(@authorization_request) %>
-
-      <% if @authorization_request.demarche.present? %>
-        <span class="fr-badge fr-text--xs">
-          <i class="fr-icon-attachment-line fr-icon--sm fr-pr-1v" aria-hidden="true"></i>
-          <%= @authorization_request.demarche %>
-        </span>
-      <% end %>
-
-      <h2 class="fr-h3 fr-mb-n0-5v"><%= @authorization_request.intitule %></h3>
+<div class="fr-container" data-controller="anchor-buttons">
+  <div class="fr-grid-row">
+    <div class="fr-col-12 fr-col-md-3">
+      <%= render partial: 'shared/authorization_requests/side_menu', locals: { token: @main_token } %>
     </div>
-    <div>
-      <span class="fr-text--xs">
-        <b><%= t('.delivered_at', humanized_date: friendly_format_from_timestamp(@authorization_request.created_at)) %></b>
-        - 
-        <%= link_to t('.links.to_datapass', external_id: @authorization_request.external_id).html_safe, 
-          datapass_authorization_request_url(@authorization_request), 
-          id: :authorization_request_link,
-          class: %w(fr-link fr-text--xs), 
-          target: '_blank' 
-        %>
-      </span>
-    </div>
-  </header>
-
-  <section id="habilitation_main_token_infos" class="fr-pb-8v">
-    <h2 class="fr-h3 fr-mb-n-1v">
-      <%= t('.main_token.title') %>
-    </h2>
-    <div>
-      <%= render partial: 'shared/tokens/detail', 
-        locals: {
-          token: @main_token,
-        }
-      %>
-      <% @banned_tokens.each do |banned_token| %>
-        <%= render partial: 'shared/tokens/detail', 
-          locals: {
-            token: banned_token,
-          }
-        %>
-      <% end %>
-      <ul class="fr-btns-group--right fr-btns-group--inline-sm fr-btns-group--inline-reverse fr-btns-group--icon-right">
-        <li>
-          <a 
-            href="<%= token_path(id: @main_token.id) %>" 
-            id="show-token-modal-link"
-            class="fr-btn fr-btn--secondary fr-icon-arrow-right-line fr-btn--icon-right fr-mt-2w" 
-            aria-controls="main-modal" 
-            data-fr-opened="false" 
-            data-turbo-frame="main-modal-content"
-          >
-            <%= t('.modal.show.display_cta') %>
-          </a>
-        </li>
-        <% if policy(@main_token).prolong? %>
-          <li>
-            <a 
-              href="<%= token_prolong_path(id: @main_token.id) %>" 
-              id="prolong-token-modal-link"
-              class="fr-btn fr-icon-arrow-right-line fr-btn--icon-right fr-mt-2w" 
-              aria-controls="main-modal" 
-              data-fr-opened="false" 
-              data-turbo-frame="main-modal-content"
-            >
-              <%= t('.modal.prolong.display_cta') %>
-            </a>
-          </li>
-        <% end %>
-        <% if policy(@main_token).ask_for_prolongation? %>
-          <li>
-            <a 
-              href="<%= token_ask_for_prolongation_path(id: @main_token.id) %>" 
-              id="ask-for-prolongation-token-modal-link"
-              class="fr-btn fr-icon-arrow-right-line fr-btn--icon-right fr-mt-2w" 
-              aria-controls="main-modal" 
-              data-fr-opened="false" 
-              data-turbo-frame="main-modal-content"
-            >
-              <%= t('.modal.ask_for_prolongation.display_cta') %>
-            </a>
-          </li>
-        <% end %>
-      </ul>
-    </div>
-  </section>
-  <section id="habilitation_old_tokens_infos" class="fr-accordion fr-mb-8v">
-    <h3 class="fr-accordion__title">
-      <button id="old_tokens_accordion_button" class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-106">
-        <%= t('.old_tokens.title') %>
-      </button>
-    </h3>
-    <div class="fr-collapse" id="accordion-106">
-    <div class="fr-table fr-table--bordered fr-table--layout-fixed fr-m-0 fr-p-0">
-      <table>
-        <thead>
-            <tr>
-              <th scope="col"><%= t('.old_tokens.table.identifier')%></th>
-              <th scope="col"><%= t('.old_tokens.table.created_at')%></th>
-              <th scope="col"><%= t('.old_tokens.table.exp')%></th>
-              <th scope="col"><%= t('.old_tokens.table.total_calls')%></th>
-            </tr>
-        </thead>
-        <tbody>
-          <% @inactive_tokens.each do |token| %>
-            <tr id="<%= dom_id(token) %>" >
-              <td><%= token.id %></td>
-              <td><%= friendly_date_from_timestamp(token.created_at) %></td>
-              <td><%= friendly_date_from_timestamp(token.exp) %></td>
-              <td><%= @access_logs_counts[token] %></td>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
-  </section>
-
-  <% if policy(@main_token).attestations_scopes? %>
-    <section id="attestations_sociales_et_fiscales" class="fr-mb-8v">
-      <blockquote class="fr-highlight fr-m-0">
-        <h2 class="fr-h3 fr-mb-n0-5v">
-          <%= t('.attestations.title') %>
-        </h2>
-        <div>
-          <p>
-            <%= t('.attestations.description') %>
-            <br />
-            <%= link_to t('.attestations.cta'), attestations_path(selected_token: @main_token.id),class: %w[fr-btn fr-btn--secondary fr-mt-2w] %>
-          </p>
-        </div>
-      </blockquote>
-    </section>
-  <% end %>
-
-  <section id="habilitation_contacts_infos" class="fr-pb-8v">
-    <h2 class="fr-h3 fr-mb-n-1v">
-      <%= t('.contacts.title') %>
-    </h2>
-    <div class="fr-container--fluid">
-      <div class="fr-grid-row fr-grid-row--gutters">
-        <div id="contact_demandeur" class="fr-col">
-          <h3 class="fr-h4 fr-mb-n-1v">
-            <i class="fr-icon fr-icon-user-star-line fr-mr-1v" aria-hidden="true"></i>
-            <%= t('.contacts.demandeur.title') %>
-          </h3>
-          <div class="fr-card">
-            <% if @authorization_request.demandeur == current_user %>
-              <div class="fr-card__header">
-                <ul class="fr-badges-group fr-badges-group--right">
-                  <li>
-                    <p id="contact_demandeur_its_me" class="fr-badge fr-badge--blue-ecume">
-                      <%= t('.contacts.its_me') %>
-                    </p>
-                  </li>
-                </ul>
-              </div>
+    <div class="fr-col-12 fr-col-md-9">
+      <article class="article">
+        <header id="habilitation_main_info" class="fr-pb-8v">
+          <div>
+            <%= authorization_request_status_badge(@authorization_request) %>
+            <% if @authorization_request.demarche.present? %>
+              <span class="fr-badge fr-text--xs">
+                <i class="fr-icon-attachment-line fr-icon--sm fr-pr-1v" aria-hidden="true"></i>
+                <%= @authorization_request.demarche %>
+              </span>
             <% end %>
-            <div class="fr-card__body">
-              <div class="fr-card__content">
-                  <h4 class="fr-h5 fr-card__title">
-                    <%= @authorization_request.demandeur.full_name %>
-                  </h4>
-                  <p class="fr-card__desc">
-                    <%= @authorization_request.demandeur.email %>
-                  </p>
-              </div>
-            </div>
+            <h2 class="fr-h3 fr-mb-n0-5v"><%= @authorization_request.intitule %></h3>
           </div>
-        </div>
-        <% if @authorization_request.contact_metier.present? %>
-          <div id="contact_metier" class="fr-col">
-            <h3 class="fr-h4 fr-mb-n-1v">
-              <i class="fr-icon fr-icon-user-star-line fr-mr-1v" aria-hidden="true"></i>
-              <%= t('.contacts.contact_metier.title') %>
-            </h3>
-            <div class="fr-card">
-              <% if @authorization_request.contact_metier == current_user %>
-                <div class="fr-card__header">
-                  <ul class="fr-badges-group fr-badges-group--right">
-                    <li>
-                      <p id="contact_metier_its_me" class="fr-badge fr-badge--blue-ecume">
-                        <%= t('.contacts.its_me') %>
-                      </p>
-                    </li>
-                  </ul>
+          <div>
+            <span class="fr-text--xs">
+              <b><%= t('.delivered_at', humanized_date: friendly_format_from_timestamp(@authorization_request.created_at)) %></b>
+              - 
+              <%= link_to t('.links.to_datapass', external_id: @authorization_request.external_id).html_safe, 
+                datapass_authorization_request_url(@authorization_request), 
+                id: :authorization_request_link,
+                class: %w(fr-link fr-text--xs), 
+                target: '_blank' 
+              %>
+            </span>
+          </div>
+        </header>
+
+        <section id="habilitation_main_token_infos" class="fr-pb-8v">
+          <h2 class="fr-h3 fr-mb-n-1v">
+            <%= t('.main_token.title') %>
+          </h2>
+          <div>
+            <%= render partial: 'shared/tokens/detail', 
+              locals: {
+                token: @main_token,
+              }
+            %>
+            <% @banned_tokens.each do |banned_token| %>
+              <%= render partial: 'shared/tokens/detail', 
+                locals: {
+                  token: banned_token,
+                }
+              %>
+            <% end %>
+            <ul class="fr-btns-group--right fr-btns-group--inline-sm fr-btns-group--inline-reverse fr-btns-group--icon-right">
+              <li>
+                <a 
+                  href="<%= token_path(id: @main_token.id) %>" 
+                  id="show-token-modal-link"
+                  class="fr-btn fr-btn--secondary fr-icon-arrow-right-line fr-btn--icon-right fr-mt-2w" 
+                  aria-controls="main-modal" 
+                  data-fr-opened="false" 
+                  data-turbo-frame="main-modal-content"
+                >
+                  <%= t('.modal.show.display_cta') %>
+                </a>
+              </li>
+              <% if policy(@main_token).prolong? %>
+                <li>
+                  <a 
+                    href="<%= token_prolong_path(id: @main_token.id) %>" 
+                    id="prolong-token-modal-link"
+                    class="fr-btn fr-icon-arrow-right-line fr-btn--icon-right fr-mt-2w" 
+                    aria-controls="main-modal" 
+                    data-fr-opened="false" 
+                    data-turbo-frame="main-modal-content"
+                  >
+                    <%= t('.modal.prolong.display_cta') %>
+                  </a>
+                </li>
+              <% end %>
+              <% if policy(@main_token).ask_for_prolongation? %>
+                <li>
+                  <a 
+                    href="<%= token_ask_for_prolongation_path(id: @main_token.id) %>" 
+                    id="ask-for-prolongation-token-modal-link"
+                    class="fr-btn fr-icon-arrow-right-line fr-btn--icon-right fr-mt-2w" 
+                    aria-controls="main-modal" 
+                    data-fr-opened="false" 
+                    data-turbo-frame="main-modal-content"
+                  >
+                    <%= t('.modal.ask_for_prolongation.display_cta') %>
+                  </a>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        </section>
+
+        <section id="habilitation_old_tokens_infos" class="fr-accordion fr-mb-8v">
+          <h3 class="fr-accordion__title">
+            <button id="old_tokens_accordion_button" class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-106">
+              <%= t('.old_tokens.title') %>
+            </button>
+          </h3>
+          <div class="fr-collapse" id="accordion-106" />
+          <div class="fr-table fr-table--bordered fr-table--layout-fixed fr-m-0 fr-p-0">
+            <table>
+              <thead>
+                  <tr>
+                    <th scope="col"><%= t('.old_tokens.table.identifier')%></th>
+                    <th scope="col"><%= t('.old_tokens.table.created_at')%></th>
+                    <th scope="col"><%= t('.old_tokens.table.exp')%></th>
+                    <th scope="col"><%= t('.old_tokens.table.total_calls')%></th>
+                  </tr>
+              </thead>
+              <tbody>
+                <% @inactive_tokens.each do |token| %>
+                  <tr id="<%= dom_id(token, :old_token_row) %>" >
+                    <td><%= token.id %></td>
+                    <td><%= friendly_date_from_timestamp(token.created_at) %></td>
+                    <td><%= friendly_date_from_timestamp(token.exp) %></td>
+                    <td><%= token.access_logs.count %></td>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <% if policy(@main_token).attestations_scopes? %>
+          <section id="attestations_sociales_et_fiscales" class="fr-mb-8v">
+            <blockquote class="fr-highlight fr-m-0">
+              <h2 class="fr-h3 fr-mb-n0-5v">
+                <%= t('.attestations.title') %>
+              </h2>
+              <div>
+                <p>
+                  <%= t('.attestations.description') %>
+                  <br />
+                  <%= link_to t('.attestations.cta'), attestations_path(selected_token: @main_token.id),class: %w[fr-btn fr-btn--secondary fr-mt-2w] %>
+                </p>
+              </div>
+            </blockquote>
+          </section>
+        <% end %>
+
+        <section id="habilitation_contacts_infos" class="fr-pb-8v">
+          <h2 class="fr-h3 fr-mb-n-1v">
+            <%= t('.contacts.title') %>
+          </h2>
+          <div class="fr-container--fluid">
+            <div class="fr-grid-row fr-grid-row--gutters">
+              <div id="contact_demandeur" class="fr-col">
+                <h3 class="fr-h4 fr-mb-n-1v">
+                  <i class="fr-icon fr-icon-user-star-line fr-mr-1v" aria-hidden="true"></i>
+                  <%= t('.contacts.demandeur.title') %>
+                </h3>
+                <div class="fr-card">
+                  <% if @authorization_request.demandeur == current_user %>
+                    <div class="fr-card__header">
+                      <ul class="fr-badges-group fr-badges-group--right">
+                        <li>
+                          <p id="contact_demandeur_its_me" class="fr-badge fr-badge--blue-ecume">
+                            <%= t('.contacts.its_me') %>
+                          </p>
+                        </li>
+                      </ul>
+                    </div>
+                  <% end %>
+                  <div class="fr-card__body">
+                    <div class="fr-card__content">
+                        <h4 class="fr-h5 fr-card__title">
+                          <%= @authorization_request.demandeur.full_name %>
+                        </h4>
+                        <p class="fr-card__desc">
+                          <%= @authorization_request.demandeur.email %>
+                        </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <% if @authorization_request.contact_metier.present? %>
+                <div id="contact_metier" class="fr-col">
+                  <h3 class="fr-h4 fr-mb-n-1v">
+                    <i class="fr-icon fr-icon-user-star-line fr-mr-1v" aria-hidden="true"></i>
+                    <%= t('.contacts.contact_metier.title') %>
+                  </h3>
+                  <div class="fr-card">
+                    <% if @authorization_request.contact_metier == current_user %>
+                      <div class="fr-card__header">
+                        <ul class="fr-badges-group fr-badges-group--right">
+                          <li>
+                            <p id="contact_metier_its_me" class="fr-badge fr-badge--blue-ecume">
+                              <%= t('.contacts.its_me') %>
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    <% end %>
+                    <div class="fr-card__body">
+                      <div class="fr-card__content">
+                          <h4 class="fr-h5 fr-card__title">
+                            <%= @authorization_request.contact_metier.full_name %>
+                          </h4>
+                          <p class="fr-card__desc">
+                            <%= @authorization_request.contact_metier.email %>
+                          </p>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               <% end %>
-              <div class="fr-card__body">
-                <div class="fr-card__content">
-                    <h4 class="fr-h5 fr-card__title">
-                      <%= @authorization_request.contact_metier.full_name %>
-                    </h4>
-                    <p class="fr-card__desc">
-                      <%= @authorization_request.contact_metier.email %>
-                    </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        <% end %>
-        <% if @authorization_request.contact_technique.present? %>
-          <div id="contact_technique" class="fr-col">
-            <h3 class="fr-h4">
-              <i class="fr-icon fr-icon-user-star-line fr-mr-1v" aria-hidden="true"></i>
-              <%= t('.contacts.contact_technique.title') %>
-            </h3>
-            <div class="fr-card">
-              <% if @authorization_request.contact_technique == current_user %>
-                <div class="fr-card__header">
-                  <ul class="fr-badges-group fr-badges-group--right">
-                    <li>
-                      <p id="contact_technique_its_me" class="fr-badge fr-badge--blue-ecume">
-                        <%= t('.contacts.its_me') %>
-                      </p>
-                    </li>
-                  </ul>
+              <% if @authorization_request.contact_technique.present? %>
+                <div id="contact_technique" class="fr-col">
+                  <h3 class="fr-h4">
+                    <i class="fr-icon fr-icon-user-star-line fr-mr-1v" aria-hidden="true"></i>
+                    <%= t('.contacts.contact_technique.title') %>
+                  </h3>
+                  <div class="fr-card">
+                    <% if @authorization_request.contact_technique == current_user %>
+                      <div class="fr-card__header">
+                        <ul class="fr-badges-group fr-badges-group--right">
+                          <li>
+                            <p id="contact_technique_its_me" class="fr-badge fr-badge--blue-ecume">
+                              <%= t('.contacts.its_me') %>
+                            </p>
+                          </li>
+                        </ul>
+                      </div>
+                    <% end %>
+                    <div class="fr-card__body">
+                      <div class="fr-card__content">
+                          <h4 class="fr-h5 fr-card__title">
+                            <%= @authorization_request.contact_technique.full_name %>
+                          </h4>
+                          <p class="fr-card__desc">
+                            <%= @authorization_request.contact_technique.email %>
+                          </p>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               <% end %>
-              <div class="fr-card__body">
-                <div class="fr-card__content">
-                    <h4 class="fr-h5 fr-card__title">
-                      <%= @authorization_request.contact_technique.full_name %>
-                    </h4>
-                    <p class="fr-card__desc">
-                      <%= @authorization_request.contact_technique.email %>
-                    </p>
-                </div>
-              </div>
             </div>
           </div>
-        <% end %>
-      </div>
+        </section>
+      </article>
     </div>
-  </section>
-</article>
+  </div>
+</div>

--- a/app/views/shared/authorization_requests/show.html.erb
+++ b/app/views/shared/authorization_requests/show.html.erb
@@ -1,6 +1,7 @@
 <div class="fr-container" data-controller="anchor-buttons">
   <div class="fr-grid-row">
     <div class="fr-col-12 fr-col-md-3">
+      <%= render partial: 'shared/authorization_requests/breadcrumb', locals: { authorization_request: @authorization_request } %>
       <%= render partial: 'shared/authorization_requests/side_menu', locals: { token: @main_token } %>
     </div>
     <div class="fr-col-12 fr-col-md-9">
@@ -111,11 +112,11 @@
               </thead>
               <tbody>
                 <% @inactive_tokens.each do |token| %>
-                  <tr id="<%= dom_id(token, :old_token_row) %>" >
+                  <tr id="<%= dom_id(token) %>" >
                     <td><%= token.id %></td>
                     <td><%= friendly_date_from_timestamp(token.created_at) %></td>
                     <td><%= friendly_date_from_timestamp(token.exp) %></td>
-                    <td><%= token.access_logs.count %></td>
+                    <td><%= @access_logs_counts[token] %></td>
                   </tr>
                 <% end %>
               </tbody>

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -89,6 +89,9 @@ fr:
             active: 🔑 Actif
             new_token: 🔑 Nouveau jeton à utiliser
     authorization_requests:
+      breadcrumb:
+        index: Habilitations
+        current_page: Habilitation N<sup>o</sup>%{datapass_id}
       side_menu:
         menu: Dans cette rubrique
         title: Sommaire

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -89,6 +89,12 @@ fr:
             active: 🔑 Actif
             new_token: 🔑 Nouveau jeton à utiliser
     authorization_requests:
+      side_menu:
+        menu: Dans cette rubrique
+        title: Sommaire
+        active_tokens: Jetons
+        attestations: Attestation sociales et fiscales
+        contacts: Contacts
       status:
         color:
           revoked: pink-tuile

--- a/spec/features/api_particulier/authorization_request_spec.rb
+++ b/spec/features/api_particulier/authorization_request_spec.rb
@@ -177,6 +177,7 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
 
               it 'displays the attestations block' do
                 expect(page).to have_css('#attestations_sociales_et_fiscales')
+                expect(page).to have_css('#attestations_sociales_et_fiscales_link')
               end
             end
 
@@ -185,6 +186,13 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
               expect(page).to have_css('#contact_demandeur_its_me')
               expect(page).not_to have_css('#contact_metier')
               expect(page).not_to have_css('#contact_technique')
+            end
+
+            it 'displays the side menu' do
+              expect(page).to have_css('#side_menu')
+              expect(page).to have_css('#habilitation_main_token_infos_link')
+              expect(page).to have_css('#habilitation_contacts_infos_link')
+              expect(page).not_to have_css('#attestations_sociales_et_fiscales_link')
             end
           end
 


### PR DESCRIPTION
Partialisation de la partie side menu et breadcrumb.
Le premier commit est pas ouf, mais je suis obligé de faire un truc dans le genre pour conserver les pages existante ca va sauter quand je vais mass delete le contenu existant.

J'ai fais beaucoup d'essai sur le look-n-feel (même si on ne dirait pas) et j'ai eu quelques discussions avec dorine au sujet du side menu. Notament sur la numérotation et le highlight du side menu pour au final revenir à la version la plus basique proposée dans le dsfr.

J'ai pas testé le breadcrumb parce que il est assez statiques et je pense pas que ca risque grand chose.

Dorenavant, chaque nouvelle section impactera le menu.

PS: cette PR se base sur l'autre qui est en cours