### PR TITLE
Modification date de fin de distribution de l'API

### DIFF
--- a/config/endpoints/api_particulier/cnaf_quotient_familial.yml
+++ b/config/endpoints/api_particulier/cnaf_quotient_familial.yml
@@ -9,7 +9,7 @@
   perimeter:
     entity_type_description: |+
       {:.fr-highlight.fr-highlight--caution}
-      > ⚠️ **Cette API ne sera plus en production à partir de janvier 2025**. Les données seront intégrées dans l'[API CNAF MSA](https://particulier.api.gouv.fr/catalogue/cnav/quotient_familial_v2) à partir de janvier 2024.
+      > ⚠️ **Cette API ne sera plus en production à partir de mai 2025**. Les données seront intégrées dans l'[API CNAF MSA](https://particulier.api.gouv.fr/catalogue/cnav/quotient_familial_v2) à partir de janvier 2024.
 
       Cette API concerne les **allocataires de la majorité des régimes** :
       - ✅ le régime général ;


### PR DESCRIPTION
L'API n'a été mise en production qu'en mai 2024 au lieu de janvier 2024. On a donc décidé de repousser la fin de la distribution de l'API à mai 2025 pour laisser un an aux éditeurs/FS de faire la bascule. Dans l'infolettre envoyée en mai pour annoncer la v2, j'ai annoncé mai comme fin de distribution de l'API. 

(Délai qu'il faudrait peut être revoir au regard des problèmes d'identification des usagers dans la nouvelle API)