### PR TITLE
Api 1599 relecture mails api part

### DIFF
--- a/app/views/api_entreprise/authorization_request_mailer/_block_help_demande.html.mjml
+++ b/app/views/api_entreprise/authorization_request_mailer/_block_help_demande.html.mjml
@@ -22,7 +22,7 @@
       </p>
       <p>
         ☑️ Identifier les données dont vous avez besoin, en parcourant le 
-        <a target="_blank" href="<%= endpoints_url %>/">Catalogue des API</a>.
+        <a target="_blank" href="<%= endpoints_url %>/">catalogue des API</a>.
       </p>
       <p>
         ☑️ Se rattacher à un 

--- a/app/views/api_entreprise/token_mailer/expiration_notice_0J.mjml
+++ b/app/views/api_entreprise/token_mailer/expiration_notice_0J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#ffdbd2',
-      title: "<b>Votre jeton a expiré ⌛️</b>",
+      title: "<b>🔒⚠️ Votre jeton a expiré</b>",
       subtitle: "Vous n'avez plus accès à l'API Entreprise."
     }
 %>

--- a/app/views/api_entreprise/token_mailer/expiration_notice_15J.mjml
+++ b/app/views/api_entreprise/token_mailer/expiration_notice_15J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#ffe5cf',
-      title: "Votre accès à l'API Entreprise <b>expire dans 2 semaines&nbsp;🚨</b>",
+      title: "🔑🚨 Votre accès à l'API Entreprise <b>expire dans 2 semaines</b>",
       subtitle: "Faîtes votre demande de renouvellement en un clic&nbsp;⬇️"
     }
 %>

--- a/app/views/api_entreprise/token_mailer/expiration_notice_30J.mjml
+++ b/app/views/api_entreprise/token_mailer/expiration_notice_30J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#ffe5cf',
-      title: "Votre accès à l'API Entreprise <b>expire dans 1 mois</b>",
+      title: "🔑⚠️ Votre accès à l'API Entreprise <b>expire dans 1 mois</b>",
       subtitle: "Faîtes votre demande de renouvellement en un clic&nbsp;⬇️"
     }
 %>

--- a/app/views/api_entreprise/token_mailer/expiration_notice_60J.mjml
+++ b/app/views/api_entreprise/token_mailer/expiration_notice_60J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#d1d3de',
-      title: "Votre accès à l'API Entreprise <b>expire dans 2 mois</b>",
+      title: "🔑⚠️ Votre accès à l'API Entreprise <b>expire dans 2 mois</b>",
       subtitle: "Faîtes votre demande de renouvellement en un clic&nbsp;⬇️"
     }
 %>

--- a/app/views/api_entreprise/token_mailer/expiration_notice_7J.mjml
+++ b/app/views/api_entreprise/token_mailer/expiration_notice_7J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#ffe5cf',
-      title: "Votre accès à l'API Entreprise <b>expire dans une semaine&nbsp;🚨</b>",
+      title: "Votre accès à l'API Entreprise <b>expire dans une semaine&nbsp;🔑🚨</b>",
       subtitle: "Faîtes votre demande de renouvellement en un clic&nbsp;⬇️"
     }
 %>

--- a/app/views/api_entreprise/token_mailer/expiration_notice_90J.mjml
+++ b/app/views/api_entreprise/token_mailer/expiration_notice_90J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#d1d3de',
-      title: "Votre accès à l'API Entreprise <b>expire dans 3 mois</b>",
+      title: "🔑 Votre accès à l'API Entreprise <b>expire dans 3 mois</b>",
       subtitle: "Faîtes votre demande de renouvellement en un clic&nbsp;⬇️"
     }
 %>

--- a/app/views/api_entreprise/token_mailer/magic_link.html.mjml
+++ b/app/views/api_entreprise/token_mailer/magic_link.html.mjml
@@ -1,16 +1,26 @@
-<mj-section>
+<%= render partial: "shared/api_entreprise/mailers/header" %>
+<mj-section padding-top="0px" padding-bottom="30px">
   <mj-column>
-    <mj-text>Bonjour,</mj-text>
-
+    <mj-divider mj-class="footer-divider" />
+    <mj-text padding-top="30px" > <p>Bonjour,</p></mj-text>
     <mj-text>
-      <%= t('.link_description') %>&nbsp; <%= link_to('suivant',
-      token_show_magic_link_url(host: @host, access_token: @magic_link.access_token)) %>
+      <p>
+        <%= t('.link_description') %>&nbsp;<%= link_to('suivant',
+        token_show_magic_link_url(host: @host, access_token: @magic_link.access_token)) %>.
+      </p>
     </mj-text>
