### PR TITLE
Harden destroy behaviour of AuthorizationRequest

### DIFF
--- a/app/models/authorization_request.rb
+++ b/app/models/authorization_request.rb
@@ -1,5 +1,5 @@
 class AuthorizationRequest < ApplicationRecord
-  has_many :user_authorization_request_roles, dependent: :nullify do
+  has_many :user_authorization_request_roles, dependent: :destroy do
     def for_user(user)
       where(user:)
     end
@@ -11,14 +11,14 @@ class AuthorizationRequest < ApplicationRecord
     class_name: 'Token',
     foreign_key: 'authorization_request_model_id',
     inverse_of: :authorization_request,
-    dependent: :nullify
+    dependent: :destroy
 
   has_one :active_token, -> { active },
     class_name: 'Token',
     inverse_of: :authorization_request,
     required: false,
     foreign_key: 'authorization_request_model_id',
-    dependent: :nullify
+    dependent: :destroy
 
   validates :external_id, uniqueness: true, allow_blank: true
 

--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -21,6 +21,7 @@ class Token < ApplicationRecord
   has_many :contacts, through: :authorization_request
   has_many :demandeurs, through: :authorization_request
   has_many :access_logs, inverse_of: :token, dependent: nil
+  has_many :magic_links, inverse_of: :token, dependent: :destroy
 
   has_one :demandeur, through: :authorization_request
   delegate :contacts_no_demandeur, :archived?, to: :authorization_request

--- a/spec/models/authorization_request_spec.rb
+++ b/spec/models/authorization_request_spec.rb
@@ -5,6 +5,22 @@ RSpec.describe AuthorizationRequest do
     expect(build(:authorization_request)).to be_valid
   end
 
+  describe 'destroy' do
+    subject(:destroy) { authorization_request.destroy }
+
+    context 'with an authorization request which is linked to multiple models' do
+      let!(:authorization_request) { create(:authorization_request, :with_tokens, :validated, :with_all_contacts) }
+
+      before do
+        create(:magic_link, token: authorization_request.token)
+      end
+
+      it 'does not raise error due to db integrity checks' do
+        expect { destroy }.not_to raise_error
+      end
+    end
+  end
+
   describe 'contacts associations' do
     let(:contact_technique) { create(:user, :contact_technique) }
     let(:contact_metier) { create(:user, :contact_metier) }


### PR DESCRIPTION
1. Destroy N-N association user_authorization_request_roles
2. Destroy magic links linked to tokens
3. Destroy token: token can't be orphan