### PR TITLE
schema : évite de supprimer access_logs si elle existe déjà

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,7 +16,7 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_07_111810) do
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
 
-  create_table "access_logs", id: false, force: :cascade do |t|
+  create_table "access_logs", id: false, force: false, if_not_exists: true do |t|
     t.timestamptz "timestamp"
     t.uuid "token_id"
   end


### PR DESCRIPTION
Pour éviter de casser le schéma de table mis en place côté système.

Dans l'état actuel, le déploiement des recettes Ansible pour cette application est cassé à cause de ça.