### PR TITLE
Deprecated APIs are back in catalogue

### DIFF
--- a/app/controllers/api_particulier/endpoints_controller.rb
+++ b/app/controllers/api_particulier/endpoints_controller.rb
@@ -2,8 +2,7 @@ class APIParticulier::EndpointsController < APIParticulierController
   before_action :extract_endpoint, except: :index
 
   def index
-    @endpoints = APIParticulier::Endpoint.all.reject(&:deprecated?)
-      .sort { |endpoint1, endpoint2| helpers.order_by_position_or_status(endpoint1, endpoint2) }
+    @endpoints = APIParticulier::Endpoint.all.sort { |endpoint1, endpoint2| helpers.order_by_position_or_status(endpoint1, endpoint2) }
 
     render 'index', layout: 'api_particulier/no_container'
   end

--- a/app/models/abstract_endpoint.rb
+++ b/app/models/abstract_endpoint.rb
@@ -108,6 +108,7 @@ class AbstractEndpoint < ApplicationAlgoliaSearchableActiveModel
     return 'novelty' if novelty?
     return 'beta' if beta?
     return 'new_version' if new_version?
+    return 'deprecated' if deprecated?
 
     'incoming' if incoming?
   end

--- a/config/endpoints/api_particulier/cnaf_quotient_familial.yml
+++ b/config/endpoints/api_particulier/cnaf_quotient_familial.yml
@@ -4,7 +4,7 @@
     - 'cnav/quotient_familial_v2'
   path: '/api/v2/composition-familiale'
   ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
-  position: 100
+  position: 201
   perimeter:
     entity_type_description: |+
       {:.fr-highlight.fr-highlight--caution}

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -437,3 +437,7 @@ fr:
     label: Nouvelle version
     title: Une nouvelle version de cette API est disponible
     color: blue-ecume
+  deprecated:
+    label: Déprécié
+    title: Cette API est dépreciée
+    color: pink-macaron

--- a/spec/features/api_particulier/endpoints/index_spec.rb
+++ b/spec/features/api_particulier/endpoints/index_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Endpoints index', app: :api_particulier do
   it 'displays endpoints with basic info and link to show' do
     visit endpoints_path
 
-    expect(page).to have_css('.endpoint-card', count: APIParticulier::Endpoint.all.reject(&:deprecated?).count)
+    expect(page).to have_css('.endpoint-card', count: APIParticulier::Endpoint.all.count)
     expect(page).to have_css("##{dom_id(sample_endpoint)}")
 
     within("##{dom_id(sample_endpoint)}") do


### PR DESCRIPTION
We only have CNAF QFv1 and we want it back, but
keeping the "deprecated" tag