### PR TITLE
error message when trying to access non-existent API

### DIFF
--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -123,6 +123,7 @@ ignore_unused:
   - 'api_{entreprise,particulier}.faq.categories'
   - 'api_{entreprise,particulier}.token_mailer.*'
   - 'api_{entreprise,particulier}.authorization_request_mailer.*'
+  - 'api_{entreprise,particulier}.endpoints.show.error.record_not_found'
 # - 'activerecord.attributes.*'
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -224,6 +224,8 @@ fr:
           swagger: "Swagger"
 
       show:
+        error:
+          record_not_found: "L'API que vous essayez d'accéder est introuvable."
         deprecated:
           title: "Cette API est dépréciée"
           description: "Cette API est une ancienne version, nous vous invitons à utiliser ces API les plus récentes :"

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -109,6 +109,8 @@ fr:
           swagger: Swagger
           documentation: Documentation
       show:
+        error:
+          record_not_found: "L'API que vous essayez d'accéder est introuvable."
         deprecated:
           title: "Cette API est dépréciée"
           description: "Cette API est une ancienne version, nous vous invitons à utiliser ces API les plus récentes :"


### PR DESCRIPTION
Ça redirige toujours vers la homepage quand on tente d'accéder à une ressource inexistante à cause de ce bout de code dans application_controller.rb:

```ruby
  rescue_from ActiveRecord::RecordNotFound do |_|
    error_message(title: t('.error.record_not_found'))
    if user_signed_in?
      redirect_current_user_to_homepage
    else
      redirect_to_root
    end
  end
```

On pourrait changer ça sur l'app entière mais la flemme et possibles effets de bord relou.

A minima fix le message, quickwin.