### PR TITLE
Introduce DataPass webhooks v2

### DIFF
--- a/app/controllers/api/datapass_webhooks_v2_controller.rb
+++ b/app/controllers/api/datapass_webhooks_v2_controller.rb
@@ -1,4 +1,4 @@
-class API::DatapassWebhooksController < APIController
+class API::DatapassWebhooksV2Controller < APIController
   include DatapassWebhooks
 
   protected
@@ -7,16 +7,17 @@ class API::DatapassWebhooksController < APIController
     params.permit(
       :event,
       :model_type,
+      :model_id,
       :fired_at,
       data: {}
     ).to_h.symbolize_keys
   end
 
   def datapass_id
-    params[:data][:pass][:id]
+    params[:model_id]
   end
 
   def extract_organizer(kind)
-    DatapassWebhook.const_get(kind.classify)
+    DatapassWebhook::V2.const_get(kind.classify)
   end
 end

--- a/app/controllers/concerns/datapass_webhooks.rb
+++ b/app/controllers/concerns/datapass_webhooks.rb
@@ -1,0 +1,82 @@
+module DatapassWebhooks
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :track_payload_through_sentry
+    before_action :verify_hub_signature!
+  end
+
+  def api_entreprise
+    handle_api('api_entreprise')
+  end
+
+  def api_particulier
+    handle_api('api_particulier')
+  end
+
+  protected
+
+  def datapass_webhook_params
+    fail NotImplementedError
+  end
+
+  def datapass_id
+    fail NotImplementedError
+  end
+
+  def extract_organizer(kind)
+    fail NotImplementedError
+  end
+
+  private
+
+  def handle_api(kind)
+    result = extract_organizer(kind).call(**datapass_webhook_params)
+
+    if result.success?
+      handle_success(result)
+    else
+      render json: {}, status: :unprocessable_entity
+    end
+  end
+
+  def handle_success(result)
+    if event == 'approve'
+      render json: {
+        token_id: result.token_id
+      }.compact
+    else
+      render json: {}
+    end
+  end
+
+  def track_payload_through_sentry
+    Sentry.set_context(
+      'DataPass webhook incoming payload',
+      payload: {
+        datapass_id:,
+        event:
+      }
+    )
+    Sentry.capture_message(
+      'DataPass Incoming Payload',
+      level: 'info'
+    )
+  end
+
+  def event
+    params[:event]
+  end
+
+  def verify_hub_signature!
+    unauthorized unless hub_signature_valid?
+  end
+
+  def hub_signature_valid?
+    HubSignature.new(hub_signature, request.raw_post).valid?
+  end
+
+  def hub_signature
+    request.headers['X-Hub-Signature-256']
+  end
+end

--- a/app/interactors/datapass_webhook/adapt_v2_to_v1.rb
+++ b/app/interactors/datapass_webhook/adapt_v2_to_v1.rb
@@ -1,0 +1,71 @@
+class DatapassWebhook::AdaptV2ToV1 < ApplicationInteractor
+  def call
+    context.event = context.event.sub('authorization_request', 'enrollment')
+    context.data = build_data
+  end
+
+  private
+
+  # rubocop:disable Metrics/AbcSize
+  def build_data
+    {
+      'pass' => {
+        'id' => context.model_id,
+        'intitule' => generic_data['intitule'],
+        'description' => generic_data['description'],
+        'demarche' => context.data['form_uid'],
+        'siret' => context.data['organization']['siret'],
+        'status' => context.data['state'],
+        'copied_from_enrollment_id' => nil,
+        'previous_enrollment_id' => nil,
+        'scopes' => generic_data['scopes'].index_with { |_scope| true },
+        'team_members' => build_team_members,
+        'events' => []
+      }
+    }
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def build_team_members
+    build_contacts + [applicant_as_team_member]
+  end
+
+  def build_contacts
+    {
+      'contact_metier' => 'contact_metier',
+      'contact_technique' => 'responsable_technique'
+    }.each_with_object([]) do |(v2_type, v1_type), acc|
+      acc << {
+        'id' => nil,
+        'uid' => nil,
+        'type' => v1_type,
+        'given_name' => generic_data["#{v2_type}_given_name"],
+        'family_name' => generic_data["#{v2_type}_family_name"],
+        'email' => generic_data["#{v2_type}_email"],
+        'phone_number' => generic_data["#{v2_type}_phone_number"],
+        'job' => generic_data["#{v2_type}_job_title"]
+      }
+    end
+  end
+
+  def applicant_as_team_member
+    {
+      'id' => applicant_data['id'],
+      'uid' => nil,
+      'type' => 'demandeur',
+      'given_name' => applicant_data['given_name'],
+      'family_name' => applicant_data['family_name'],
+      'email' => applicant_data['email'],
+      'phone_number' => applicant_data['phone_number'],
+      'job' => applicant_data['job_title']
+    }
+  end
+
+  def applicant_data
+    context.data['applicant']
+  end
+
+  def generic_data
+    context.data['data']
+  end
+end

