### PR TITLE
Revert "running all tests on dependabot prs"

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -7,6 +7,7 @@ on: [push]
 jobs:
   security:
     name: Brakeman
+    if: "${{ github.actor != 'dependabot[bot]' }}"
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -103,6 +104,7 @@ jobs:
         run: bundle exec rspec
 
       - uses: joshmfrankel/simplecov-check-action@main
+        if: "${{ github.actor != 'dependabot[bot]' }}"
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           minimum_suite_coverage: 95


### PR DESCRIPTION
This reverts commit 7b81a0b4d2aa843495f1bd9396309c11fcc4a8b9.

This was desirable after all, brakeman is useless for dependabot and simplecov can simply not be run by the integrator.