### PR TITLE
Feature/api 1468 en tant quutilisateur je peux voir la liste de mes

### DIFF
--- a/app/assets/stylesheets/dsfr-extensions.scss
+++ b/app/assets/stylesheets/dsfr-extensions.scss
@@ -151,3 +151,7 @@
   position: sticky;
   top: 0;
 }
+
+.fr-container--bordered > .fr-grid-row:nth-child(odd) {
+  background-image: linear-gradient(0deg, #e5e5e5, #e5e5e5);
+}

--- a/app/controllers/api_entreprise/authorization_requests_controller.rb
+++ b/app/controllers/api_entreprise/authorization_requests_controller.rb
@@ -3,8 +3,6 @@
 class APIEntreprise::AuthorizationRequestsController < APIEntreprise::AuthenticatedUsersController
   include AuthorizationRequestsManagement
 
-  layout :resolve_layout
-
   def index
     @authorization_requests = current_user
       .authorization_requests
@@ -15,16 +13,5 @@ class APIEntreprise::AuthorizationRequestsController < APIEntreprise::Authentica
       .order(
         first_submitted_at: :desc
       )
-  end
-
-  private
-
-  def resolve_layout
-    case action_name
-    when 'index'
-      'api_entreprise/authenticated_user'
-    else
-      'api_entreprise/application'
-    end
   end
 end

--- a/app/controllers/concerns/authorization_requests_management.rb
+++ b/app/controllers/concerns/authorization_requests_management.rb
@@ -15,6 +15,18 @@ module AuthorizationRequestsManagement
     redirect_current_user_to_homepage
   end
 
+  def list
+    @authorization_requests = current_user
+      .authorization_requests
+      .where(api:)
+      .submitted_at_least_once
+      .order(
+        first_submitted_at: :desc
+      )
+
+    render 'shared/authorization_requests/index', layout: "#{namespace}/application"
+  end
+
   private
 
   def extract_authorization_request

--- a/app/controllers/concerns/authorization_requests_management.rb
+++ b/app/controllers/concerns/authorization_requests_management.rb
@@ -8,7 +8,7 @@ module AuthorizationRequestsManagement
     @access_logs_counts = AccessLogsCounts.new(@inactive_tokens)
     @banned_tokens = @authorization_request.tokens.blacklisted_later.decorate
 
-    render 'shared/authorization_requests/show'
+    render 'shared/authorization_requests/show', layout: "#{namespace}/application"
   rescue ActiveRecord::RecordNotFound
     error_message(title: t('.error.title'))
 

--- a/app/controllers/concerns/authorization_requests_management.rb
+++ b/app/controllers/concerns/authorization_requests_management.rb
@@ -20,9 +20,10 @@ module AuthorizationRequestsManagement
       .authorization_requests
       .where(api:)
       .submitted_at_least_once
+      .viewable_by_users
       .order(
         first_submitted_at: :desc
-      )
+      ).includes(:active_token)
 
     render 'shared/authorization_requests/index', layout: "#{namespace}/application"
   end

--- a/app/decorators/token_decorator.rb
+++ b/app/decorators/token_decorator.rb
@@ -1,10 +1,8 @@
 class TokenDecorator < ApplicationDecorator
   delegate_all
 
-  def end_timestamp
-    return blacklisted_at.to_i if blacklisted_at.present?
-
-    exp
+  def day_left
+    @day_left ||= (end_timestamp - Time.zone.now.to_i) / 86_400
   end
 
   def passed_time_as_ratio
@@ -23,10 +21,6 @@ class TokenDecorator < ApplicationDecorator
     return 'new_token' if access_logs.empty?
 
     'active'
-  end
-
-  def day_left
-    @day_left ||= (end_timestamp - Time.zone.now.to_i) / 86_400
   end
 
   def progress_bar_color

--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -1,5 +1,10 @@
 class AuthorizationRequest < ApplicationRecord
-  has_many :user_authorization_request_roles, dependent: :nullify
+  has_many :user_authorization_request_roles, dependent: :nullify do
+    def for_user(user)
+      where(user:)
+    end
+  end
+
   has_many :users, through: :user_authorization_request_roles, source: :user
 
   has_many :tokens,

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -66,6 +66,12 @@ class Token < ApplicationRecord
       blacklisted_at > Time.zone.now
   end
 
+  def end_timestamp
+    return blacklisted_at.to_i if blacklisted_at.present?
+
+    exp
+  end
+
   private
 
   def jwt_data

--- a/app/policies/token_policy.rb
+++ b/app/policies/token_policy.rb
@@ -2,7 +2,7 @@ class TokenPolicy < ApplicationPolicy
   alias token record
 
   def ask_for_prolongation?