--- a/app/interactors/datapass_webhook/extract_mailjet_variables.rb
+++ b/app/interactors/datapass_webhook/extract_mailjet_variables.rb
@@ -2,7 +2,6 @@ class DatapassWebhook::ExtractMailjetVariables < ApplicationInteractor
   def call
     context.mailjet_variables = build_common_mailjet_variables
 
-    add_instructors_variables if event_from_instructor?
     add_token_scopes if token_present?
   end
 
@@ -32,19 +31,6 @@ class DatapassWebhook::ExtractMailjetVariables < ApplicationInteractor
       "#{contact_kind}_last_name" => model.last_name,
       "#{contact_kind}_email" => model.email
     }
-  end
-
-  def add_instructors_variables
-    instructor_payload = latest_authorization_request_event['user']
-
-    context.mailjet_variables['instructor_first_name'] = instructor_payload['given_name']
-    context.mailjet_variables['instructor_last_name'] = instructor_payload['family_name']
-  end
-
-  def latest_authorization_request_event
-    context.data['pass']['events'].min do |event1, event2|
-      DateTime.parse(event2['created_at']).to_i <=> DateTime.parse(event1['created_at']).to_i
-    end
   end
 
   def event_from_instructor?

--- a/app/organizers/datapass_webhook/v2/api_entreprise.rb
+++ b/app/organizers/datapass_webhook/v2/api_entreprise.rb
@@ -1,0 +1,10 @@
+module DatapassWebhook::V2
+  class APIEntreprise < ApplicationOrganizer
+    before do
+      context.api = 'entreprise'
+    end
+
+    organize ::DatapassWebhook::AdaptV2ToV1,
+      ::DatapassWebhook::APIEntreprise
+  end
+end

--- a/app/organizers/datapass_webhook/v2/api_particulier.rb
+++ b/app/organizers/datapass_webhook/v2/api_particulier.rb
@@ -1,0 +1,10 @@
+module DatapassWebhook::V2
+  class APIParticulier < ApplicationOrganizer
+    before do
+      context.api = 'particulier'
+    end
+
+    organize ::DatapassWebhook::AdaptV2ToV1,
+      ::DatapassWebhook::APIParticulier
+  end
+end

--- a/config/routes/api_entreprise.rb
+++ b/config/routes/api_entreprise.rb
@@ -2,6 +2,8 @@ constraints(APIEntrepriseDomainConstraint.new) do
   namespace :api do
     post '/datapass/api_entreprise/webhook' => 'datapass_webhooks#api_entreprise'
     post '/datapass/api_particulier/webhook' => 'datapass_webhooks#api_particulier'
+
+    post '/datapass/v2/api_entreprise/webhook' => 'datapass_webhooks_v2#api_entreprise'
   end
 
   post '/auth/api_gouv_entreprise', as: :login_api_gouv_entreprise

--- a/config/routes/api_particulier.rb
+++ b/config/routes/api_particulier.rb
@@ -1,6 +1,7 @@
 constraints(APIParticulierDomainConstraint.new) do
   namespace :api do
     post '/datapass/api_particulier/webhook' => 'datapass_webhooks#api_particulier'
+    post '/datapass/v2/api_particulier/webhook' => 'datapass_webhooks_v2#api_particulier'
   end
 
   post '/auth/api_gouv_particulier', as: :login_api_gouv_particulier

