### PR TITLE
Met en avant la modalité d'appel FranceConnect dans le catalogue et la fiche métier - API-2158 et API-660 

### DIFF
--- a/app/views/api_particulier/endpoints/_details.html.erb
+++ b/app/views/api_particulier/endpoints/_details.html.erb
@@ -20,10 +20,12 @@
   <ul >
     <% @endpoint.parameters.each do |parameter| %>
     <li class=" fr-mb-0 fr-pb-0">
-      <%= parameter %>
-      <% if parameter == "FranceConnect" %>
-        <%= image_tag("api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg", style: 'vertical-align: middle; margin-left: 2px;', size: '25x25', alt: 'Pictogramme fournisseurs de données regroupés') %>
-      <% end %>
+      <span class="fr-grid-row">
+        <%= parameter %>
+        <% if parameter == "FranceConnect" %>
+          <%= image_tag("api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg", size: '25x25', alt: 'Pictogramme fournisseurs de données regroupés', class: %w(fr-ml-1w))%>
+        <% end %>
+      </span>
     </li>
     <% end %>
   </ul>

--- a/app/views/api_particulier/endpoints/_details.html.erb
+++ b/app/views/api_particulier/endpoints/_details.html.erb
@@ -17,13 +17,17 @@
     <%= t('.parameters.title', count: @endpoint.parameters.count) %>
   </h3>
 
-  <ul>
+  <ul >
     <% @endpoint.parameters.each do |parameter| %>
-      <li>
-        <%= parameter %>
-      </li>
+    <li class=" fr-mb-0 fr-pb-0">
+      <%= parameter %>
+      <% if parameter == "FranceConnect" %>
+        <%= image_tag("api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg", style: 'vertical-align: middle; margin-left: 2px;', size: '25x25', alt: 'Pictogramme fournisseurs de données regroupés') %>
+      <% end %>
+    </li>
     <% end %>
   </ul>
+
   <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" title="Détails des modalités d'appel" href="#parameters_details">
   <%= t('.parameters.link') %>
  </a>

--- a/app/views/api_particulier/endpoints/_endpoint.html.erb
+++ b/app/views/api_particulier/endpoints/_endpoint.html.erb
@@ -24,11 +24,11 @@
       </div>
     </section>
 
-     <section class="metadata fr-mt-2w fr-pb-0">
+     <section class="metadata fr-text--sm fr-mt-2w fr-pb-0">
       <strong>Modalités d'appel :</strong>  
       <ul >
         <% endpoint.parameters.each do |parameter| %>
-        <li class=" fr-mb-0 fr-pb-0">
+        <li class="fr-text--sm fr-mb-0 fr-pb-0">
           <%= parameter %>
           <% if parameter == "FranceConnect" %>
             <%= image_tag("api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg", style: 'vertical-align: middle; margin-left: 2px;', size: '25x25', alt: 'Pictogramme fournisseurs de données regroupés') %>

--- a/app/views/api_particulier/endpoints/_endpoint.html.erb
+++ b/app/views/api_particulier/endpoints/_endpoint.html.erb
@@ -24,6 +24,18 @@
       </div>
     </section>
 
+     <section class="metadata fr-mt-2w fr-pb-0">
+      <strong>Modalités d'appel :</strong>  
+      <ul >
+      <% endpoint.parameters.each do |parameter| %>
+      <li class="fr-text--sm fr-mb-0 fr-pb-0">
+        
+      <%= parameter %><% if parameter == "FranceConnect" %><%= image_tag("api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg", style: 'vertical-align: middle; margin-left: 2px;', size: '25x25', alt: 'Pictogramme fournisseurs de données regroupés') %><% end %>
+      </li>
+     <% end %>
+     </ul>
+    </section>
+
     <footer>
       <ul class="fr-btns-group fr-btns-group--right fr-btns-group--inline-md fr-mt-1w">
         <li>

--- a/app/views/api_particulier/endpoints/_endpoint.html.erb
+++ b/app/views/api_particulier/endpoints/_endpoint.html.erb
@@ -29,10 +29,12 @@
       <ul >
         <% endpoint.parameters.each do |parameter| %>
         <li class="fr-text--sm fr-mb-0 fr-pb-0">