-    !demandeur? && token.day_left < 90
+    !demandeur? && day_left < 90
   end
 
   def show?
@@ -10,7 +10,7 @@ class TokenPolicy < ApplicationPolicy
   end
 
   def prolong?
-    demandeur? && token.day_left < 90 && !token.blacklisted?
+    demandeur? && day_left < 90 && !token.blacklisted?
   end
 
   def download_attestations?
@@ -33,5 +33,9 @@ class TokenPolicy < ApplicationPolicy
 
   def authorization_request
     @authorization_request ||= token.authorization_request
+  end
+
+  def day_left
+    (token.end_timestamp - Time.zone.now.to_i) / 1.day
   end
 end

--- a/app/policies/token_policy.rb
+++ b/app/policies/token_policy.rb
@@ -10,7 +10,7 @@ class TokenPolicy < ApplicationPolicy
   end
 
   def prolong?
-    demandeur? && token.day_left < 90
+    demandeur? && token.day_left < 90 && !token.blacklisted?
   end
 
   def download_attestations?

--- a/app/policies/token_policy.rb
+++ b/app/policies/token_policy.rb
@@ -10,7 +10,7 @@ class TokenPolicy < ApplicationPolicy
   end
 
   def prolong?
-    demandeur? && day_left < 90 && !token.blacklisted?
+    demandeur? && day_left < 90 && !token.blacklisted? && false
   end
 
   def download_attestations?

--- a/app/views/shared/authorization_requests/_breadcrumb.html.erb
+++ b/app/views/shared/authorization_requests/_breadcrumb.html.erb
@@ -3,7 +3,7 @@
   <div class="fr-collapse" id="breadcrumb-1">
     <ol class="fr-breadcrumb__list">
       <li>
-        <%= link_to t('.index'), user_profile_path, class: %w(fr-breadcrumb__link) %>
+        <%= link_to t('.index'), authorization_requests_list_path, class: %w(fr-breadcrumb__link) %>
       </li>
       <li>
         <a class="fr-breadcrumb__link" aria-current="page">

--- a/app/views/shared/authorization_requests/index.html.erb
+++ b/app/views/shared/authorization_requests/index.html.erb
@@ -38,12 +38,12 @@
             <div class="fr-col-12 fr-col-md-6 fr-col-lg-3">
               <%= authorization_request_status_badge(authorization_request) %>
               <span class="fr-hint-text">
-              <%= link_to t('.links.to_datapass', external_id: authorization_request.external_id).html_safe, 
-                datapass_authorization_request_url(authorization_request), 
-                id: dom_id(authorization_request, :authorization_request_link),
-                class: %w(fr-link fr-text--xs), 
-                target: '_blank' 
-              %>
+                <%= link_to t('.links.to_datapass', external_id: authorization_request.external_id).html_safe, 
+                  datapass_authorization_request_url(authorization_request), 
+                  id: dom_id(authorization_request, :authorization_request_link),
+                  class: %w(fr-link fr-text--xs), 
+                  target: '_blank' 
+                %>
               </span>
               <strong><%= authorization_request.intitule %></strong>
               <br />
@@ -62,7 +62,7 @@
             <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
               <%= render partial: 'shared/tokens/detail_short', 
                 locals: {
-                  token: authorization_request.token.decorate,
+                  token: authorization_request.token.decorate
                 }
               %>
             </div>

--- a/app/views/shared/authorization_requests/index.html.erb
+++ b/app/views/shared/authorization_requests/index.html.erb
@@ -69,20 +69,34 @@
             <% end %>
             </div>
             <div class="fr-col-12 fr-col-md-6 fr-col-lg-3 center">
