### PR TITLE
[API Statut étudiant boursier] Correction de la documentation

### DIFF
--- a/config/endpoints/api_particulier/cnaf_msa_quotient_familial_v2.yml
+++ b/config/endpoints/api_particulier/cnaf_msa_quotient_familial_v2.yml
@@ -55,27 +55,47 @@
       **Avec la [modalité d'appel FranceConnect](<%= cas_usage_path('modalite_appel_france_connect') %>)**.
 
       <p class="fr-badge fr-badge--brown-cafe-creme">Identité pivot</p>
-      **Avec les données d'identité** :
+      <section class="fr-accordion fr-mt-2v">
+        <p class="fr-accordion__title">
+        <button class="fr-accordion__btn" aria-expanded="false" aria-controls="accordion-106"><b>Avec les données d'identité</b></button>
+        </p>
+        <div class="fr-collapse" id="accordion-106">
+        <div class="fr-mb-0">
+        <ul>
+          <li>Nom de naissance<sup>*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>*</sup>, date de naissance de l'allocataire<sup>**</sup>&nbsp;;</li>
+          <li>Lieu de naissance&nbsp;:
+          <ul>
+            <li>
+            <em>Si le lieu de naissance est en France,</em> la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
+            <ul>
+              <li class="fr-text--sm fr-mb-0">
+              Option 1 : Code COG de la commune de naissance<sup>*</sup>. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>&nbsp;;
+              </li>
+              <li class="fr-text--sm fr-mb-0">
+              Option 2 : Nom de la commune de naissance<sup>*</sup> et code du département de naissance<sup>*</sup>. Pour cette option, la date de naissance est obligatoire. <a href="#renseigner-lieu-de-naissance">En savoir plus</a>.
+              </li>
+            </ul>
+            Pour chacune des deux options ci-dessus, le code COG de la France <code>99100</code><sup>*</sup> doit également être renseigné en paramètre d'appel. Vous n'avez pas besoin de le demander à l'usager, il peut être déduit de la commune de naissance.
+            </li>
+            <li class="fr-mt-2v">
+            <em>Si le lieu de naissance est à l'étranger&nbsp;:</em> code COG du pays de naissance<sup>*</sup>.
+            </li>
+          </ul>
+          </li>
+        </ul>
+        </div>
+        <span class="fr-text--xs">
+        <sup>*</sup> Obligatoire | <sup>**</sup> Obligatoire pour l'option 2 du lieu de naissance.
+        </span>
+        <span class="fr-text--xs fr-m-0">
+        <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
+        </span>
+        <blockquote class="fr-highlight fr-highlight--caution">
+        ⚠️ <strong>Message API Particulier du 04.06.2024</strong> : Nous avons constaté que les appels effectués sans nom de naissance et <strong>avec le nom d'usage ne fonctionnent pas</strong> dans une très grande partie des cas. Après investigation auprès de la CNAV (opérateur de l'API source), API Particulier a donc décidé de passer le paramètre "Nom de naissance" en obligatoire.
+        </blockquote>
+        </div>
+      </section>
 
