### PR TITLE
Fixing flaky test on prolong suite

### DIFF
--- a/spec/features/prolong_token_build_spec.rb
+++ b/spec/features/prolong_token_build_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe 'follows the prolong token wizard' do
     create(:token, authorization_request:, exp:)
   end
 
+  before do
+    Timecop.freeze
+  end
+
+  after do
+    Timecop.return
+  end
+
   describe 'when user is not authenticated', app: :api_entreprise do
     it 'redirects to the login' do
       go_to_prolong_token_start


### PR DESCRIPTION
Sometimes execution could lead to 1 second diff during execution. Froze time during test execution to match correct behavior without luck

Vu dans l'execution des tests ici : https://github.com/etalab/admin_api_entreprise/actions/runs/8042944900/job/21967165344