-              <% if authorization_request.tokens.blacklisted_later.any? %>
-                <p class="fr-text--sm fr-mb-1v fr-text-default--warning">
-                  <%= t('.modal.show.description') %>
-                </p>
-                <a
-                  href="<%= token_path(id: authorization_request.token.id) %>"
-                  id="<%= dom_id(authorization_request, :show_token_modal_link) %>"
-                  class="fr-btn fr-icon-eye-fill fr-btn--icon-right fr-mt-2w"
-                  aria-controls="main-modal"
-                  data-fr-opened="false"
-                  data-turbo-frame="main-modal-content"
-                >
-                  <%= t('.modal.show.display_cta') %>
-                </a>
+              <% if authorization_request.status == 'validated' %>
+                <% if authorization_request.tokens.blacklisted_later.any? %>
+                  <p class="fr-text--sm fr-mb-1v fr-text-default--warning">
+                    <%= t('.modal.show.description') %>
+                  </p>
+                  <a
+                    href="<%= token_path(id: authorization_request.token.id) %>"
+                    id="<%= dom_id(authorization_request, :show_token_modal_link) %>"
+                    class="fr-btn fr-icon-eye-fill fr-btn--icon-right fr-mt-2w"
+                    aria-controls="main-modal"
+                    data-fr-opened="false"
+                    data-turbo-frame="main-modal-content"
+                  >
+                    <%= t('.modal.show.display_cta') %>
+                  </a>
+                <% end %>
+                <% if policy(authorization_request.token).prolong? %>
+                  <a
+                    href="<%= token_prolong_path(id: authorization_request.token.id) %>"
+                    id="<%= dom_id(authorization_request, :prolong_token_modal_link) %>"
+                    class="fr-btn fr-icon-arrow-right-line fr-btn--icon-right fr-mt-2w"
+                    aria-controls="main-modal"
+                    data-fr-opened="false"
+                    data-turbo-frame="main-modal-content"
+                  >
+                    <%= t('.modal.prolong.display_cta') %>
+                  </a>
+                <% end %>
               <% end %>
             </div>
             <div class="fr-col-12 fr-col-md-6 fr-col-lg-2 center">

--- a/app/views/shared/authorization_requests/index.html.erb
+++ b/app/views/shared/authorization_requests/index.html.erb
@@ -1,5 +1,5 @@
 <div class="fr-container">
-  <div class="fr-row">
+  <div class="fr-grid-row">
     <div class="fr-col-12">
       <h1 class="fr-h1">
         <% if @authorization_requests.empty? %>
@@ -8,6 +8,72 @@
           <%= t('.title', api_label: t(".#{@authorization_requests.first.api}"), count: @authorization_requests.count) %>
         <% end %>
       </h1>
+    </div>
+  </div>
+  <div class="fr-row">
+    <div class="fr-col-12">
+      <div class="fr-container fr-container--bordered">
+        <div class="fr-grid-row fr-p-4v fr-grid-row--middle">
+          <div class="fr-col-12 fr-col-md-6 fr-col-lg-3">
+            <span class="fr-hint-text"><%= t('.table.head.datapass').html_safe %></span>
+            <strong><%= t('.table.head.authorization_request') %></strong>
+            <br />
+            <span class="fr-text--sm"><%= t('.table.head.role') %></span>
+          </div>
+          <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
+            <strong><%= t('.table.head.token') %></strong>
+            <br />
+            <span class="fr-hint-text"><%= t('.table.head.exp') %></span>
+            <span class="fr-text--regular"><%= t('.table.head.id') %></span>
+          </div>
+          <div class="fr-col-12 fr-col-md-6 fr-col-lg-3">
+              <strong><%= t('.table.head.actions') %></strong>
+          </div>
+          <div class="fr-col-12 fr-col-md-6 fr-col-lg-2">
+              <strong><%= t('.table.head.detail') %></strong>
+          </div>
+        </div>
+        <% @authorization_requests.each do |authorization_request| %>
+          <div id="<%= dom_id(authorization_request) %>" class="fr-grid-row fr-grid-row--middle fr-p-4v">
+            <div class="fr-col-12 fr-col-md-6 fr-col-lg-3">
+              <%= authorization_request_status_badge(authorization_request) %>
+              <span class="fr-hint-text">
+              <%= link_to t('.links.to_datapass', external_id: authorization_request.external_id).html_safe, 
+                datapass_authorization_request_url(authorization_request), 
+                id: dom_id(authorization_request, :authorization_request_link),
+                class: %w(fr-link fr-text--xs), 
+                target: '_blank' 
+              %>
+              </span>
+              <strong><%= authorization_request.intitule %></strong>
+              <br />
+<<<<<<< Updated upstream
+              <br />
+              <span class="fr-text--regular">demandeur</span>
+=======
+              <span class="fr-text--sm">
+                <%= authorization_request.user_authorization_request_roles.for_user(@current_user).map { |uarr|
+                  I18n.t("user_authorization_request_roles.role.#{uarr.role}")
+                  }.join(', ')
+                %>
+              </span>
+>>>>>>> Stashed changes
+            </div>
+            <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
+              <%= render partial: 'shared/tokens/detail_short', 
+                locals: {
+                  token: authorization_request.token.decorate,
+                }
+              %>
+            </div>
+            <div class="fr-col-12 fr-col-md-6 fr-col-lg-3">
+            </div>
+            <div class="fr-col-12 fr-col-md-6 fr-col-lg-2 center">
+              <%= link_to "", authorization_requests_show_path(authorization_request), class: %w[fr-btn fr-btn--lg fr-btn--tertiary-no-outline fr-icon-arrow-right-line] %>
+            </div>
+          </div>
+        <% end %>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/shared/authorization_requests/index.html.erb
+++ b/app/views/shared/authorization_requests/index.html.erb
@@ -65,6 +65,13 @@
                   token: authorization_request.token.decorate
                 }
               %>
