### PR TITLE
Use a custom url for each data provider for datapass_reopen_authorization_request_url

### DIFF
--- a/app/helpers/external_url_helper.rb
+++ b/app/helpers/external_url_helper.rb
@@ -4,7 +4,7 @@ module ExternalUrlHelper
   end
 
   def datapass_reopen_authorization_request_url(authorization_request, prolong_token_wizard = nil)
-    url = "#{datapass_base_url}/reopen-enrollment-request/#{authorization_request.external_id}"
+    url = "#{datapass_base_url}/reopen-enrollment-request-api_#{authorization_request.api}/#{authorization_request.external_id}"
 
     url += "?highlightedSections=#{highlight_section(prolong_token_wizard).join(',')}" unless prolong_token_wizard.nil?
 

--- a/spec/helpers_spec/external_url_helper_spec.rb
+++ b/spec/helpers_spec/external_url_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe ExternalUrlHelper, type: :helper do
 
     describe '#datapass_reopen_authorization_request_url' do
       it 'returns the DataPass\' authorization request URL with highlight sections' do
-        expect(datapass_reopen_authorization_request_url(authorization_request, prolong_token_wizard)).to include("datapass.api.gouv.fr/reopen-enrollment-request/#{external_id}?highlightedSections=description,contact_metier,contact_technique")
+        expect(datapass_reopen_authorization_request_url(authorization_request, prolong_token_wizard)).to include("datapass.api.gouv.fr/reopen-enrollment-request-api_#{authorization_request.api}/#{external_id}?highlightedSections=description,contact_metier,contact_technique")
       end
     end
   end


### PR DESCRIPTION
Will be use to handle disjonction between data provider for the redirection between v1->v2.