### PR TITLE
API Particulier : FIX invalid path for API Status

### DIFF
--- a/config/routes/api_particulier.rb
+++ b/config/routes/api_particulier.rb
@@ -10,7 +10,7 @@ constraints(APIParticulierDomainConstraint.new) do
     get '/auth/api_gouv_particulier/callback', to: 'sessions#create_from_oauth'
     get '/auth/failure', to: 'sessions#failure'
     get '/robots.txt', to: ->(env) { [200, {}, [File.read('config/seo/robots.txt') % { app: 'particulier' }]] }
-    get '/apis/status', to: 'pages#current_status', as: :api_particulier_current_status
+    get '/status/apis', to: 'pages#current_status', as: :api_particulier_current_status
   end
 
   namespace :api_particulier, path: '' do


### PR DESCRIPTION
Because of nginx config, everything starting with /api is routed on siade, not the website.

Just had to change the URL