+              <% authorization_request.tokens.blacklisted_later.decorate.each do |banned_token| %> 
+                <%= render partial: 'shared/tokens/detail_short', 
+                  locals: {
+                    token: banned_token.decorate
+                  }
+                %>
+            <% end %>
             </div>
             <div class="fr-col-12 fr-col-md-6 fr-col-lg-3">
             </div>

--- a/app/views/shared/authorization_requests/index.html.erb
+++ b/app/views/shared/authorization_requests/index.html.erb
@@ -68,7 +68,22 @@
                 %>
             <% end %>
             </div>
-            <div class="fr-col-12 fr-col-md-6 fr-col-lg-3">
+            <div class="fr-col-12 fr-col-md-6 fr-col-lg-3 center">
+              <% if authorization_request.tokens.blacklisted_later.any? %>
+                <p class="fr-text--sm fr-mb-1v fr-text-default--warning">
+                  <%= t('.modal.show.description') %>
+                </p>
+                <a
+                  href="<%= token_path(id: authorization_request.token.id) %>"
+                  id="<%= dom_id(authorization_request, :show_token_modal_link) %>"
+                  class="fr-btn fr-icon-eye-fill fr-btn--icon-right fr-mt-2w"
+                  aria-controls="main-modal"
+                  data-fr-opened="false"
+                  data-turbo-frame="main-modal-content"
+                >
+                  <%= t('.modal.show.display_cta') %>
+                </a>
+              <% end %>
             </div>
             <div class="fr-col-12 fr-col-md-6 fr-col-lg-2 center">
               <%= link_to "", authorization_requests_show_path(authorization_request), class: %w[fr-btn fr-btn--lg fr-btn--tertiary-no-outline fr-icon-arrow-right-line] %>

--- a/app/views/shared/authorization_requests/index.html.erb
+++ b/app/views/shared/authorization_requests/index.html.erb
@@ -71,7 +71,7 @@
             <div class="fr-col-12 fr-col-md-6 fr-col-lg-3 center">
               <% if authorization_request.status == 'validated' %>
                 <% if authorization_request.tokens.blacklisted_later.any? %>
-                  <p class="fr-text--sm fr-mb-1v fr-text-default--warning">
+                  <p class="fr-text--sm fr-mb-1v fr-text-default--error">
                     <%= t('.modal.show.description') %>
                   </p>
                   <a

--- a/app/views/shared/authorization_requests/index.html.erb
+++ b/app/views/shared/authorization_requests/index.html.erb
@@ -1,0 +1,13 @@
+<div class="fr-container">
+  <div class="fr-row">
+    <div class="fr-col-12">
+      <h1 class="fr-h1">
+        <% if @authorization_requests.empty? %>
+          <%= t('.no_authorization_requests') %>
+        <% else %>
+          <%= t('.title', api_label: t(".#{@authorization_requests.first.api}"), count: @authorization_requests.count) %>
+        <% end %>
+      </h1>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/authorization_requests/index.html.erb
+++ b/app/views/shared/authorization_requests/index.html.erb
@@ -47,17 +47,12 @@
               </span>
               <strong><%= authorization_request.intitule %></strong>
               <br />
-<<<<<<< Updated upstream
-              <br />
-              <span class="fr-text--regular">demandeur</span>
-=======
               <span class="fr-text--sm">
                 <%= authorization_request.user_authorization_request_roles.for_user(@current_user).map { |uarr|
                   I18n.t("user_authorization_request_roles.role.#{uarr.role}")
                   }.join(', ')
                 %>
               </span>
->>>>>>> Stashed changes
             </div>
             <div class="fr-col-12 fr-col-md-6 fr-col-lg-4">
               <%= render partial: 'shared/tokens/detail_short', 

--- a/app/views/shared/tokens/_detail_short.html.erb
+++ b/app/views/shared/tokens/_detail_short.html.erb
@@ -1,0 +1,20 @@
+<div class="fr-pb-6v">
+  <div class="fr-pb-2v">
+    <p class="fr-badge fr-badge--<%= t(".status.color.#{token.status}") %>">
+    <%= t(".status.label.#{token.status}") %>
+    </p>
+    <span class="fr-text--xs">
+      <%= friendly_date_from_timestamp(token.end_timestamp)%>
+    </span>
+  </div>
+  <p class="fr-mb-1v">
+  |  <%= t(".expiration_date", 
+        expiration_date: friendly_date_from_timestamp(token.end_timestamp)
+       ).html_safe %>
+  </p>
+  <p class="fr-mb-1v">
+    <span class="fr-text--xs">ID: <%= token.id %></span>
+  </p>
+</div>
+
+

