### PR TITLE
Harden seeds

### DIFF
--- a/app/lib/seeds.rb
+++ b/app/lib/seeds.rb
@@ -16,6 +16,8 @@ class Seeds
 
     load_all_models!
 
+    ProlongTokenWizard.destroy_all
+
     ActiveRecord::Base.connection.transaction do
       ApplicationRecord.descendants.each(&:delete_all)
       AccessLog.delete_all


### PR DESCRIPTION
Destroy ProlongTokenWizard records before flushing as to avoid foreign key constraint issues while seeding

C'est pas le commit le plus elegant mais OSEF KISS