### PR TITLE
Fix URI gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'bcrypt', '~> 3.1.20'
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 
+gem 'uri', '1.0.3'
+
 gem 'good_job', '~> 3.99'
 
 gem 'draper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -678,6 +678,7 @@ DEPENDENCIES
   timecop
   turbo-rails
   unindent
+  uri (= 1.0.3)
   web-console (>= 4.1.0)
   webmock
   wicked


### PR DESCRIPTION
During deployment, when bundler is installing or updating gems, it might be trying to activate different versions of the uri gem. The error message shows uri 1.0.2 (base version from our Ruby version) is activated but the Gemfile requires uri 1.0.3

there's a version conflict between what's already loaded and what bundler wants to load.

Other solution: update deployment process to include bundle clean --force