--- a/app/views/shared/tokens/_detail_short.html.erb
+++ b/app/views/shared/tokens/_detail_short.html.erb
@@ -5,7 +5,7 @@
     <%= t(".no_token.description", status: t(".no_token.status.#{token.authorization_request.status}")) %>
   </div>
 <% else %>
-  <div class="fr-pb-6v">
+  <div id="<%= dom_id(token) %>" class="fr-pb-6v">
     <div class="fr-pb-2v">
       <p class="fr-badge fr-badge--<%= t(".status.color.#{token.status}") %>">
       <%= t(".status.label.#{token.status}") %>

--- a/app/views/shared/tokens/_detail_short.html.erb
+++ b/app/views/shared/tokens/_detail_short.html.erb
@@ -1,20 +1,28 @@
-<div class="fr-pb-6v">
-  <div class="fr-pb-2v">
-    <p class="fr-badge fr-badge--<%= t(".status.color.#{token.status}") %>">
-    <%= t(".status.label.#{token.status}") %>
-    </p>
-    <span class="fr-text--xs">
-      <%= friendly_date_from_timestamp(token.end_timestamp)%>
-    </span>
+<% if token.authorization_request.status != 'validated' %>
+  <div class="fr-pb-6v">
+    <strong> <%= t(".no_token.title") %></strong>
+    <br />
+    <%= t(".no_token.description", status: t(".no_token.status.#{token.authorization_request.status}")) %>
   </div>
-  <p class="fr-mb-1v">
-  |  <%= t(".expiration_date", 
-        expiration_date: friendly_date_from_timestamp(token.end_timestamp)
-       ).html_safe %>
-  </p>
-  <p class="fr-mb-1v">
-    <span class="fr-text--xs">ID: <%= token.id %></span>
-  </p>
-</div>
+<% else %>
+  <div class="fr-pb-6v">
+    <div class="fr-pb-2v">
+      <p class="fr-badge fr-badge--<%= t(".status.color.#{token.status}") %>">
+      <%= t(".status.label.#{token.status}") %>
+      </p>
+      <span class="fr-text--xs">
+        <%= friendly_date_from_timestamp(token.end_timestamp)%>
+      </span>
+    </div>
+    <p class="fr-mb-1v">
+    |  <%= t(".expiration_date", 
+          expiration_date: friendly_date_from_timestamp(token.end_timestamp)
+        ).html_safe %>
+    </p>
+    <p class="fr-mb-1v">
+      <span class="fr-text--xs">ID: <%= token.id %></span>
+    </p>
+  </div>
+<% end %>
 
 

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -216,6 +216,12 @@ fr:
         tokens: "Habilitations et jetons d'accès"
         download_attestations: 'Télécharger attestations'
 
+  user_authorization_request_roles:
+    role:
+      demandeur: Demandeur
+      contact_technique: Contact technique
+      contact_metier: Contact metier
+
   api_entreprise:
     users:
       user:

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -64,6 +64,21 @@ fr:
         warning_description: "Pour prolonger votre jeton, veuillez compléter le formulaire suivant :"
         warning: ⚠️ Vos réponses au formulaire <strong>vous engagent</strong> en regard des CGU d'api entreprise.
         cta: Compléter le formulaire de prolongation
+      detail_short:
+        expiration_date: "Expire le : <strong>%{expiration_date}</strong>"
+        status:
+          color:
+            revoked: pink-tuile
+            revoked_later: pink-tuile
+            expired: no-specific-color
+            active: green-emeraude
+            new_token: green-emeraude
+          label:
+            revoked: 🚫 Banni
+            revoked_later: 🚫 Banni
+            expired: ☠️  Expiré
+            active: 🔑 Actif
+            new_token: 🔑 Nouveau jeton à utiliser
       detail:
         remaining_time:
           new_token: "Durée restante du jeton : <strong>%{remaining_time}</strong>"
@@ -85,7 +100,7 @@ fr:
           label:
             revoked: 🚫 Banni
             revoked_later: 🚫 Banni
-            expired: 🔑 Expiré
+            expired: ☠️  Expiré
             active: 🔑 Actif
             new_token: 🔑 Nouveau jeton à utiliser
     authorization_requests:
@@ -94,6 +109,19 @@ fr:
         title: "Habilitations %{api_label} (%{count})"
         entreprise: API Entreprise
         particulier: API Particulier
