### PR TITLE
Fix error when endpoint missing

### DIFF
--- a/app/models/api_entreprise/endpoint.rb
+++ b/app/models/api_entreprise/endpoint.rb
@@ -40,7 +40,7 @@ class APIEntreprise::Endpoint < AbstractEndpoint
   def load_dummy_definition!
     missing_endpoints_definition = I18n.t("api_entreprise.missing_endpoints.#{path}", default: nil)
 
-    raise 'Endpoint(s) not found, check endpoints paths are available in OpenAPI file or in missing_endpoints.yml' if missing_endpoints_definition.nil?
+    raise "Endpoint(s) #{path} not found, check endpoints paths are available in OpenAPI file or in missing_endpoints.yml" if missing_endpoints_definition.nil?
 
     @open_api_definition = missing_endpoints_definition.stringify_keys
     @dummy_definition = true

--- a/app/models/api_entreprise/endpoint.rb
+++ b/app/models/api_entreprise/endpoint.rb
@@ -38,7 +38,8 @@ class APIEntreprise::Endpoint < AbstractEndpoint
   end
 
   def load_dummy_definition!
-    missing_endpoints_definition = I18n.t("api_entreprise.missing_endpoints.#{path}")
+    missing_endpoints_definition = I18n.t("api_entreprise.missing_endpoints.#{path}", default: nil)
+
     raise 'Endpoint(s) not found, check endpoints paths are available in OpenAPI file or in missing_endpoints.yml' if missing_endpoints_definition.nil?
 
     @open_api_definition = missing_endpoints_definition.stringify_keys


### PR DESCRIPTION
We expect a hash to call "stringify_keys",
or raise if nil (when value is absent).
I18n returns "Translation missing" string if absent, which isn't caught by "nil?" and errors with "stringify_keys".