### PR TITLE
Harden initial db creation for production

### DIFF
--- a/db/migrate/20221025080557_initial_schema.rb
+++ b/db/migrate/20221025080557_initial_schema.rb
@@ -22,9 +22,11 @@ class InitialSchema < ActiveRecord::Migration[7.0]
       t.index ["external_id"], name: "index_authorization_requests_on_external_id", unique: true, where: "(external_id IS NOT NULL)"
     end
 
-    create_table "access_logs", id: false, force: :cascade do |t|
-      t.timestamptz "timestamp"
-      t.uuid "token_id"
+    if Rails.env.local?
+      create_table "access_logs", id: false, force: :cascade do |t|
+        t.timestamptz "timestamp"
+        t.uuid "token_id"
+      end
     end
 
     create_table "contacts", id: :uuid, default: -> { "gen_random_uuid()" } do |t|


### PR DESCRIPTION
Skip access_logs for production, created with ansible

Ref https://github.com/etalab/admin_api_entreprise/pull/1475