### PR TITLE
API-3675 Supprimer le mot "qualiopi" inscrit 2 fois

### DIFF
--- a/config/endpoints/api_entreprise/carif_oref_certifications_qualiopi_france_competences.yml
+++ b/config/endpoints/api_entreprise/carif_oref_certifications_qualiopi_france_competences.yml
@@ -50,7 +50,7 @@
     description: |+
       Cette API permet de savoir si un établissement est habilité à former. Elle indique :
       - **le ou les numéros de déclaration d'activité**, si l'établissement en possède ;
-      - **si l'établissement est certifié Qualiopi Qualiopi** au moment de l'appel et s'il est qualifié _Action formation_, _Bilan Compétences_, _VAE_ ou _Apprentissage_ ;
+      - **si l'établissement est certifié Qualiopi** au moment de l'appel et s'il est qualifié _Action formation_, _Bilan Compétences_, _VAE_ ou _Apprentissage_ ;
       - **la liste des habilitations France Compétences**, pour les établissements certifiés.
 
       [NDA, Qualiopi, France Compétences, quelles différences ?](#faq_entry_0_api_entreprise_endpoint_carif_oref_certifications_qualiopi_france_competences)


### PR DESCRIPTION
Le mot "Qualiopi" était inscrit 2 fois . 