+        links:
+          to_datapass: "Datapass N<sup>o</sup>%{external_id}"
+        table: 
+          caption: "Liste de vos habilitations"
+          head:
+            datapass: "N<sup>o</sup> Demande Datapass"
+            authorization_request: "Nom de l'habilitation"
+            role: Votre rôle
+            token: État du jeton principal
+            exp: Expiration
+            id: Identifiant
+            actions: Actions attendues
+            detail: Page détaillées
       breadcrumb:
         index: Habilitations
         current_page: Habilitation N<sup>o</sup>%{datapass_id}

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -89,6 +89,11 @@ fr:
             active: 🔑 Actif
             new_token: 🔑 Nouveau jeton à utiliser
     authorization_requests:
+      index:
+        no_authorization_requests: "Vous n'avez aucune habilitations"
+        title: "Habilitations %{api_label} (%{count})"
+        entreprise: API Entreprise
+        particulier: API Particulier
       breadcrumb:
         index: Habilitations
         current_page: Habilitation N<sup>o</sup>%{datapass_id}

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -111,6 +111,12 @@ fr:
             new_token: 🔑 Nouveau jeton à utiliser
     authorization_requests:
       index:
+        modal:
+          show:
+            description: "Remplacez maintenant le jeton banni par le nouveau jeton"
+            display_cta: "Voir le jeton"
+          prolong:
+            display_cta: Prolonger le jeton
         no_authorization_requests: "Vous n'avez aucune habilitations"
         title: "Habilitations %{api_label} (%{count})"
         entreprise: API Entreprise

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -65,6 +65,12 @@ fr:
         warning: ⚠️ Vos réponses au formulaire <strong>vous engagent</strong> en regard des CGU d'api entreprise.
         cta: Compléter le formulaire de prolongation
       detail_short:
+        no_token:
+          title: Aucun jeton actif
+          description: Cette demande ayant été %{status}, aucun jeton ne peut être demandé
+          status:
+            revoked: revoquée
+            archived: archivée
         expiration_date: "Expire le : <strong>%{expiration_date}</strong>"
         status:
           color:

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -124,7 +124,6 @@ fr:
         links:
           to_datapass: "Datapass N<sup>o</sup>%{external_id}"
         table: 
-          caption: "Liste de vos habilitations"
           head:
             datapass: "N<sup>o</sup> Demande Datapass"
             authorization_request: "Nom de l'habilitation"

--- a/config/routes/api_entreprise.rb
+++ b/config/routes/api_entreprise.rb
@@ -24,6 +24,7 @@ constraints(APIEntrepriseDomainConstraint.new) do
 
     get '/compte/demandes', to: 'authorization_requests#index', as: :authorization_requests
     get '/compte/demandes/:id', to: 'authorization_requests#show', as: :authorization_requests_show
+    get '/compte/demandes_list', to: 'authorization_requests#list', as: :authorization_requests_list
 
     get '/compte/telecharcher-documents', to: 'download_attestations#new', as: :attestations
     post '/compte/telecharcher-documents', to: 'download_attestations#create', as: :search_attestations

--- a/config/routes/api_particulier.rb
+++ b/config/routes/api_particulier.rb
@@ -35,6 +35,7 @@ constraints(APIParticulierDomainConstraint.new) do
     get '/compte', to: 'users#profile', as: :user_profile
     get '/compte/nouveaux-jetons/telecharger', to: "new_tokens#download", as: :new_tokens_download
 
+    get '/compte/demandes_list', to: 'authorization_requests#list', as: :authorization_requests_list
     get '/compte/demandes/:id', to: 'authorization_requests#show', as: :authorization_requests_show
 
     get '/compte/jetons/:id/prolonger', to: 'tokens#prolong', as: :token_prolong

--- a/spec/features/api_particulier/authorization_request_index_spec.rb
+++ b/spec/features/api_particulier/authorization_request_index_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
         ]
       end
 
