### PR TITLE
Fix notify_datapass_for_data_reconciliation

### DIFF
--- a/app/mailers/api_entreprise/user_mailer.rb
+++ b/app/mailers/api_entreprise/user_mailer.rb
@@ -13,7 +13,8 @@ class APIEntreprise::UserMailer < APIEntrepriseMailer
 
   def notify_datapass_for_data_reconciliation(user)
     @user = user
-    @authorization_requests_ids = user.tokens.pluck(:authorization_request_id).map(&:to_i)
+    @datapass_ids = user.authorization_requests.map(&:external_id).map(&:to_i)
+
     dest_address = 'datapass@api.gouv.fr'
     subject = 'API Entreprise - Réconciliation de demandes d\'accès à un nouvel usager'
 

--- a/app/views/api_entreprise/user_mailer/notify_datapass_for_data_reconciliation.html.mjml
+++ b/app/views/api_entreprise/user_mailer/notify_datapass_for_data_reconciliation.html.mjml
@@ -4,7 +4,7 @@
 
     <mj-text>Suite à une demande de transfert de compte, l'utilisateur <%= @user.email %> ayant pour ID technique API Gouv <%= @user.oauth_api_gouv_id %> vient de se connecter pour la première fois au compte utilisateur API Entreprise !</mj-text>
 
-    <mj-text>Cet usager est maintenant garant des jetons associés aux demandes d'accès DataPass dont voici les ID : <%= @authorization_requests_ids %>.</mj-text>
+    <mj-text>Cet usager est maintenant garant des jetons associés aux demandes d'accès DataPass dont voici les ID : <%= @datapass_ids %>.</mj-text>
 
     <mj-text>Merci de vous assurez que l'usager est bien le propriétaire de ces demandes d'accès dans DataPass !</mj-text>
 

--- a/app/views/api_entreprise/user_mailer/notify_datapass_for_data_reconciliation.text.erb
+++ b/app/views/api_entreprise/user_mailer/notify_datapass_for_data_reconciliation.text.erb
@@ -2,7 +2,7 @@ Bonjour,
 
 Suite à une demande de transfert de compte, l'utilisateur <%= @user.email %> ayant pour ID technique API Gouv <%= @user.oauth_api_gouv_id %> vient de se connecter pour la première fois au compte utilisateur API Entreprise !
 
-Cet usager est maintenant garant des jetons associés aux demandes d'accès DataPass dont voici les ID : <%= @authorization_requests_ids %>.
+Cet usager est maintenant garant des jetons associés aux demandes d'accès DataPass dont voici les ID : <%= @datapass_ids %>.
 
 Merci de vous assurez que l'usager est bien le propriétaire de ces demandes d'accès dans DataPass !
 

--- a/spec/mailers/api_entreprise/user_mailer_spec.rb
+++ b/spec/mailers/api_entreprise/user_mailer_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe APIEntreprise::UserMailer do
     subject { described_class.notify_datapass_for_data_reconciliation(user) }
 
     let(:user) { create(:user, :with_token) }
+    let(:datapass_ids) { user.authorization_requests.map(&:external_id).map(&:to_i) }
 
     its(:subject) { is_expected.to eq('API Entreprise - Réconciliation de demandes d\'accès à un nouvel usager') }
     its(:to) { is_expected.to eq(['datapass@api.gouv.fr']) }
@@ -52,12 +53,9 @@ RSpec.describe APIEntreprise::UserMailer do
       expect(subject.text_part.decoded).to include(user.oauth_api_gouv_id.to_s)
     end
 
-    it 'contains the user\'s authorization requests ID' do
-      authorization_requests_ids = user.tokens.pluck(:authorization_request_id)
-      authorization_requests_ids.map!(&:to_i)
-
-      expect(subject.html_part.decoded).to include(authorization_requests_ids.to_s)
-      expect(subject.text_part.decoded).to include(authorization_requests_ids.to_s)
+    it 'contains the user\'s datapass IDs' do
+      expect(subject.html_part.decoded).to include(datapass_ids.to_s)
+      expect(subject.text_part.decoded).to include(datapass_ids.to_s)
     end
   end
 end


### PR DESCRIPTION
We don't have good DB integrity on authorization_request_id which supposedly represents datapass ID for the AuthorizationRequest.

Will use external_id instead.