### PR TITLE
Modification doc Recipient

### DIFF
--- a/config/locales/api_particulier/documentation.fr.yml
+++ b/config/locales/api_particulier/documentation.fr.yml
@@ -154,7 +154,7 @@ fr:
 
 
                   {:.fr-highlight.fr-highlight--caution}
-                  > ⚠️ **Ces paramètres sont obligatoires pour les API FranceConnectées. Ils sont optionnels pour les API publiées avant mars 2024 et obligatoires pour celles publiées à partir de cette date. Le caractère requis de ce champ est précisé dans le [swagger](https://particulier.api.gouv.fr/developpeurs/openapi#section/Bienvenue-sur-la-documentation-interactive-d'API-Particulier.).**. Les appels ne comportant pas ces paramètres sont rejetés, et un code erreur vous est renvoyé.
+                  > ⚠️ **Ces paramètres sont obligatoires pour les API FranceConnectées. Ils sont optionnels pour les API publiées avant mars 2024 et obligatoires pour celles publiées à partir de cette date. Le caractère requis de ce champ est précisé dans le [swagger](https://particulier.api.gouv.fr/developpeurs/openapi#section/Bienvenue-sur-la-documentation-interactive-d'API-Particulier.).**. Lorsqu'ils sont obligatoires, les appels ne comportant pas ces paramètres sont rejetés, et un code erreur vous est renvoyé.
 
 
                   Pour chaque endpoint, nous précisons dans le [swagger, rubrique "Query parameters"](<%= developers_openapi_path %>){:target="_blank"} les paramètres obligatoires spécifiques, ci-dessous une explication détaillée des éléments à fournir pour chaque paramètre de traçabilité :

--- a/config/locales/api_particulier/documentation.fr.yml
+++ b/config/locales/api_particulier/documentation.fr.yml
@@ -154,7 +154,7 @@ fr:
 
 
                   {:.fr-highlight.fr-highlight--caution}
-                  > ⚠️ **Ces paramètres sont obligatoires**. Les appels ne comportant pas ces paramètres sont rejetés, et un code erreur vous est renvoyé.
+                  > ⚠️ **Ces paramètres sont obligatoires pour les API FranceConnectées. Ils sont optionnels pour les API publiées avant mars 2024 et obligatoires pour celles publiées à partir de cette date. Le caractère requis de ce champ est précisé dans le [swagger](https://particulier.api.gouv.fr/developpeurs/openapi#section/Bienvenue-sur-la-documentation-interactive-d'API-Particulier.).**. Les appels ne comportant pas ces paramètres sont rejetés, et un code erreur vous est renvoyé.
 
 
                   Pour chaque endpoint, nous précisons dans le [swagger, rubrique "Query parameters"](<%= developers_openapi_path %>){:target="_blank"} les paramètres obligatoires spécifiques, ci-dessous une explication détaillée des éléments à fournir pour chaque paramètre de traçabilité :


### PR DESCRIPTION
- Préciser que le recipient n'est pas obligatoire sur toutes les API