### PR TITLE
Reword to remove false implication

### DIFF
--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -209,8 +209,8 @@ fr:
           label: "Catégorie d'entreprise :"
         naf_code:
           label: 'Code NAF :'
-        attestation_sociale_not_downloadable: "Attestation sociale non‑téléchargeable avec ce jeton"
-        attestation_fiscale_not_downloadable: 'Attestation fiscale non‑téléchargeable avec ce jeton'
+        attestation_sociale_not_downloadable: "Attestation sociale non‑téléchargeable"
+        attestation_fiscale_not_downloadable: 'Attestation fiscale non‑téléchargeable'
 
     transfer_user_account:
       new:


### PR DESCRIPTION
Attestation might not be downloadable for
many reasons other than token not allowing for it