### PR TITLE
Link to github test cases

### DIFF
--- a/app/models/abstract_endpoint.rb
+++ b/app/models/abstract_endpoint.rb
@@ -211,6 +211,14 @@ class AbstractEndpoint < ApplicationAlgoliaSearchableActiveModel
     use_cases_forbidden&.include?(cas_usage_name)
   end
 
+  def test_cases_external_url
+    "https://github.com/etalab/siade_staging_data/tree/develop/payloads/#{operation_id}"
+  end
+
+  def operation_id
+    open_api_definition['responses']['200']['x-operationId']
+  end
+
   private
 
   def tag_for_redoc

--- a/app/views/api_entreprise/endpoints/show.html.erb
+++ b/app/views/api_entreprise/endpoints/show.html.erb
@@ -156,6 +156,10 @@
           <a href="<%= endpoint_example_path(uid: @endpoint.uid) %>" id="example_link" class="fr-btn fr-btn--secondary fr-icon-eye-line fr-btn--icon-left fr-mt-2w" aria-controls="main-modal" data-fr-opened="false" data-turbo-frame="main-modal-content">
             Aperçu d'un exemple de réponse JSON
           </a>
+
+          <a href="<%= @endpoint.test_cases_external_url %>" target="_blank" class="fr-btn fr-btn--secondary fr-icon-eye-line fr-btn--icon-left fr-mt-2w">
+            <%= t('.test_cases') %>
+          </a>
         </div>
 
         <div class="keep-within-block-mobile">

--- a/app/views/api_particulier/endpoints/show.html.erb
+++ b/app/views/api_particulier/endpoints/show.html.erb
@@ -178,6 +178,10 @@
           <a href="<%= endpoint_example_path(uid: @endpoint.uid) %>" id="example_link" class="fr-btn fr-btn--secondary fr-icon-eye-line fr-btn--icon-left fr-mt-2w" aria-controls="main-modal" data-fr-opened="false" data-turbo-frame="main-modal-content">
             Aperçu d'un exemple de réponse JSON
           </a>
+
+          <a href="<%= @endpoint.test_cases_external_url %>" target="_blank" class="fr-btn fr-btn--secondary fr-icon-eye-line fr-btn--icon-left fr-mt-2w">
+            <%= t('.test_cases') %>
+          </a>
         </div>
 
         <div class="keep-within-block-mobile">

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -278,6 +278,7 @@ fr:
           api_cgu_title: "Conditions spécifiques à cette API :"
           main_title: "Conditions générales :"
           cta: "CGU API Entreprise"
+        test_cases: "Cas de tests"
       use_cases:
         main:
           title: "Cas d'usage"

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -146,6 +146,7 @@ fr:
           api_cgu_title: "Conditions spécifiques à cette API :"
           main_title: "Conditions générales :"
           cta: "CGU API Particulier"
+        test_cases: "Cas de tests"
       use_cases:
         main:
           title: "Cas d'usage"

--- a/spec/features/api_entreprise/endpoints/show_spec.rb
+++ b/spec/features/api_entreprise/endpoints/show_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe 'Endpoints show', app: :api_entreprise do
     expect(page).to have_link('Marchés publics', href: cas_usage_path(uid: 'marches_publics'))
   end
 
+  it 'displays link to test cases' do
+    expect(page).to have_link(I18n.t('api_entreprise.endpoints.show.test_cases'), href: endpoint.test_cases_external_url)
+  end
+
   describe 'real time status' do
     context 'when endpoint is up' do
       let(:api_status) { 200 }

--- a/spec/features/api_particulier/endpoints/show_spec.rb
+++ b/spec/features/api_particulier/endpoints/show_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe 'Endpoints show', app: :api_particulier do
     expect(page).to have_content('Tarification sociale et solidaire des transports')
   end
 
+  it 'displays link to test cases' do
+    expect(page).to have_link(I18n.t('api_particulier.endpoints.show.test_cases'), href: endpoint.test_cases_external_url)
+  end
+
   describe 'real time status' do
     context 'when endpoint is up' do
       let(:api_status) { 200 }

--- a/spec/models/api_entreprise/endpoint_spec.rb
+++ b/spec/models/api_entreprise/endpoint_spec.rb
@@ -87,4 +87,10 @@ RSpec.describe APIEntreprise::Endpoint do
       end
     end
   end
+
+  describe '#test_cases_external_url' do
+    subject { described_class.find(api_entreprise_example_uid).test_cases_external_url }
+
+    it { is_expected.to eq('https://github.com/etalab/siade_staging_data/tree/develop/payloads/api_entreprise_v3_insee_unites_legales') }
+  end
 end

--- a/spec/models/api_particulier/endpoint_spec.rb
+++ b/spec/models/api_particulier/endpoint_spec.rb
@@ -1,10 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe APIParticulier::Endpoint do
+  let(:uid) { 'cnaf/quotient_familial' }
+
   describe '.find' do
     subject { described_class.find(uid) }
-
-    let(:uid) { 'cnaf/quotient_familial' }
 
     it { is_expected.to be_an_instance_of(described_class) }
 
@@ -15,5 +15,11 @@ RSpec.describe APIParticulier::Endpoint do
 
     its(:attributes) { is_expected.to be_an_instance_of(Hash) }
     its(:attributes) { is_expected.to have_key('quotientFamilial') }
+  end
+
+  describe '#test_cases_external_url' do
+    subject { described_class.find(uid).test_cases_external_url }
+
+    it { is_expected.to eq('https://github.com/etalab/siade_staging_data/tree/develop/payloads/api_particulier_v2_cnaf_quotient_familial') }
   end
 end


### PR DESCRIPTION
Ça fonctionne sauf pour certains repos dans siade_staging_data où on a écrit "diffusable" au lieu de "diffusible" - je vais faire une PR pour corriger ça.

Je met ça là pour le moment, à voir si @DorineLam veut changer à son retour :

![image](https://github.com/etalab/admin_api_entreprise/assets/14159757/04519171-5a67-4caf-b255-2dfa0510043b)

