### PR TITLE
Remove token ids from dashboard view

### DIFF
--- a/app/views/shared/tokens/_detail.html.erb
+++ b/app/views/shared/tokens/_detail.html.erb
@@ -3,25 +3,22 @@
     <p class="fr-badge fr-badge--<%= t(".status.color.#{token.status}") %>">
       <%= t(".status.label.#{token.status}") %>
     </p>
-    <span class="fr-text--xs">
-      idenfitiant: <%= token.id %>
-    </span>
     <span class="fr-text--m fr-text--bold uppercase fr-text--xs">
       | <%= t('.call_for_a_week', count: token.access_logs.since(7.days.ago).count) %>
     </span>
     <%= link_to t('.links.stats'), token_stats_path(token), id: dom_id(token, :stats_link), class: %w(fr-link fr-link--sm fr-icon-arrow-right-line fr-link--icon-right pull-right) %>
   </div>
   <p class="fr-mb-1v">
-  <%= t(".remaining_time.#{token.status}", 
+  <%= t(".remaining_time.#{token.status}",
         remaining_time: distance_of_time_in_words(Time.zone.now, token.end_timestamp)
        ).html_safe %>
   </p>
   <div class="progress-bar-light-grey progress-bar-round">
-    <div 
-      class="progress-bar-container progress-bar-round progress-bar-<%= token.progress_bar_color %>" 
+    <div
+      class="progress-bar-container progress-bar-round progress-bar-<%= token.progress_bar_color %>"
       style="width:<%= token.passed_time_as_ratio %>%">
     </div>
-  </div> 
+  </div>
   <span class=""><%= friendly_date_from_timestamp(token.created_at)%></span>
   <span class="pull-right"><%= friendly_date_from_timestamp(token.end_timestamp)%></span>
 </div>

--- a/app/views/shared/tokens/_detail_short.html.erb
+++ b/app/views/shared/tokens/_detail_short.html.erb
@@ -9,16 +9,12 @@
     <p>
       <p class="fr-badge fr-badge--<%= t(".status.color.#{token.status}") %>">
       <%= t(".status.label.#{token.status}") %>
-      </p>     
+      </p>
       <span class="fr-mb-1v fr-text--sm">
-    |  <%= t(".expiration_date", 
+    |  <%= t(".expiration_date",
           expiration_date: friendly_date_from_timestamp(token.end_timestamp)
         ).html_safe %>
       </span>
-      <p class="fr-mb-1v" style="text-overflow: ellipsis; overflow: hidden;
-white-space: nowrap;">
-        <span class="fr-text--xs" >ID: <%= token.id %></span>
-      </p>
     </p>
   </div>
 <% end %>

--- a/spec/features/api_particulier/authorization_request_show_spec.rb
+++ b/spec/features/api_particulier/authorization_request_show_spec.rb
@@ -124,13 +124,11 @@ RSpec.describe 'displays show of authorization request', app: :api_particulier d
 
             expect(page).to have_content('Jeton principal :')
             expect(page).to have_content('Actif')
-            expect(page).to have_content(token.id)
             expect(page).to have_content('4 appels les 7 derniers jours')
             expect(page).to have_content(distance_of_time_in_words(Time.zone.now, token.exp))
 
             expect(page).to have_css('#' << dom_id(token, :stats_link))
 
-            expect(page).to have_content(banned_token.id)
             expect(page).to have_content('Banni')
             expect(page).to have_content(distance_of_time_in_words(Time.zone.now, banned_token.blacklisted_at))
             expect(page).to have_content('0 appel les 7 derniers jours')


### PR DESCRIPTION
Not really important, confuse users, so flip it