-      let!(:token_active) { create(:token, authorization_request:) }
+      let!(:token_active) { create(:token, authorization_request:, exp: 70.days.from_now) }
       let!(:token_blacklisted_later) { create(:token, :blacklisted, blacklisted_at: 1.day.from_now, authorization_request:) }
       let!(:authorization_request_active) do
         create(
@@ -137,6 +137,13 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
 
       it 'displays the button to view the token details' do
         expect(page).to have_css('#' << dom_id(authorization_request_active, :show_token_modal_link))
+        expect(page).not_to have_css('#' << dom_id(authorization_request_blacklisted, :show_token_modal_link))
+        expect(page).not_to have_css('#' << dom_id(authorization_request_archived, :show_token_modal_link))
+      end
+
+      it 'displays the button to prolong the token' do
+        expect(page).to have_css('#' << dom_id(authorization_request_active, :prolong_token_modal_link))
+        expect(page).not_to have_css('#' << dom_id(authorization_request_archived, :prolong_token_modal_link))
       end
     end
   end

--- a/spec/features/api_particulier/authorization_request_index_spec.rb
+++ b/spec/features/api_particulier/authorization_request_index_spec.rb
@@ -1,0 +1,36 @@
+RSpec.describe 'displays authorization requests', app: :api_particulier do
+  subject(:go_to_authorization_requests_index) do
+    visit api_particulier_authorization_requests_list_path
+  end
+
+  let!(:authenticated_user) { create(:user, :demandeur, :contact_technique, :contact_metier) }
+  let!(:non_authenticated_user) { create(:user, :demandeur) }
+  let!(:authorization_request) do
+    create(
+      :authorization_request,
+      demandeur_authorization_request_role: non_authenticated_user.user_authorization_request_roles.first,
+      api: 'entreprise'
+    )
+  end
+  let!(:token) do
+    create(:token, authorization_request:)
+  end
+
+  describe 'when user is not authenticated' do
+    it 'redirects to the login' do
+      go_to_authorization_requests_index
+      expect(page).to have_current_path(api_particulier_login_path, ignore_query: true)
+    end
+  end
+
+  describe 'when user is authenticated' do
+    before do
+      login_as(authenticated_user)
+      go_to_authorization_requests_index
+    end
+
+    it 'displays the page' do
+      expect(page).to have_current_path(api_particulier_authorization_requests_list_path, ignore_query: true)
+    end
+  end
+end

--- a/spec/features/api_particulier/authorization_request_index_spec.rb
+++ b/spec/features/api_particulier/authorization_request_index_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
       end
 
       it 'displays the button to prolong the token' do
-        expect(page).to have_css('#' << dom_id(authorization_request_active, :prolong_token_modal_link))
+        expect(page).not_to have_css('#' << dom_id(authorization_request_active, :prolong_token_modal_link))
         expect(page).not_to have_css('#' << dom_id(authorization_request_archived, :prolong_token_modal_link))
       end
     end

--- a/spec/features/api_particulier/authorization_request_index_spec.rb
+++ b/spec/features/api_particulier/authorization_request_index_spec.rb
@@ -3,15 +3,18 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
     visit api_particulier_authorization_requests_list_path
   end
 
-  let!(:authenticated_user) { create(:user, :demandeur, :contact_technique, :contact_metier) }
+  let!(:authenticated_user) { create(:user) }
   let!(:non_authenticated_user) { create(:user, :demandeur) }
+
   let!(:authorization_request) do
     create(
       :authorization_request,
-      demandeur_authorization_request_role: non_authenticated_user.user_authorization_request_roles.first,
+      :with_demandeur,
+      demandeur: non_authenticated_user,
       api: 'entreprise'
     )
   end
+
   let!(:token) do
     create(:token, authorization_request:)
   end
@@ -31,6 +34,26 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
 
     it 'displays the page' do
       expect(page).to have_current_path(api_particulier_authorization_requests_list_path, ignore_query: true)
+
+      expect(page).to have_content("Vous n'avez aucune habilitations")
+    end
+
+    describe 'when the user has authorization requests' do
+      let!(:authorization_request) do
+        create(
+          :authorization_request,
+          :with_demandeur,
+          :validated,
+          demandeur: authenticated_user,
+          api: 'particulier'
+        )
+      end
+
+      it 'displays the page' do
+        expect(page).to have_current_path(api_particulier_authorization_requests_list_path, ignore_query: true)
+
+        expect(page).to have_content('Habilitations API Particulier')
+      end
     end
   end
 end

--- a/spec/features/api_particulier/authorization_request_index_spec.rb
+++ b/spec/features/api_particulier/authorization_request_index_spec.rb
@@ -18,11 +18,13 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
   let!(:authorization_request_active) { nil }
   let!(:authorization_request_expired) { nil }
   let!(:authorization_request_blacklisted) { nil }
+  let!(:authorization_request_archived) { nil }
   let!(:authorization_requests) do
     [
       authorization_request_active,
       authorization_request_expired,
-      authorization_request_blacklisted
+      authorization_request_blacklisted,
+      authorization_request_archived
     ]
   end
 
@@ -88,10 +90,23 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
         )
       end
 
+      let!(:token_archived) { create(:token, authorization_request:) }
+      let!(:authorization_request_archived) do
+        create(
+          :authorization_request,
+          :with_demandeur,
+          :submitted,
+          status: 'archived',
+          tokens: [token_archived],
+          demandeur: authenticated_user,
+          api: 'particulier'
+        )
+      end
+
       it 'displays the page' do
         expect(page).to have_current_path(api_particulier_authorization_requests_list_path, ignore_query: true)
 