-
     <mj-text>
-      Ce lien est temporaire. Il est valable jusqu'au <%= friendly_format_from_timestamp(@magic_link.expires_at) %>
+      <p>
+        Ce lien est temporaire. Il est valable jusqu'au <%= friendly_format_from_timestamp(@magic_link.expires_at) %>
+      </p>
     </mj-text>
-    <mj-text>Cordialement,</mj-text>
-    <mj-text><%= t(".signature") %></mj-text>
+    <mj-text>
+      <p>
+        À bientôt 👋
+        <br />
+        <b>L'équipe API Entreprise</b>
+      </p>
+    </mj-text>
   </mj-column>
 </mj-section>
+<%= render partial: "shared/api_entreprise/mailers/footer" %>

--- a/app/views/api_particulier/authorization_request_mailer/_block_help_demande.html.mjml
+++ b/app/views/api_particulier/authorization_request_mailer/_block_help_demande.html.mjml
@@ -22,7 +22,7 @@
       </p>
       <p>
         ☑️ Identifier les données dont vous avez besoin, en parcourant le
-        <a target="_blank" href="<%= api_particulier_endpoints_url %>/">Catalogue des API</a>.
+        <a target="_blank" href="<%= api_particulier_endpoints_url %>/">catalogue des API</a>.
       </p>
       <p>
         ☑️ Se rattacher à un 

--- a/app/views/api_particulier/authorization_request_mailer/_block_help_demande.html.mjml
+++ b/app/views/api_particulier/authorization_request_mailer/_block_help_demande.html.mjml
@@ -24,6 +24,13 @@
         ☑️ Identifier les données dont vous avez besoin, en parcourant le
         <a target="_blank" href="<%= api_particulier_endpoints_url %>/">Catalogue des API</a>.
       </p>
+      <p>
+        ☑️ Se rattacher à un 
+        <a target="_blank" href="https://api.gouv.fr/les-api/api-particulier#exemples-d%E2%80%99application">
+          cas d’usage
+        </a> et utiliser son formulaire pré-rempli dans
+        votre demande d'habilitation.
+      </p>
     </mj-text>
   </mj-column>
 </mj-section>

--- a/app/views/api_particulier/authorization_request_mailer/_enquete_satisfaction.html
+++ b/app/views/api_particulier/authorization_request_mailer/_enquete_satisfaction.html
@@ -159,7 +159,7 @@
                                                 color: #000000;
                                               ">
                                               <a
-                                                href="https://form.typeform.com/to/x1nrR9kY?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=44cee5ec-0f6f-45a8-86d8-5c5bbe0fd590"
+                                                href="https://form.typeform.com/to/W7wHJP0K?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=44cee5ec-0f6f-45a8-86d8-5c5bbe0fd590"
                                                 style="
                                                   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
                                                     Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans',
@@ -191,7 +191,7 @@
                                                 color: #000000;
                                               ">
                                               <a
-                                                href="https://form.typeform.com/to/x1nrR9kY?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=9cfd3cb3-e6e4-4e7b-95e3-17b13f761a0e"
+                                                href="https://form.typeform.com/to/W7wHJP0K?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=9cfd3cb3-e6e4-4e7b-95e3-17b13f761a0e"
                                                 style="
                                                   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
                                                     Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans',
@@ -216,7 +216,7 @@
                                           <td style="font-size: 0px; padding: 10px 25px; word-break: break-word">
                                             <div style="font-family: Open Sans; font-size: 13px; color: #000000">
                                               <a
-                                                href="https://form.typeform.com/to/x1nrR9kY?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=56a90d30-f86b-4bd8-924e-519c9fa74108"
+                                                href="https://form.typeform.com/to/W7wHJP0K?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=56a90d30-f86b-4bd8-924e-519c9fa74108"
                                                 style="
                                                   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
                                                     Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans',
@@ -248,7 +248,7 @@
                                                 color: #000000;
                                               ">
                                               <a
-                                                href="https://form.typeform.com/to/x1nrR9kY?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=e0afb804-0e8a-423e-913e-ad57e54642bb"
+                                                href="https://form.typeform.com/to/W7wHJP0K?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=e0afb804-0e8a-423e-913e-ad57e54642bb"
                                                 style="
                                                   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
                                                     Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans',
@@ -280,7 +280,7 @@
                                                 color: #000000;
                                               ">
                                               <a