--- a/spec/factories/datapass_webhooks_v2.rb
+++ b/spec/factories/datapass_webhooks_v2.rb
@@ -1,0 +1,62 @@
+FactoryBot.define do
+  sequence(:datapass_webhook_v2_id, &:to_i)
+
+  factory :datapass_webhook_v2, class: Hash do
+    initialize_with { attributes.stringify_keys }
+
+    event { %w[refuse_application refuse].sample }
+    model_id { generate(:datapass_webhook_v2_id) }
+    model_type { 'authorization_request/api_entreprise' }
+    fired_at { Time.zone.now.to_i }
+    data factory: :datapass_webhook_data_v2
+  end
+
+  factory :datapass_webhook_data_v2, class: Hash do
+    initialize_with { attributes.stringify_keys }
+
+    state { %w[approved refused].sample }
+    form_uid { 'api-entreprise' }
+    applicant factory: :datapass_webhook_applicant_v2
+    organization factory: :datapass_webhook_organization_v2
+    data factory: :datapass_webhook_data_data_v2
+  end
+
+  factory :datapass_webhook_applicant_v2, class: Hash do
+    initialize_with { attributes.stringify_keys }
+
+    id { generate(:datapass_webhook_v2_id) }
+    email { 'applicant@gouv.fr' }
+    given_name { 'Nicolas' }
+    family_name { 'Demandeur' }
+    job_title { 'CEO' }
+    phone_number { '0123456789' }
+  end
+
+  factory :datapass_webhook_organization_v2, class: Hash do
+    initialize_with { attributes.stringify_keys }
+
+    id { generate(:datapass_webhook_v2_id) }
+    siret { '13002526500013' }
+    raison_sociale { 'DINUM' }
+  end
+
+  factory :datapass_webhook_data_data_v2, class: Hash do
+    initialize_with { attributes.stringify_keys }
+
+    intitule { 'Intitule' }
+    description { 'Description' }
+    scopes { %w[association entreprises] }
+
+    contact_technique_email { 'tech@gouv.fr' }
+    contact_technique_given_name { 'Jean' }
+    contact_technique_family_name { 'Tech' }
+    contact_technique_job { 'CTO' }
+    contact_technique_phone { '0123456789' }
+
+    contact_metier_email { 'metier@gouv.fr' }
+    contact_metier_phone_number { '0123456789' }
+    contact_metier_given_name { 'Jacques' }
+    contact_metier_family_name { 'Metier' }
+    contact_metier_job_title { 'CMO' }
+  end
+end

--- a/spec/interactors/datapass_webhook/extract_mailjet_variables_spec.rb
+++ b/spec/interactors/datapass_webhook/extract_mailjet_variables_spec.rb
@@ -26,24 +26,6 @@ RSpec.describe DatapassWebhook::ExtractMailjetVariables, type: :interactor do
     expect(subject.mailjet_variables['token_scopes']).to be_nil
   end
 
-  context 'when event is from an instructor' do
-    let(:event) { %w[refuse_application refuse].sample }
-
-    it 'sets instructor first and last name' do
-      expect(subject.mailjet_variables['instructor_first_name']).to eq('Instructor first name')
-      expect(subject.mailjet_variables['instructor_last_name']).to eq('Instructor last name')
-    end
-  end
-
-  context 'when event is not from an instructor' do
-    let(:event) { %w[created create].sample }
-
-    it 'does not set instructor first and last name' do
-      expect(subject.mailjet_variables['instructor_first_name']).to be_nil
-      expect(subject.mailjet_variables['instructor_last_name']).to be_nil
-    end
-  end
-
   context 'when authorization request has a token' do
     let!(:token) { create(:token, authorization_request:) }
 