-        expect(page).to have_content('Habilitations API Particulier (3)')
+        expect(page).to have_content('Habilitations API Particulier (4)')
 
         authorization_requests.each do |ar|
           expect(page).to have_css('#' << dom_id(ar))
@@ -100,6 +115,8 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
         expect(page).to have_text('☠️ Expiré')
         expect(page).to have_text('🚫 Banni')
         expect(page).to have_text('🔑 Nouveau jeton à utiliser')
+
+        expect(page).to have_text('Cette demande ayant été archivée, aucun jeton ne peut être demandé')
       end
     end
   end

--- a/spec/features/api_particulier/authorization_request_index_spec.rb
+++ b/spec/features/api_particulier/authorization_request_index_spec.rb
@@ -134,6 +134,10 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
 
         expect(page).to have_text('Cette demande ayant été archivée, aucun jeton ne peut être demandé')
       end
+
+      it 'displays the button to view the token details' do
+        expect(page).to have_css('#' << dom_id(authorization_request_active, :show_token_modal_link))
+      end
     end
   end
 end

--- a/spec/features/api_particulier/authorization_request_index_spec.rb
+++ b/spec/features/api_particulier/authorization_request_index_spec.rb
@@ -54,13 +54,23 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
     end
 
     describe 'when the user has authorization requests' do
+      let!(:tokens) do
+        [
+          token_active,
+          token_blacklisted_later,
+          token_expired,
+          token_blacklisted
+        ]
+      end
+
       let!(:token_active) { create(:token, authorization_request:) }
+      let!(:token_blacklisted_later) { create(:token, :blacklisted, blacklisted_at: 1.day.from_now, authorization_request:) }
       let!(:authorization_request_active) do
         create(
           :authorization_request,
           :with_demandeur,
           :validated,
-          tokens: [token_active],
+          tokens: [token_active, token_blacklisted_later],
           demandeur: authenticated_user,
           api: 'particulier'
         )
@@ -111,6 +121,12 @@ RSpec.describe 'displays authorization requests', app: :api_particulier do
         authorization_requests.each do |ar|
           expect(page).to have_css('#' << dom_id(ar))
         end
+
+        tokens.each do |token|
+          expect(page).to have_css('#' << dom_id(token))
+        end
+
+        expect(page).not_to have_css('#' << dom_id(token_archived))
 
         expect(page).to have_text('☠️ Expiré')
         expect(page).to have_text('🚫 Banni')

--- a/spec/features/api_particulier/authorization_request_show_spec.rb
+++ b/spec/features/api_particulier/authorization_request_show_spec.rb
@@ -137,11 +137,7 @@ RSpec.describe 'displays show of authorization request', app: :api_particulier d
           describe 'when the user is demandeur' do
             describe 'when the token has less than 90 days left' do
               it 'displays the button to prolong the token' do
-                expect(page).to have_css('#prolong-token-modal-link')
-
-                click_link 'prolong-token-modal-link'
-
-                expect(page).to have_content('Compléter le formulaire de prolongation')
+                expect(page).not_to have_css('#prolong-token-modal-link')
               end
             end
 

--- a/spec/features/api_particulier/authorization_request_show_spec.rb
+++ b/spec/features/api_particulier/authorization_request_show_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe 'displays authorization requests', app: :api_particulier do
+RSpec.describe 'displays show of authorization request', app: :api_particulier do
   subject(:go_to_authorization_requests_show) do
     visit api_particulier_authorization_requests_show_path(id: authorization_request.id)
   end

--- a/spec/features/api_particulier/prolong_token_spec.rb
+++ b/spec/features/api_particulier/prolong_token_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe 'displays prolong token content', app: :api_particulier do
     end
 
     it 'displays the page' do
-      expect(page).to have_current_path(api_particulier_token_prolong_path(id: token.id), ignore_query: true)
+      expect(page).to have_current_path(api_particulier_user_profile_path, ignore_query: true)
     end
   end
 end


### PR DESCRIPTION
La route demande_list va sauter et devenir authorization_request_index lors du remplacement. C'était pour pouvoir accéder à la page sans écraser la page existante.

c'est une jolie page bien que pas si complexe que ca. Il y a pas particulièrement de point tricky, ca réutilise au max les concepts de la PR d'avant.

Pour pouvoir tout passer en prod et faire le remplacement il faut encore : 
- Faire un point visuel avec Dorine
- Décider de ce qu'on fait avec le bouton de prolongation de token
- Ajouter une liste sommaire des api du token dans le show du token (ici c'est l'index).