### PR TITLE
Préciser que l'API ne délivre plus notion de bourse

### DIFF
--- a/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
+++ b/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
@@ -7,6 +7,8 @@
   perimeter:
     entity_type_description: |+
       Cette API concerne les **✅ élèves de la maternelle, du primaire, du collège et du lycée**.
+      {:.fr-highlight.fr-highlight--caution}
+       Attention, cette API ne délivre plus de données en lien avec la bourse de puis décembre 2024 : statut boursier et échelon de la bourse. La notion de bourse sera réintroduite dans l'API courant 2025.
 
       Une **large majorité d'établissements** sont concernés :
       - ✅ établissements publics ;

--- a/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
+++ b/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
@@ -4,11 +4,13 @@
   path: '/api/v2/scolarites'
   ping_url: 'https://particulier.api.gouv.fr/api/men_scolarite/ping'
   position: 500
+  alert:
+    title: "Données de bourse indisponibles"
+    description: |+
+      Cette API ne délivre plus de données en lien avec la bourse depuis décembre 2024 : statut boursier et échelon de la bourse. La notion de bourse sera réintroduite dans l'API courant 2025.
   perimeter:
     entity_type_description: |+
       Cette API concerne les **✅ élèves de la maternelle, du primaire, du collège et du lycée**.
-      {:.fr-highlight.fr-highlight--caution}
-       Attention, cette API ne délivre plus de données en lien avec la bourse de puis décembre 2024 : statut boursier et échelon de la bourse. La notion de bourse sera réintroduite dans l'API courant 2025.
 
       Une **large majorité d'établissements** sont concernés :
       - ✅ établissements publics ;


### PR DESCRIPTION
@DorineLam preneuse de ton point de vue 
Il faudrait modifier la doc métier de l'API élève scolarisé et boursier pour préciser qu'il n'y a plus la bourse. La bourse devrait être réintégré dans l'API courant 2025

- je retire toute mention de la bourse dans la doc métier

ou 

- je mets juste une alerte au début de la doc pour prévenir qu'on ne délivre plus le statut boursier

Je suis plutôt pour la 2ème option pour que les FS puissent quand même se documenter sur la notion de bourse (mise à jour, bascule d'année etc.)/se projeter mais tu as peut être un avis différent ?

Ici une proposition avec la 2ème option.