### PR TITLE
Fait réaparaitre le bouton vers les cas d'usage API Gouv

### DIFF
--- a/app/models/abstract_cas_usage.rb
+++ b/app/models/abstract_cas_usage.rb
@@ -16,6 +16,7 @@ class AbstractCasUsage
     endpoints
     endpoints_optional
     endpoints_forbidden
+    link_api_gouv
   ].freeze
 
   attr_accessor(*ATTRIBUTES)


### PR DESCRIPTION
Faire réapparaitre ce bouton : 

<img width="696" alt="image" src="https://github.com/etalab/admin_api_entreprise/assets/46896006/e7b85115-e05c-4f9a-a0ab-6e7b56056ae1">