-          <%= parameter %>
-          <% if parameter == "FranceConnect" %>
-            <%= image_tag("api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg", style: 'vertical-align: middle; margin-left: 2px;', size: '25x25', alt: 'Pictogramme fournisseurs de données regroupés') %>
-          <% end %>
+          <span class="fr-grid-row">
+            <%= parameter %>
+            <% if parameter == "FranceConnect" %>
+            <%= image_tag("api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg", size: '25x25', alt: 'Pictogramme fournisseurs de données regroupés')%>
+            <% end %>
+          </span>
         </li>
         <% end %>
       </ul>

--- a/app/views/api_particulier/endpoints/_endpoint.html.erb
+++ b/app/views/api_particulier/endpoints/_endpoint.html.erb
@@ -27,13 +27,15 @@
      <section class="metadata fr-mt-2w fr-pb-0">
       <strong>Modalités d'appel :</strong>  
       <ul >
-      <% endpoint.parameters.each do |parameter| %>
-      <li class="fr-text--sm fr-mb-0 fr-pb-0">
-        
-      <%= parameter %><% if parameter == "FranceConnect" %><%= image_tag("api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg", style: 'vertical-align: middle; margin-left: 2px;', size: '25x25', alt: 'Pictogramme fournisseurs de données regroupés') %><% end %>
-      </li>
-     <% end %>
-     </ul>
+        <% endpoint.parameters.each do |parameter| %>
+        <li class=" fr-mb-0 fr-pb-0">
+          <%= parameter %>
+          <% if parameter == "FranceConnect" %>
+            <%= image_tag("api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg", style: 'vertical-align: middle; margin-left: 2px;', size: '25x25', alt: 'Pictogramme fournisseurs de données regroupés') %>
+          <% end %>
+        </li>
+        <% end %>
+      </ul>
     </section>
 
     <footer>

--- a/config/endpoints/api_particulier/cnaf_msa_complementaire_sante_solidaire.yml
+++ b/config/endpoints/api_particulier/cnaf_msa_complementaire_sante_solidaire.yml
@@ -16,10 +16,10 @@
   parameters_details:
     description: |+
       Cette API propose 2 modalités d'appel :