-                                                href="https://form.typeform.com/to/x1nrR9kY?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=54b5f631-c8c9-425a-8979-39d6f12aa57f"
+                                                href="https://form.typeform.com/to/W7wHJP0K?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=54b5f631-c8c9-425a-8979-39d6f12aa57f"
                                                 style="
                                                   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
                                                     Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans',
@@ -312,7 +312,7 @@
                                                 color: #000000;
                                               ">
                                               <a
-                                                href="https://form.typeform.com/to/x1nrR9kY?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=1a55faaa-647e-4675-a161-4fbe1f0df328"
+                                                href="https://form.typeform.com/to/W7wHJP0K?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=1a55faaa-647e-4675-a161-4fbe1f0df328"
                                                 style="
                                                   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
                                                     Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans',
@@ -344,7 +344,7 @@
                                                 color: #000000;
                                               ">
                                               <a
-                                                href="https://form.typeform.com/to/x1nrR9kY?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=0c9fbdd8-c50d-4f0b-92a0-be2560179c45"
+                                                href="https://form.typeform.com/to/W7wHJP0K?typeform-medium=embed-email#answers-61d0d37a-3b94-432e-9dbb-e378c3ef6009=0c9fbdd8-c50d-4f0b-92a0-be2560179c45"
                                                 style="
                                                   font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
                                                     Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans', 'Droid Sans',

--- a/app/views/api_particulier/authorization_request_mailer/embarquement_valide_to_demandeur_is_tech.html.mjml
+++ b/app/views/api_particulier/authorization_request_mailer/embarquement_valide_to_demandeur_is_tech.html.mjml
@@ -42,5 +42,6 @@
   </mj-column>
 </mj-section>
 <%= render partial: "block_subscribed_newsletter" %>
+<%= render partial: "block_analytics" %>
 <%= render partial: "block_questions" %>
 <%= render partial: "shared/api_particulier/mailers/footer" %>

--- a/app/views/api_particulier/token_mailer/expiration_notice_0J.mjml
+++ b/app/views/api_particulier/token_mailer/expiration_notice_0J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#ffdbd2',
-      title: "<b>⚠️ Votre jeton a expiré</b>",
+      title: "<b>🔒⚠️ Votre jeton a expiré</b>",
       subtitle: "Vous n'avez plus accès à l'API Particulier."
     }
 %>

--- a/app/views/api_particulier/token_mailer/expiration_notice_0J.mjml
+++ b/app/views/api_particulier/token_mailer/expiration_notice_0J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#ffdbd2',
-      title: "<b>Votre jeton a expiré ⌛️</b>",
+      title: "<b>⚠️ Votre jeton a expiré</b>",
       subtitle: "Vous n'avez plus accès à l'API Particulier."
     }
 %>

--- a/app/views/api_particulier/token_mailer/expiration_notice_15J.mjml
+++ b/app/views/api_particulier/token_mailer/expiration_notice_15J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#ffe5cf',
-      title: "Votre accès à l'API Particulier <b>expire dans 2 semaines&nbsp;🚨</b>",
+      title: "🔑🚨 Votre accès à l'API Particulier <b>expire dans 2 semaines</b>",
       subtitle: "Faîtes votre demande de renouvellement en un clic&nbsp;⬇️"
     }
 %>

--- a/app/views/api_particulier/token_mailer/expiration_notice_30J.mjml
+++ b/app/views/api_particulier/token_mailer/expiration_notice_30J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#ffe5cf',
-      title: "Votre accès à l'API Particulier <b>expire dans 1 mois</b>",
+      title: "🔑⚠️ Votre accès à l'API Particulier <b>expire dans 1 mois</b>",
       subtitle: "Faîtes votre demande de renouvellement en un clic&nbsp;⬇️"
     }
 %>

--- a/app/views/api_particulier/token_mailer/expiration_notice_60J.mjml
+++ b/app/views/api_particulier/token_mailer/expiration_notice_60J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#d1d3de',
-      title: "Votre accès à l'API Particulier <b>expire dans 2 mois</b>",
+      title: "🔑 Votre accès à l'API Particulier <b>expire dans 2 mois</b>",
       subtitle: "Faîtes votre demande de renouvellement en un clic&nbsp;⬇️"
     }
 %>

--- a/app/views/api_particulier/token_mailer/expiration_notice_7J.mjml
+++ b/app/views/api_particulier/token_mailer/expiration_notice_7J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#ffe5cf',
-      title: "Votre accès à l'API Particulier <b>expire dans une semaine&nbsp;🚨</b>",
+      title: "🔑🚨⚠️ Votre accès à l'API Particulier <b>expire dans une semaine</b>",
       subtitle: "Faîtes votre demande de renouvellement en un clic&nbsp;⬇️"
     }
 %>

