### PR TITLE
API Paiement FranceTravail : mieux mettre en avant le fait de vérifier le lien entre identité du particulier et identifiant

### DIFF
--- a/config/endpoints/api_particulier/pole_emploi.yml
+++ b/config/endpoints/api_particulier/pole_emploi.yml
@@ -101,7 +101,9 @@
 
       <p class="fr-badge fr-badge--purple-glycine">Identifiant</p>
       **Avec l'identifiant du compte utilisateur France Travail** : Cet identifiant est celui choisi par le particulier lors de la création de son espace personnel en ligne.
-      ⚠️ Pour utiliser cette API, il est indispensable de recouper ce paramètre d'appel avec l'identité du particulier. [Consulter les CGU spécifiques](#api_cgu).
+      
+      {:.fr-highlight.fr-highlight--caution}
+      > ⚠️ **Avant d'utiliser la donnée issue de l'API**, il est indispensable de vérifier que l'identifiant FranceTravail, utilisé en paramètre d'appel, correspond à l'identité du particulier. Pour cela vous devez effectuer un appel sur l'API statut demandeur d'emploi : [Consulter les CGU spécifiques](#api_cgu).
 
       <section class="fr-accordion">
         <h3 class="fr-accordion__title">


### PR DESCRIPTION
## Avant : 
<img width="715" alt="image" src="https://github.com/user-attachments/assets/3372278a-c889-47ad-b53b-b634405e6864">


## Après : 
<img width="703" alt="image" src="https://github.com/user-attachments/assets/b00a1c90-ee70-4e66-970e-caeae11856dc">