--- a/spec/organizers/datapass_webhook/v2/api_entreprise_spec.rb
+++ b/spec/organizers/datapass_webhook/v2/api_entreprise_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatapassWebhook::V2::APIEntreprise, type: :interactor do
+  subject { described_class.call(datapass_webhook_params) }
+
+  let(:datapass_webhook_params) do
+    build(
+      :datapass_webhook_v2,
+      event: 'approve',
+      demarche: 'editeurs'
+    )
+  end
+
+  let(:token) { create(:token) }
+
+  before do
+    allow(Mailjet::Contactslist_managemanycontacts).to receive(:create)
+  end
+
+  it_behaves_like 'datapass webhooks', 'v2'
+
+  it 'creates one contact metier' do
+    expect { subject }.to change(UserAuthorizationRequestRole.where(role: 'contact_metier'), :count).by(1)
+  end
+
+  it 'creates an authorization request with entreprise api and demarche' do
+    expect(subject.authorization_request.api).to eq('entreprise')
+    expect(subject.authorization_request.demarche).to eq('api-entreprise')
+  end
+
+  describe 'when contact metier is empty (non-regression test)' do
+    before do
+      %w[family_name given_name email phone_number job_title].each do |attribute|
+        datapass_webhook_params['data']['data']["contact_metier_#{attribute}"] = nil
+      end
+    end
+
+    it 'creates token for API Entreprise and stores id in token_id' do
+      expect {
+        subject
+      }.to change(Token, :count).by(1)
+
+      token = Token.find(subject.token_id)
+
+      expect(token.api).to eq('entreprise')
+    end
+  end
+
+  describe 'Mailjet adding contacts' do
+    it 'adds contacts to Entreprise mailjet list' do
+      expect(Mailjet::Contactslist_managemanycontacts).to receive(:create).with(
+        id: Rails.application.credentials.mj_list_id_entreprise!,
+        action: 'addnoforce',
+        contacts: [
+          {
+            email: 'applicant@gouv.fr',
+            properties: {
+              'contact_demandeur' => true,
+              'contact_métier' => false,
+              'contact_technique' => false,
+              'nom' => 'Demandeur',
+              'prénom' => 'Nicolas'
+            }
+          },
+          {
+            email: 'metier@gouv.fr',
+            properties: {
+              'contact_demandeur' => false,
+              'contact_métier' => true,
+              'contact_technique' => false,
+              'nom' => 'Metier',
+              'prénom' => 'Jacques'
+            }
+          },
+          {
+            email: 'tech@gouv.fr',
+            properties: {
+              'contact_demandeur' => false,
+              'contact_métier' => false,
+              'contact_technique' => true,
+              'nom' => 'Tech',
+              'prénom' => 'Jean'
+            }
+          }
+        ]
+      )
+
+      subject
+    end
+  end
+
+  describe 'when demandeur, contact technique and contact metier are the same' do
+    let(:email) { generate(:email) }
+
+    before do
+      %w[contact_metier contact_technique].each do |role|
+        %w[family_name given_name email].each do |attribute|
+          datapass_webhook_params['data']['data']["#{role}_#{attribute}"] = datapass_webhook_params['data']['applicant'][attribute]
+        end
+      end
+    end
+
+    it 'creates one contact metier' do
+      expect {
+        subject
+      }.to change(UserAuthorizationRequestRole.where(role: 'contact_metier'), :count).by(1)
+    end
+  end
+end

--- a/spec/organizers/datapass_webhook/v2/api_particulier_spec.rb
+++ b/spec/organizers/datapass_webhook/v2/api_particulier_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DatapassWebhook::V2::APIParticulier, type: :interactor do
+  subject { described_class.call(datapass_webhook_params) }
+
+  let(:datapass_webhook_params) do
+    params = build(:datapass_webhook_v2, event: 'approve')
+
+    %w[family_name given_name email phone_number job_title].each do |attribute|
+      params['data']['data'].delete "contact_metier_#{attribute}"
+    end
+
+    params['data']['data']['scopes'] = ['cnaf_quotient_familial']
+
+    params
+  end
+
+  before do
+    allow(Mailjet::Contactslist_managemanycontacts).to receive(:create)
+  end
+
+  it_behaves_like 'datapass webhooks', 'v2'
+
+  it 'creates an authorization request with particulier api' do
+    expect(subject.authorization_request.api).to eq('particulier')
+  end
+
+  it 'does not creates contact metier' do
+    expect {
+      subject
+    }.not_to change(UserAuthorizationRequestRole.where(role: 'contact_metier'), :count)
+  end
+
+  it 'creates token for API Particulier' do
+    subject
+
+    last_token = Token.last
+
+    expect(last_token.api).to eq('particulier')
+  end
+
+  describe 'Mailjet adding contacts' do
+    it 'adds contacts to Entreprise mailjet list' do
+      expect(Mailjet::Contactslist_managemanycontacts).to receive(:create).with(
+        id: Rails.application.credentials.mj_list_id_particulier!,
+        action: 'addnoforce',
+        contacts: [
+          {
+            email: 'applicant@gouv.fr',
+            properties: {
+              'contact_demandeur' => true,
+              'contact_technique' => false,
+              'nom' => 'Demandeur',
+              'prénom' => 'Nicolas'
+            }
+          },
+          {
+            email: 'tech@gouv.fr',
+            properties: {
+              'contact_demandeur' => false,
+              'contact_technique' => true,
+              'nom' => 'Tech',
+              'prénom' => 'Jean'
+            }
+          }
+        ]
+      )
+
+      subject
+    end
+  end
+end


### PR DESCRIPTION
NYI in DataPass v2.

We use an adapter to keep this PR small and reuse v1 format, thanks to the iso aspect.

Full ~iso with v1, will be some iteration to add more data (like the `data` key within the example payload below), in order to handle future `modalities` ( ref https://github.com/etalab/data_pass/pull/237 ))

Ref https://gist.github.com/skelz0r/07d6a797804652f5b2496897d124820a