### PR TITLE
environment.rb : ignorer access_logs lors des migrations de base

### DIFF
--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,5 @@ require_relative "application"
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+ActiveRecord::SchemaDumper.ignore_tables = ['access_logs']


### PR DESCRIPTION
C'est sûrement pas tout à fait placé au bon endroit, mais parfois le déploiement de cette application et la migration de base qui l'accompagne cassent le schéma de la table `access_logs`. Cette table est gérée par Ansible et ne doit pas figurer dans `schema.rb` afin d'être ignorée lors des migrations. J'ai trouvé cette méthode [ici](https://stackoverflow.com/questions/1752667/keep-a-table-out-of-schema-rb-during-migrations).