### PR TITLE
Replacing CNAV by CNAF & MSA label in qf scopes

### DIFF
--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -248,13 +248,13 @@ fr:
       token:
         scope:
           cnaf_quotient_familial:
-            label: CNAV || API Quotient familial || QF
+            label: CNAF & MSA || API Quotient familial || QF
           cnaf_allocataires:
-            label: CNAV || API Quotient familial || Identités allocataire et conjoint
+            label: CNAF & MSA || API Quotient familial || Identités allocataire et conjoint
           cnaf_enfants:
-            label: CNAV || API Quotient familial || Identités enfants
+            label: CNAF & MSA || API Quotient familial || Identités enfants
           cnaf_adresse:
-            label: CNAV || API Quotient familial || Adresse du foyer
+            label: CNAF & MSA || API Quotient familial || Adresse du foyer
           pole_emploi_identite:
             label: France Travail || API statut demandeur d'emploi || Statut et identité du demandeur
           pole_emploi_contact:


### PR DESCRIPTION
Seul éventuel soucis c'est que c'est un peu confusant pour les users de qfv1.

Mais bon vu qu'elle est déprécié IMO osef.