-      <p class="fr-badge fr-badge--green-emeraude">FranceConnect</p>
-      **Avec FranceConnect**.
+      <p class="fr-badge fr-badge--blue-ecume">![Cette API est FranceConnectée](<%= image_path('api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg') %>){:width="20px"} FranceConnect</p>
+      **Avec la [modalité d'appel FranceConnect](<%= cas_usage_path('modalite_appel_france_connect') %>)**.
 
-      <p class="fr-badge fr-badge--blue-ecume">Identité pivot</p>
+      <p class="fr-badge fr-badge--green-emeraude">Identité pivot</p>
       **Avec les données d'identité** : Noms, prénoms, sexe<sup>\*</sup>, date de naissance, code COG de la commune de naissance (COG)<sup>\**</sup> et code COG du pays de naissance<sup>\*</sup> de l'allocataire.
       <span class="fr-text--xs">
       <sup>\*</sup> Obligatoire | <sup>\**</sup> Obligatoire si la personne est née en France.

--- a/config/endpoints/api_particulier/cnaf_msa_complementaire_sante_solidaire.yml
+++ b/config/endpoints/api_particulier/cnaf_msa_complementaire_sante_solidaire.yml
@@ -44,8 +44,8 @@
     - assurance maladie
     - mutuelle
   parameters:
-    - Identité pivot ;
-    - ou FranceConnect.
+    - Identité pivot
+    - FranceConnect
   faq:
     - q: "Qu'est-ce qu'une complémentaire santé solidaire ?"
       a: |+

--- a/config/endpoints/api_particulier/cnaf_msa_complementaire_sante_solidaire.yml
+++ b/config/endpoints/api_particulier/cnaf_msa_complementaire_sante_solidaire.yml
@@ -19,7 +19,7 @@
       <p class="fr-badge fr-badge--blue-ecume">![Cette API est FranceConnectée](<%= image_path('api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg') %>){:width="20px"} FranceConnect</p>
       **Avec la [modalité d'appel FranceConnect](<%= cas_usage_path('modalite_appel_france_connect') %>)**.
 
-      <p class="fr-badge fr-badge--green-emeraude">Identité pivot</p>
+      <p class="fr-badge fr-badge--brown-cafe-creme">Identité pivot</p>
       **Avec les données d'identité** : Noms, prénoms, sexe<sup>\*</sup>, date de naissance, code COG de la commune de naissance (COG)<sup>\**</sup> et code COG du pays de naissance<sup>\*</sup> de l'allocataire.
       <span class="fr-text--xs">
       <sup>\*</sup> Obligatoire | <sup>\**</sup> Obligatoire si la personne est née en France.

--- a/config/endpoints/api_particulier/cnaf_msa_quotient_familial_v2.yml
+++ b/config/endpoints/api_particulier/cnaf_msa_quotient_familial_v2.yml
@@ -51,7 +51,7 @@
       <p class="fr-badge fr-badge--blue-ecume">![Cette API est FranceConnectée](<%= image_path('api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg') %>){:width="20px"} FranceConnect</p>
       **Avec la [modalité d'appel FranceConnect](<%= cas_usage_path('modalite_appel_france_connect') %>)**.
 
-      <p class="fr-badge fr-badge--green-emeraude">Identité pivot</p>
+      <p class="fr-badge fr-badge--brown-cafe-creme">Identité pivot</p>
       **Avec les données d'identité** : Noms, prénoms, sexe<sup>\*</sup>, date de naissance, code COG de la commune de naissance<sup>\**</sup> et code COG du pays de naissance<sup>\*</sup> de l'allocataire.
       <span class="fr-text--xs">
       <sup>\*</sup> Obligatoire | <sup>\**</sup> Obligatoire si la personne est née en France.

--- a/config/endpoints/api_particulier/cnaf_msa_quotient_familial_v2.yml
+++ b/config/endpoints/api_particulier/cnaf_msa_quotient_familial_v2.yml
@@ -48,10 +48,10 @@
   parameters_details:
     description: |+
       Cette API propose deux modalités d'appel :
-      <p class="fr-badge fr-badge--green-emeraude">FranceConnect</p>
-      **Avec FranceConnect**.
+      <p class="fr-badge fr-badge--blue-ecume">![Cette API est FranceConnectée](<%= image_path('api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg') %>){:width="20px"} FranceConnect</p>
+      **Avec la [modalité d'appel FranceConnect](<%= cas_usage_path('modalite_appel_france_connect') %>)**.
 
-      <p class="fr-badge fr-badge--blue-ecume">Identité pivot</p>
+      <p class="fr-badge fr-badge--green-emeraude">Identité pivot</p>
       **Avec les données d'identité** : Noms, prénoms, sexe<sup>\*</sup>, date de naissance, code COG de la commune de naissance<sup>\**</sup> et code COG du pays de naissance<sup>\*</sup> de l'allocataire.
       <span class="fr-text--xs">
       <sup>\*</sup> Obligatoire | <sup>\**</sup> Obligatoire si la personne est née en France.

--- a/config/endpoints/api_particulier/cnaf_msa_quotient_familial_v2.yml
+++ b/config/endpoints/api_particulier/cnaf_msa_quotient_familial_v2.yml
@@ -62,8 +62,8 @@
   provider_uids:
     - 'cnaf_msa'
   parameters:
-    - Identité pivot ;
-    - ou FranceConnect.
+    - Identité pivot
+    - FranceConnect
   keywords:
     - composition
     - quotient

--- a/config/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -42,9 +42,9 @@
     - 'cnous'
   keywords: []
   parameters:
-    - Identité pivot ;
-    - ou Identifiant National Étudiant (INE) ;
-    - ou FranceConnect.
+    - Identité pivot
+    - INE
+    - FranceConnect
   faq:
     - q: À quoi correspondent les échelons de bourse ?
       a:

--- a/config/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -24,13 +24,13 @@
   parameters_details:
     description: |+
       Cette API propose trois modalités d'appel :
-      <p class="fr-badge fr-badge--green-emeraude">FranceConnect</p>
-      **Avec FranceConnect**.
-      
+      <p class="fr-badge fr-badge--blue-ecume">![Cette API est FranceConnectée](<%= image_path('api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg') %>){:width="20px"} FranceConnect</p>
+      **Avec la [modalité d'appel FranceConnect](<%= cas_usage_path('modalite_appel_france_connect') %>)**.
+
       <p class="fr-badge fr-badge--purple-glycine">Identifiant</p>
       **Avec l'Identifiant National Étudiant (INE)** : Cet identifiant unique figure notamment sur la carte étudiant.
 
-      <p class="fr-badge fr-badge--blue-ecume">Identité pivot</p>
+      <p class="fr-badge fr-badge--green-emeraude">Identité pivot</p>
       **Avec les données d'identité** : Nom, prénom, sexe, date de naissance et lieu de naissance de l'étudiant (exemple : Angers)<sup>\*</sup>.
       <span class="fr-text--xs">
       <sup>\*</sup>Tous les champs sont facultatifs.

--- a/config/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -30,7 +30,7 @@
       <p class="fr-badge fr-badge--purple-glycine">Identifiant</p>
       **Avec l'Identifiant National Étudiant (INE)** : Cet identifiant unique figure notamment sur la carte étudiant.
 
-      <p class="fr-badge fr-badge--green-emeraude">Identité pivot</p>
+      <p class="fr-badge fr-badge--brown-cafe-creme">Identité pivot</p>
       **Avec les données d'identité** : Nom, prénom, sexe, date de naissance et lieu de naissance de l'étudiant (exemple : Angers)<sup>\*</sup>.
       <span class="fr-text--xs">
       <sup>\*</sup>Tous les champs sont facultatifs.

--- a/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
+++ b/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
@@ -35,7 +35,7 @@
   parameters_details:
     description: |+
       Cette API propose une modalité d'appel :
-      <p class="fr-badge fr-badge--blue-ecume">Identité pivot</p>
+      <p class="fr-badge fr-badge--green-emeraude">Identité pivot</p>
       **Avec les données d'identité** : Nom<sup>\*</sup>, prénom<sup>\*</sup>, sexe<sup>\*</sup> et date de naissance de l'élève<sup>\*</sup>, ainsi que le code UAI de l'établissement<sup>\*</sup> et l'année scolaire<sup>\*</sup> souhaitées.
       <span class="fr-text--xs">
       <sup>\*</sup> Obligatoire.

--- a/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
+++ b/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
@@ -35,7 +35,7 @@
   parameters_details:
     description: |+
       Cette API propose une modalité d'appel :
-      <p class="fr-badge fr-badge--green-emeraude">Identité pivot</p>
+      <p class="fr-badge fr-badge--brown-cafe-creme">Identité pivot</p>
       **Avec les données d'identité** : Nom<sup>\*</sup>, prénom<sup>\*</sup>, sexe<sup>\*</sup> et date de naissance de l'élève<sup>\*</sup>, ainsi que le code UAI de l'établissement<sup>\*</sup> et l'année scolaire<sup>\*</sup> souhaitées.
       <span class="fr-text--xs">
       <sup>\*</sup> Obligatoire.

--- a/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
+++ b/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
@@ -47,7 +47,7 @@
     - 'education_nationale'
   keywords: []
   parameters:
-    - Identité pivot.
+    - Identité pivot
   faq:
     - q: De quelle année scolaire sont les données transmises ?
       a: |+

--- a/config/endpoints/api_particulier/mesri_student_status.yml
+++ b/config/endpoints/api_particulier/mesri_student_status.yml
@@ -48,13 +48,13 @@
   parameters_details:
     description: |+
       Cette API propose trois modalités d'appel :
-      <p class="fr-badge fr-badge--green-emeraude">FranceConnect</p>
-      **Avec FranceConnect**.
+      <p class="fr-badge fr-badge--blue-ecume">![Cette API est FranceConnectée](<%= image_path('api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg') %>){:width="20px"} FranceConnect</p>
+      **Avec la [modalité d'appel FranceConnect](<%= cas_usage_path('modalite_appel_france_connect') %>)**.
 
       <p class="fr-badge fr-badge--purple-glycine">Identifiant</p>
       **Avec l'Identifiant National Étudiant (INE)** : Cet identifiant unique figure notamment sur la carte étudiant.
 
-      <p class="fr-badge fr-badge--blue-ecume">Identité pivot</p>
+      <p class="fr-badge fr-badge--green-emeraude">Identité pivot</p>
       **Avec les données d'identité** : Nom, prénom, sexe, date de naissance et lieu de naissance de l'étudiant (Code COG de la commune ou du pays de naissance)<sup>\*</sup>.
       <span class="fr-text--xs">
       <sup>\*</sup>Tous les champs sont facultatifs.

--- a/config/endpoints/api_particulier/mesri_student_status.yml
+++ b/config/endpoints/api_particulier/mesri_student_status.yml
@@ -54,7 +54,7 @@
       <p class="fr-badge fr-badge--purple-glycine">Identifiant</p>
       **Avec l'Identifiant National Étudiant (INE)** : Cet identifiant unique figure notamment sur la carte étudiant.
 
-      <p class="fr-badge fr-badge--green-emeraude">Identité pivot</p>
+      <p class="fr-badge fr-badge--brown-cafe-creme">Identité pivot</p>
       **Avec les données d'identité** : Nom, prénom, sexe, date de naissance et lieu de naissance de l'étudiant (Code COG de la commune ou du pays de naissance)<sup>\*</sup>.
       <span class="fr-text--xs">
       <sup>\*</sup>Tous les champs sont facultatifs.

--- a/config/endpoints/api_particulier/mesri_student_status.yml
+++ b/config/endpoints/api_particulier/mesri_student_status.yml
@@ -69,9 +69,9 @@
     - 'mesri'
   keywords: []
   parameters:
-    - Identité pivot ;
-    - ou Identifiant National Étudiant (INE) ;
-    - ou FranceConnect.
+    - Identité pivot
+    - INE
+    - FranceConnect
   faq:
     - q: Quelle différence entre le statut "admis" et le statut "inscrit" ?
       a:

--- a/config/endpoints/api_particulier/pole_emploi.yml
+++ b/config/endpoints/api_particulier/pole_emploi.yml
@@ -57,7 +57,7 @@
   provider_uids:
     - 'pole_emploi'
   parameters:
-    - Identifiant Pôle emploi.
+    - Identifiant Pôle emploi
   keywords: []
   faq:
     - q: &pole_emploi_faq_q_1 Périmètre détaillé des catégories de demandeurs d'emploi concernés par l'API.
@@ -124,7 +124,7 @@
   provider_uids:
     - 'pole_emploi'
   parameters:
-    - Identifiant Pôle emploi.
+    - Identifiant Pôle emploi
   keywords: []
   faq:
     - q: Périmètre détaillé des catégories de demandeurs d'emploi concernés par l'API.

--- a/config/endpoints/api_particulier/pole_emploi.yml
+++ b/config/endpoints/api_particulier/pole_emploi.yml
@@ -2,7 +2,7 @@
 - uid: 'pole_emploi/situation'
   path: '/api/v2/situations-pole-emploi'
   ping_url: 'https://particulier.api.gouv.fr/api/pole_emploi_status/ping'
-  position: 700
+  position: 501
   perimeter:
     entity_type_description: &pole_emploi__entity_type_description |+
       L'API concerne **les demandeurs d'emploi ayant été inscrits à Pôle emploi depuis 2010**, y compris ceux dont l'inscription a pris fin.
@@ -79,7 +79,7 @@
 - uid: 'pole_emploi/indemnites'
   path: '/api/v2/paiements-pole-emploi'
   ping_url: 'https://particulier.api.gouv.fr/api/pole_emploi_indemnites/ping'
-  position: 501
+  position: 502
   perimeter:
     entity_type_description: |+
       L'API concerne **les demandeurs d'emploi ayant été inscrits à Pôle emploi depuis 2010**, y compris ceux dont l'inscription a pris fin.

--- a/config/endpoints/template.particulier.yml.example
+++ b/config/endpoints/template.particulier.yml.example
@@ -16,13 +16,13 @@
   parameters_details:
     description: |+
       Cette API propose XXX modalités d'appel :
-      <p class="fr-badge fr-badge--blue-ecume">Identité pivot</p>
+      <p class="r-badge fr-badge--brown-cafe-creme">Identité pivot</p>
       Avec les données d'identité : Lorem ipsum
 
       <p class="fr-badge fr-badge--purple-glycine">Identifiant</p>
       Avec TYPE IDENTIFIANT : Lorem ipsum
 
-      <p class="fr-badge fr-badge--green-emeraude">FranceConnect</p>
+      <p class="fr-badge fr-badge--blue-ecume">FranceConnect</p>
       Avec FranceConnect.
   data:
     description: |+

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -184,7 +184,7 @@ fr:
           title:
             one: "Modalité d'appel"
             other: "Modalités d'appel"
-          link: "Détails des paramètres"
+          link: "Détails des modalités"
         technical_specifications:
           title: "Spécifications techniques :"
           cta: "Consulter le swagger"


### PR DESCRIPTION
- Ajoute lien vers le guide
- Ajoute picto FC
- Ajoute les modalités d'appel sur les cartes du catalogue : https://linear.app/pole-api/issue/API-2158/afficher-les-modalites-dappel-sur-les-cartes-api-du-catalogue

<img width="742" alt="image" src="https://github.com/etalab/admin_api_entreprise/assets/46896006/b27d8812-0784-4c4b-b147-4bd95c40faba">

<img width="1348" alt="image" src="https://github.com/etalab/admin_api_entreprise/assets/46896006/5df5699d-118b-40ee-aec0-a47193f6386b">

