### PR TITLE
Fixed scopes trying to display when no token

### DIFF
--- a/app/views/api_entreprise/authorization_request_mailer/_list_scopes.html.mjml
+++ b/app/views/api_entreprise/authorization_request_mailer/_list_scopes.html.mjml
@@ -1,14 +1,16 @@
-<mj-text mj-class="section-block">
-  <h2>
-    🔐 Cette habilitation donne accès aux API suivantes&nbsp;:</b>
-  </h2>
-  <ul>
-    <% @all_scopes.each do |scope_key, scope_label| %>
-      <% if (@authorization_request_scopes || []).include?(scope_key) %>
-        <li>
-          <%= scope_label %>
-        </li>
+<% if @authorization_request_scopes %>
+  <mj-text mj-class="section-block">
+    <h2>
+      🔐 Cette habilitation donne accès aux API suivantes&nbsp;:</b>
+    </h2>
+    <ul>
+      <% @all_scopes.each do |scope_key, scope_data| %>
+        <% if (@authorization_request_scopes || []).include?(scope_key) %>
+          <li>
+            <%= scope_data[:label] %>
+          </li>
+        <% end %>
       <% end %>
-    <% end %>
-  </ul>
-</mj-text>
+    </ul>
+  </mj-text>
+<% end %>

--- a/spec/mailers/api_entreprise/authorization_request_mailer_spec.rb
+++ b/spec/mailers/api_entreprise/authorization_request_mailer_spec.rb
@@ -33,4 +33,26 @@ RSpec.describe APIEntreprise::AuthorizationRequestMailer do
       end
     end
   end
+
+  describe 'scopes in mails' do
+    subject(:generate_email) { described_class.embarquement_valide_to_demandeur_is_metier_not_tech({ to:, cc:, authorization_request: }) }
+
+    let(:scope_label) { I18n.t('api_entreprise.tokens.token.scope.entreprises.label') }
+
+    describe 'when there is no token' do
+      it 'doesnt display scopes' do
+        expect(subject.html_part.decoded).not_to include('Cette habilitation donne accès aux API suivantes')
+        expect(subject.html_part.decoded).not_to include(scope_label)
+      end
+    end
+
+    describe 'when there is a token' do
+      let(:authorization_request) { create(:authorization_request, :with_all_contacts, :with_tokens) }
+
+      it 'display scopes' do
+        expect(subject.html_part.decoded).to include('Cette habilitation donne accès aux API suivantes')
+        expect(subject.html_part.decoded).to include(scope_label)
+      end
+    end
+  end
 end


### PR DESCRIPTION
fix https://linear.app/pole-api/issue/API-1780/bug-scopes-sur-mail-embarquement

Je suis pas certain de vouloir conditionner l'affichage du partial scopes à l'existence d'un token parce que NORMALEMENT on affiche la liste des scopes seulement dans les mails où un token a été généré.

D'un autre coté c'est plus safe comme ça si pour une raison ou une autre le token a pas encore été généré. Whatever.