### PR TITLE
Simplify and fix robots.txt

### DIFF
--- a/config/routes/api_entreprise.rb
+++ b/config/routes/api_entreprise.rb
@@ -63,7 +63,7 @@ constraints(APIEntrepriseDomainConstraint.new) do
 
     get '/open-api.yml', to: ->(env) { [200, {}, [APIEntreprise::OpenAPIDefinition.instance.open_api_definition_content]] }, as: :openapi_definition
     get '/open-api-without-deprecated-paths.yml', to: ->(env) { [200, {}, [APIEntreprise::OpenAPIDefinition.instance.open_api_without_deprecated_paths_definition_content]] }, as: :openapi_without_deprecated_definition
-    get '/robots.txt', to: ->(env) { [200, {}, URI.open('config/seo/api-entreprise/robots.txt')] }
+    get '/robots.txt', to: ->(env) { [200, {}, [File.read('config/seo/robots.txt') % { app: 'entreprise' }]] }
 
     get '/infolettre', to: 'pages#newsletter', as: :newsletter
     get '/mentions-legales', to: 'pages#mentions', as: :mentions

--- a/config/routes/api_particulier.rb
+++ b/config/routes/api_particulier.rb
@@ -8,7 +8,7 @@ constraints(APIParticulierDomainConstraint.new) do
   scope module: :api_particulier do
     get '/auth/api_gouv_particulier/callback', to: 'sessions#create_from_oauth'
     get '/auth/failure', to: 'sessions#failure'
-    get '/robots.txt', to: ->(env) { [200, {}, URI.open('config/seo/api-particulier/robots.txt')] }
+    get '/robots.txt', to: ->(env) { [200, {}, [File.read('config/seo/robots.txt') % { app: 'particulier' }]] }
   end
 
   namespace :api_particulier, path: '' do

--- a/config/seo/api-entreprise/robots.txt
+++ b/config/seo/api-entreprise/robots.txt
@@ -1,6 +1,0 @@
-User-agent: *
-Sitemap: http://entreprise.api.gouv.fr/sitemaps/api-entreprise/sitemap.xml.gz
-
-Disallow: /api/
-Disallow: /compte
-Disallow: /compte/

--- a/config/seo/api-particulier/robots.txt
+++ b/config/seo/api-particulier/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Sitemap: http://entreprise.api.gouv.fr/sitemaps/api-particulier/sitemap.xml.gz

--- a/config/seo/robots.txt
+++ b/config/seo/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Sitemap: http://%{app}.api.gouv.fr/sitemaps/api-%{app}/sitemap.xml.gz
+
+Disallow: /api/
+Disallow: /compte/


### PR DESCRIPTION
URI.open renders a 500 error in dev. Keep it simple and shared (apps are iso now).