-        {:.fr-mb-0}
-        - Nom de naissance<sup>\*</sup>, nom d'usage, prénoms<sup>1</sup>, sexe<sup>\*</sup>, date de naissance de l'allocataire<sup>\**</sup>&nbsp;;
-        - Lieu de naissance&nbsp;: 
-            - *Si le lieu de naissance est en France,* la commune de naissance est obligatoire, elle peut être saisie de deux façons différentes :
-                - {:.fr-text--sm .fr-mb-0} Option 1 : Code COG de la commune de naissance<sup>\*</sup>. [En savoir plus](#renseigner-lieu-de-naissance)&nbsp;;
-                - {:.fr-text--sm .fr-mb-0} Option 2 : Nom de la commune de naissance<sup>\*</sup> et code du département de naissance<sup>\*</sup>. Pour cette option, la date de naissance est obligatoire. [En savoir plus](#renseigner-lieu-de-naissance).
-                
-              Pour chacune des deux options ci-dessus, le code COG de la France `99100`<sup>\*</sup> doit également être renseigné en paramètre d'appel. Vous n'avez pas besoin de le demander à l'usager, il peut être déduit de la commune de naissance.
-            - *Si le lieu de naissance est à l'étranger&nbsp;:* code COG du pays de naissance<sup>\*</sup>.
-
-      <span class="fr-text--xs">
-      <sup>\*</sup> Obligatoire | <sup>\**</sup> Obligatoire pour l'option 2 du lieu de naissance.
-      </span>
-      <span class="fr-text--xs fr-m-0">
-      <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
-      </span>
-
-      {:.fr-highlight.fr-highlight--caution}
-      > ⚠️ **Message API Particulier du 04.06.2024** : Nous avons constaté que les appels effectués sans nom de naissance et **avec le nom d'usage ne fonctionnent pas** dans une très grande partie des cas. Après investigation auprès de la CNAV (opérateur de l'API source), API Particulier a donc décidé de passer le paramètre "Nom de naissance" en obligatoire.
   provider_uids:
     - 'cnav'
   call_id: 

--- a/config/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -9,7 +9,7 @@
       Cette API délivre **uniquement les bourses "obligatoires"** et ne concerne pas les bourses d'ordre facultatif.
 
       L'API délivre les données sur :
-      - ✅ **le statut de bourse définitif pour les boursiers d’État sur critères sociaux (gérés par les Crous)** ;
+      - ✅ **des boursiers d’État sur critères sociaux (gérés par les Crous)** ;
       - ✅ **le statut de bourse provisoire et définitif pour les boursiers sur critères sociaux des filières sanitaires et sociales** des régions Occitanie, Grand Est, Bourgogne-Franche-Comté, Bretagne et Auvergne-Rhône-Alpes. D'autres régions devraient être couvertes à l'avenir.
 
     geographical_scope_description:  |+

--- a/config/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -8,9 +8,9 @@
     entity_type_description: |+
       Cette API délivre **uniquement les bourses "obligatoires"** et ne concerne pas les bourses d'ordre facultatif.
 
-      L'API délivre les données :
-      - ✅ des **le statut de bourse définitif pour les boursiers d’État sur critères sociaux (gérés par les Crous)** ;
-      - ✅ des **le statut de bourse provisoire et définitif pour les boursiers sur critères sociaux des filières sanitaires et sociales** des régions Occitanie, Grand Est, Bourgogne-Franche-Comté, Bretagne et Auvergne-Rhône-Alpes. D'autres régions devraient être couvertes à l'avenir.
+      L'API délivre les données sur :
+      - ✅ **le statut de bourse définitif pour les boursiers d’État sur critères sociaux (gérés par les Crous)** ;
+      - ✅ **le statut de bourse provisoire et définitif pour les boursiers sur critères sociaux des filières sanitaires et sociales** des régions Occitanie, Grand Est, Bourgogne-Franche-Comté, Bretagne et Auvergne-Rhône-Alpes. D'autres régions devraient être couvertes à l'avenir.
 
     geographical_scope_description:  |+
       L'API couvre :

--- a/config/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -21,7 +21,9 @@
       - ❌ les territoires d'outre-mer ;
       - ❌ les données des étudiants ayant des bourses étrangères.
     updating_rules_description: |+
-      Les données sont **mises à jour tout au long de l'année**, avec une bascule d'année qui se fait à partir de juillet.
+      Les données sont **mises à jour tout au long de l'année**, avec une bascule d'année qui se fait à partir du mois de : 
+      - mai pour les bourses régionales ;
+      - juillet pour les bourses nationales.
   parameters_details:
     description: |+
       Cette API propose trois modalités d'appel :

--- a/config/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -10,14 +10,14 @@
 
       L'API délivre les données sur :
       - ✅ **des boursiers d’État sur critères sociaux (gérés par les Crous)** ;
-      - ✅ **le statut de bourse provisoire et définitif pour les boursiers sur critères sociaux des filières sanitaires et sociales** des régions Occitanie, Grand Est, Bourgogne-Franche-Comté, Bretagne et Auvergne-Rhône-Alpes. D'autres régions devraient être couvertes à l'avenir.
+      - ✅ **des boursiers sur critères sociaux des filières sanitaires et sociales** pour une partie des régions.
 
     geographical_scope_description:  |+
-      L'API couvre :
-      - ✅ la France hexagonale et la Corse pour les bourses d'État; 
-      - ✅ les régions Occitanie, Grand Est, Bourgogne-Franche-Comté, Bretagne et Auvergne-Rhône-Alpes pour les bourses des filières sanitaires et sociales.
+      **L'API couvre :**
+      - ✅ **pour les bourses d'État** : la France hexagonale et la Corse ; 
+      - ✅ **pour les bourses des filières sanitaires et sociales** : les régions Auvergne-Rhône-Alpe, Bourgogne-Franche-Comté, Bretagne, Grand Est, Ile-de-France et Occitanie. _D'autres régions devraient être couvertes à l'avenir._
 
-      Ne sont pas couverts par cette API :
+      **Ne sont pas couverts par cette API :**
       - ❌ les territoires d'outre-mer ;
       - ❌ les données des étudiants ayant des bourses étrangères.
     updating_rules_description: |+
@@ -40,7 +40,9 @@
       </span>
   data:
     description: |+
-      Cette API **indique si un étudiant est boursier et permet de connaître le montant de la bourse** perçue grâce à l'échelon et la durée de versement.
+      Cette API **indique si un étudiant est boursier et permet de connaître le montant de la bourse** perçue grâce à l'échelon et la durée de versement. 
+
+      _Uniquement pour les bourses sur critères sociaux des filières sanitaires et sociales, en région,_ il est indiqué si l'échelon de bourse est définitif ou provisoire.
   provider_uids:
     - 'cnous'
   keywords: []

--- a/config/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -14,7 +14,7 @@
 
     geographical_scope_description:  |+
       L'API couvre :
-      - ✅ la France Hexagonale et la Corse pour les bourses d'Etat; 
+      - ✅ la France hexagonale et la Corse pour les bourses d'État; 
       - ✅ les régions Occitanie, Grand Est, Bourgogne-Franche-Comté, Bretagne et Auvergne-Rhône-Alpes pour les bourses des filières sanitaires et sociale.
 
       Ne sont pas couverts par cette API :

--- a/config/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -9,19 +9,19 @@
       Cette API délivre **uniquement les bourses "obligatoires"** et ne concerne pas les bourses d'ordre facultatif.
 
       L'API délivre les données :
-      - ✅ des **boursiers d’État sur critères sociaux (gérés par les Crous)** ;
-      - ✅ des **boursiers sur critères sociaux des filières sanitaires et sociales** des régions Normandie et Occitanie. D'autres régions devraient être couvertes à l'avenir.
+      - ✅ des **le statut de bourse définitif pour les boursiers d’État sur critères sociaux (gérés par les Crous)** ;
+      - ✅ des **le statut de bourse provisoire et définitif pour les boursiers sur critères sociaux des filières sanitaires et sociales** des régions Occitanie, Grand Est, Bourgogne-Franche-Comté, Bretagne et Auvergne-Rhône-Alpes. D'autres régions devraient être couvertes à l'avenir.
 
     geographical_scope_description:  |+
       L'API couvre :
-      - ✅ les territoire français, dont les ✅ DROM ; _uniquement régions Normandie et Occitanie pour les bourses des filières sanitaires et sociales_ ;
-      - ✅ les boursiers de nationalité française.
+      - ✅ la France Hexagonale et la Corse pour les bourses d'Etat; 
+      - ✅ les régions Occitanie, Grand Est, Bourgogne-Franche-Comté, Bretagne et Auvergne-Rhône-Alpes pour les bourses des filières sanitaires et sociale.
 
       Ne sont pas couverts par cette API :
       - ❌ les territoires d'outre-mer ;
-      - ❌ les données des étudiants boursiers étrangers.
+      - ❌ les données des étudiants ayant des bourses étrangères.
     updating_rules_description: |+
-      Les données sont **mises à jour une fois par an**, début septembre, une fois tous les étudiants inscrits.
+      Les données sont **mises à jour tout au long de l'année**, avec une bascule d'année qui se fait à partir de juillet.
   parameters_details:
     description: |+
       Cette API propose trois modalités d'appel :

--- a/config/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -15,7 +15,7 @@
     geographical_scope_description:  |+
       L'API couvre :
       - ✅ la France hexagonale et la Corse pour les bourses d'État; 
-      - ✅ les régions Occitanie, Grand Est, Bourgogne-Franche-Comté, Bretagne et Auvergne-Rhône-Alpes pour les bourses des filières sanitaires et sociale.
+      - ✅ les régions Occitanie, Grand Est, Bourgogne-Franche-Comté, Bretagne et Auvergne-Rhône-Alpes pour les bourses des filières sanitaires et sociales.
 
       Ne sont pas couverts par cette API :
       - ❌ les territoires d'outre-mer ;

--- a/config/endpoints/api_particulier/cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/cnous_student_scholarship.yml
@@ -21,7 +21,7 @@
       - ❌ les territoires d'outre-mer ;
       - ❌ les données des étudiants ayant des bourses étrangères.
     updating_rules_description: |+
-      Les données sont **mises à jour tout au long de l'année**, avec une bascule d'année qui se fait à partir du mois de : 
+      Les données sont **mises à jour tout au long de l'année**. Une bascule d'année s'effectue à la fin de l'année scolaire, les données concernant la rentrée suivante sont alors disponibles (et remplacent l'année en cours) à partir du mois de : 
       - mai pour les bourses régionales ;
       - juillet pour les bourses nationales.
   parameters_details:


### PR DESCRIPTION
Suite à mon point avec le CNOUS le 11.10, j'ai modifié la doc pour : 
- ajouter de nouvelles régions pour les bourses sanitaires et sociales (et retirer la région Normandie, qui n'est pas inclus)
- retirer les DROM dans les territoires que couvre l'API (pas encore conventionnés donc non inclus)
- supprimer la mention qui dit que ça n'inclut que les boursiers français : pas de distinction de nationalité, tant qu'ils ont une bourse gérée par le CNOUS ou une bourse régionale, ils sont inclus. J'ai modifié en mettant que ça n'intègre pas les bourses étrangères (même ceux de l'UE). ça me paraît évident, mais sait on jamais.