### PR TITLE
DataPass webhooks: set first_submitted_at for any non-draft event

### DIFF
--- a/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
+++ b/app/interactors/datapass_webhook/find_or_create_authorization_request.rb
@@ -58,22 +58,13 @@ class DatapassWebhook::FindOrCreateAuthorizationRequest < ApplicationInteractor
   end
 
   def authorization_request_attributes_for_current_event
-    case context.event
-    when 'send_application', 'submit'
-      if context.authorization_request.first_submitted_at.nil?
-        {
-          'first_submitted_at' => fired_at_as_datetime
-        }
-      else
-        {}
-      end
-    when 'validate_application', 'validate'
-      {
-        'validated_at' => fired_at_as_datetime
-      }
-    else
-      {}
-    end
+    authorization_request_attributes_for_current_event = {}
+
+    authorization_request_attributes_for_current_event['first_submitted_at'] = fired_at_as_datetime if context.event != 'draft' && context.authorization_request.first_submitted_at.nil?
+
+    authorization_request_attributes_for_current_event['validated_at'] = fired_at_as_datetime if %w[validate_application validate].include?(context.event)
+
+    authorization_request_attributes_for_current_event
   end
 
   def contact_payload_for(kind)

--- a/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
+++ b/spec/interactors/datapass_webhook/find_or_create_authorization_request_spec.rb
@@ -99,8 +99,8 @@ RSpec.describe DatapassWebhook::FindOrCreateAuthorizationRequest, type: :interac
     end
   end
 
-  context 'when event is send_application or submit' do
-    let(:datapass_webhook_params) { build(:datapass_webhook, event: %w[send_application submit].sample, fired_at:, authorization_request_attributes: { id: authorization_id }) }
+  context 'when event is not draft' do
+    let(:datapass_webhook_params) { build(:datapass_webhook, event: %w[validate].sample, fired_at:, authorization_request_attributes: { id: authorization_id }) }
 
     let!(:authorization_request) { create(:authorization_request, external_id: authorization_id, first_submitted_at:) }
 


### PR DESCRIPTION
For API Particulier, we only sent webhooks for validated event, so every validated API Particulier authorization request has no first_submitted_at set, which leads to a bug for end user on their account (no tokens).