### PR TITLE
Bugfix: try to displays archived authorization token

### DIFF
--- a/app/views/shared/authorization_requests/index.html.erb
+++ b/app/views/shared/authorization_requests/index.html.erb
@@ -36,14 +36,14 @@
             <h2 class="fr-h6 fr-mb-0"><%= authorization_request.intitule %></h2>
               <%= authorization_request_status_badge(authorization_request) %>
               <span class="fr-hint-text">
-                <%= link_to t('.links.to_datapass', external_id: authorization_request.external_id).html_safe, 
-                  datapass_authorization_request_url(authorization_request), 
+                <%= link_to t('.links.to_datapass', external_id: authorization_request.external_id).html_safe,
+                  datapass_authorization_request_url(authorization_request),
                   id: dom_id(authorization_request, :authorization_request_link),
-                  class: %w(fr-link fr-text--sm fr-mt-2v), 
-                  target: '_blank' 
+                  class: %w(fr-link fr-text--sm fr-mt-2v),
+                  target: '_blank'
                 %>
               </span>
-              <span class="fr-text--xs"><span class="fr-icon-user-fill fr-icon--xs fr-pr-1v" aria-hidden="true"></span>Vous êtes  
+              <span class="fr-text--xs"><span class="fr-icon-user-fill fr-icon--xs fr-pr-1v" aria-hidden="true"></span>Vous êtes
                 <%= authorization_request.user_authorization_request_roles.for_user(@current_user).map { |uarr|
                   I18n.t("user_authorization_request_roles.role.#{uarr.role}")
                   }.join(', ')
@@ -51,13 +51,16 @@
               </span>
             </div>
             <div class="fr-col-12 fr-col-sm-4 fr-p-0 center">
-              <%= render partial: 'shared/tokens/detail_short', 
-                locals: {
-                  token: authorization_request.token.decorate
-                }
-              %>
-              <% authorization_request.tokens.blacklisted_later.decorate.each do |banned_token| %> 
-                <%= render partial: 'shared/tokens/detail_short', 
+              <% if authorization_request.token %>
+                <%= render partial: 'shared/tokens/detail_short',
+                  locals: {
+                    token: authorization_request.token.decorate
+                  }
+                %>
+              <% end %>
+
+              <% authorization_request.tokens.blacklisted_later.decorate.each do |banned_token| %>
+                <%= render partial: 'shared/tokens/detail_short',
                   locals: {
                     token: banned_token.decorate
                   }


### PR DESCRIPTION
`viewable_by_users` includes archived authorization requests, did not have a required token in that state (we can go from draft to archived)

Closes https://errors.data.gouv.fr/organizations/sentry/issues/137139/