### PR TITLE
Validation mailing: group similar cases

### DIFF
--- a/app/lib/authorization_request_condition_facade.rb
+++ b/app/lib/authorization_request_condition_facade.rb
@@ -1,11 +1,11 @@
 class AuthorizationRequestConditionFacade < SimpleDelegator
-  def not_editor_and_all_contacts_have_different_emails?
+  def not_editor_and_demandeur_different_to_other_contacts?
     not_editor_authorization_request &&
-      [
-        demandeur.email,
-        contact_technique&.email,
-        contact_metier&.email
-      ].uniq.count == 3
+      (
+        same_contact_everywhere? ||
+          (demandeur.email != contact_technique&.email &&
+            contact_technique&.email == contact_metier&.email)
+      )
   end
 
   def not_editor_and_all_contacts_have_the_same_email?
@@ -35,5 +35,13 @@ class AuthorizationRequestConditionFacade < SimpleDelegator
 
   def not_editor_authorization_request
     !editor_authorization_request
+  end
+
+  def same_contact_everywhere?
+    [
+      demandeur.email,
+      contact_technique&.email,
+      contact_metier&.email
+    ].uniq.count == 3
   end
 end

--- a/config/datapass_webhooks_entreprise.yml
+++ b/config/datapass_webhooks_entreprise.yml
@@ -103,19 +103,19 @@ production: &production
         condition_on_authorization: 'not_editor_and_all_contacts_have_the_same_email?'
 
       - template: 'embarquement_valide_to_demandeur_seulement'
-        condition_on_authorization: 'not_editor_and_all_contacts_have_different_emails?'
+        condition_on_authorization: 'not_editor_and_demandeur_different_to_other_contacts?'
         to:
           - 'authorization_request.demandeur'
 
       - template: 'embarquement_valide_to_tech_cc_demandeur_metier'
-        condition_on_authorization: 'not_editor_and_all_contacts_have_different_emails?'
+        condition_on_authorization: 'not_editor_and_demandeur_different_to_other_contacts?'
         to:
           - 'authorization_request.contact_technique'
         cc:
           - 'authorization_request.demandeur'
 
       - template: 'embarquement_valide_to_metier_cc_demandeur_tech'
-        condition_on_authorization: 'not_editor_and_all_contacts_have_different_emails?'
+        condition_on_authorization: 'not_editor_and_demandeur_different_to_other_contacts?'
         to:
           - 'authorization_request.contact_metier'
         cc:

--- a/config/datapass_webhooks_particulier.yml
+++ b/config/datapass_webhooks_particulier.yml
@@ -90,12 +90,12 @@ production: &production
         condition_on_authorization: 'not_editor_and_all_contacts_have_the_same_email?'
 
       - template: 'embarquement_valide_to_demandeur_seulement'
-        condition_on_authorization: 'not_editor_and_all_contacts_have_different_emails?'
+        condition_on_authorization: 'not_editor_and_demandeur_different_to_other_contacts?'
         to:
           - 'authorization_request.demandeur'
 
       - template: 'embarquement_valide_to_tech_cc_demandeur'
-        condition_on_authorization: 'not_editor_and_all_contacts_have_different_emails?'
+        condition_on_authorization: 'not_editor_and_demandeur_different_to_other_contacts?'
         to:
           - 'authorization_request.contact_technique'
         cc:

--- a/spec/lib/authorization_request_condition_facade_spec.rb
+++ b/spec/lib/authorization_request_condition_facade_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe AuthorizationRequestConditionFacade do
 
     let(:methods) do
       %i[
-        not_editor_and_all_contacts_have_different_emails?
+        not_editor_and_demandeur_different_to_other_contacts?
         not_editor_and_all_contacts_have_the_same_email?
         not_editor_and_user_is_contact_technique_and_not_contact_metier?
         not_editor_and_user_is_contact_metier_and_not_contact_technique?


### PR DESCRIPTION
Previous version did not send validation emails to contacts if demandeur is different from metier, and metier is the same as technique.

This commit groups this case above with the 3 distincts emails.

Ref https://mattermost.incubateur.net/betagouv/pl/s3mwaj1muifepp7wtc4spsxcwc