--- a/app/views/api_particulier/token_mailer/expiration_notice_90J.mjml
+++ b/app/views/api_particulier/token_mailer/expiration_notice_90J.mjml
@@ -2,7 +2,7 @@
 <%= render partial: "banner",
     locals: {
       color: '#d1d3de',
-      title: "Votre accès à l'API Particulier <b>expire dans 3 mois</b>",
+      title: "🔑 Votre accès à l'API Particulier <b>expire dans 3 mois</b>",
       subtitle: "Faîtes votre demande de renouvellement en un clic&nbsp;⬇️"
     }
 %>

--- a/app/views/api_particulier/token_mailer/magic_link.html.mjml
+++ b/app/views/api_particulier/token_mailer/magic_link.html.mjml
@@ -1,16 +1,29 @@
-<mj-section>
+<%= render partial: "shared/api_particulier/mailers/header" %>
+<mj-section padding-top="0px" padding-bottom="30px">
   <mj-column>
-    <mj-text>Bonjour,</mj-text>
-
+    <mj-divider mj-class="footer-divider" />
+      <mj-text padding-top="30px" > 
+        <p>
+          Bonjour,
+        </p>
+      </mj-text>
     <mj-text>
-      <%= t('.link_description') %>&nbsp;
-      <%= link_to('suivant', token_show_magic_link_url(host: @host, access_token: @magic_link.access_token)) %>
+      <p>
+        <%= t('.link_description') %>&nbsp;<%= link_to('suivant', token_show_magic_link_url(host: @host, access_token: @magic_link.access_token)) %>.
+      </p>
     </mj-text>
-
     <mj-text>
-      Ce lien est temporaire. Il est valable jusqu'au <%= friendly_format_from_timestamp(@magic_link.expires_at) %>
+      <p>
+        Ce lien est temporaire. Il est valable jusqu'au <%= friendly_format_from_timestamp(@magic_link.expires_at) %>
+      </p>
     </mj-text>
-    <mj-text>Cordialement,</mj-text>
-    <mj-text><%= t(".signature") %></mj-text>
+    <mj-text>
+      <p>
+        À bientôt 👋
+        <br />
+        <b>L'équipe API Particulier</b>
+      </p>
+    </mj-text>
   </mj-column>
 </mj-section>
+<%= render partial: "shared/api_particulier/mailers/footer" %>

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -86,6 +86,6 @@ fr:
       expiration_notice_0J:
         subject: "🔒⚠️ Rupture de service : votre accès à l'API Particulier a expiré."
       magic_link:
-        subject: 🔑 Lien d'accès temporaire au jeton API Entreprise
+        subject: 🔑 Lien d'accès temporaire au jeton API Particulier
         signature: L'équipe API Particulier
         link_description: Un lien vers un jeton d'accès API Particulier vient d'être généré à votre intention. Vous pouvez accéder à ce jeton via le lien

--- a/config/locales/mailers.fr.yml
+++ b/config/locales/mailers.fr.yml
@@ -32,21 +32,21 @@ fr:
 
     token_mailer:
       expiration_notice_90J:
-        subject: Votre habilitation API Entreprise expire dans 3 mois, effectuez dès maintenant votre demande de renouvellement.
+        subject: 🔑 Faîtes votre demande de renouvellement API Entreprise
       expiration_notice_60J:
-        subject: Votre habilitation API Entreprise expire dans 2 mois, effectuez dès maintenant votre demande de renouvellement.
+        subject: 🔑 Faîtes votre demande de renouvellement, votre habilitation API Entreprise expire dans 2 mois
       expiration_notice_30J:
-        subject: Pour être sûr de ne pas avoir de coupure de service, faîtes votre demande de renouvellement dès aujourd'hui.
+        subject: 🔑⚠️ Expiration dans 30 jours de votre accès API Entreprise
       expiration_notice_15J:
-        subject: Dernière limite pour éviter toute coupure de service, faîtes votre demande de renouvellement dès aujourd'hui.
+        subject: 🔑🚨 Expiration dans 15 jours de votre accès API Entreprise
       expiration_notice_7J:
-        subject: Faîtes votre demande de renouvellement aujourd'hui car vos accès à l'API Entreprise expirent dans 7 jours.
+        subject: 🔑🚨⚠️ Expiration dans 7 jours de votre accès API Entreprise
       expiration_notice_0J:
-        subject: Votre accès à l'API Entreprise a expiré.
+        subject: "🔒⚠️ Rupture de service : votre accès à l'API Entreprise a expiré."
       magic_link:
-        subject: API Entreprise - Lien d'accès à votre jeton !
+        subject: 🔑 Lien d'accès temporaire au jeton API Entreprise
         signature: L'équipe API Entreprise
-        link_description: Un lien vers votre jeton d'accès vient d'être généré à votre intention. Vous pouvez accéder à ce jeton via le lien
+        link_description: Un lien vers un jeton d'accès API Entreprise vient d'être généré à votre intention. Vous pouvez accéder à ce jeton via le lien
   api_particulier:
     authorization_request_mailer:
       embarquement_brouillon_en_attente:
@@ -74,18 +74,18 @@ fr:
         subject: Comment se passe votre intégration de l'API Particulier ?
     token_mailer:
       expiration_notice_90J:
-        subject: Votre habilitation API Particulier expire dans 3 mois, effectuez dès maintenant votre demande de renouvellement.
+        subject: 🔑 Faîtes votre demande de renouvellement API Particulier
       expiration_notice_60J:
-        subject: Votre habilitation API Particulier expire dans 2 mois, effectuez dès maintenant votre demande de renouvellement.
+        subject: 🔑 Faîtes votre demande de renouvellement, votre habilitation API Particulier expire dans 2 mois
       expiration_notice_30J:
-        subject: Pour être sûr de ne pas avoir de coupure de service, faîtes votre demande de renouvellement dès aujourd'hui.
+        subject: 🔑⚠️ Expiration dans 30 jours de votre accès API Particulier
       expiration_notice_15J:
-        subject: Dernière limite pour éviter toute coupure de service, faîtes votre demande de renouvellement dès aujourd'hui.
+        subject: 🔑🚨 Expiration dans 15 jours de votre accès API Particulier
       expiration_notice_7J:
-        subject: Faîtes votre demande de renouvellement aujourd'hui car vos accès à l'API Particulier expirent dans 7 jours.
+        subject: 🔑🚨⚠️ Expiration dans 7 jours de votre accès API Particulier
       expiration_notice_0J:
-        subject: Votre accès à l'API Particulier a expiré.
+        subject: "🔒⚠️ Rupture de service : votre accès à l'API Particulier a expiré."
       magic_link:
-        subject: API Particulier - Lien d'accès à votre jeton !
+        subject: 🔑 Lien d'accès temporaire au jeton API Entreprise
         signature: L'équipe API Particulier
-        link_description: Un lien vers votre jeton d'accès vient d'être généré à votre intention. Vous pouvez accéder à ce jeton via le lien
+        link_description: Un lien vers un jeton d'accès API Particulier vient d'être généré à votre intention. Vous pouvez accéder à ce jeton via le lien

--- a/spec/mailers/api_entreprise/token_mailer_spec.rb
+++ b/spec/mailers/api_entreprise/token_mailer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe APIEntreprise::TokenMailer do
     let(:email) { 'muchemail@wow.com' }
     let(:host) { 'entreprise.api.gouv.fr' }
 
-    its(:subject) { is_expected.to eq('API Entreprise - Lien d\'accès à votre jeton !') }
+    its(:subject) { is_expected.to eq("🔑 Lien d'accès temporaire au jeton API Entreprise") }
     its(:to) { is_expected.to contain_exactly(email) }
 
     it 'contains the magic link to the token' do

--- a/spec/mailers/api_particulier/token_mailer_spec.rb
+++ b/spec/mailers/api_particulier/token_mailer_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe APIParticulier::TokenMailer do
     let(:email) { 'muchemail@wow.com' }
     let(:host) { 'particulier.api.gouv.fr' }
 
-    its(:subject) { is_expected.to eq('API Particulier - Lien d\'accès à votre jeton !') }
+    its(:subject) { is_expected.to eq("🔑 Lien d'accès temporaire au jeton API Particulier") }
     its(:to) { is_expected.to contain_exactly(email) }
 
     it 'contains the magic link to the token' do


### PR DESCRIPTION
@Samuelfaure c'est prêt, j'ai fini ma relecture. 

Par contre, il va y avoir du changement concernant les mails de transferts de compte. ça concerne : 

[notify_datapass_for_data_reconciliation](http://entreprise.api.localtest.me:5000/rails/mailers/api_entreprise/user_mailer/notify_datapass_for_data_reconciliation)
    [transfer_ownership](http://entreprise.api.localtest.me:5000/rails/mailers/api_entreprise/user_mailer/transfer_ownership)
    
C'est en cours dans [cette PR ](https://github.com/etalab/admin_api_entreprise/pull/1354) mais je pense qu'on peut merger