### PR TITLE
Removing modality from catalogue titles

### DIFF
--- a/app/models/abstract_endpoint.rb
+++ b/app/models/abstract_endpoint.rb
@@ -60,7 +60,7 @@ class AbstractEndpoint < ApplicationAlgoliaSearchableActiveModel
   end
 
   def title
-    @title ||= open_api_definition['summary']
+    @title ||= open_api_definition['summary'].gsub(/\[.*?\]/, '').strip
   end
 
   def description

--- a/spec/models/api_particulier/endpoint_spec.rb
+++ b/spec/models/api_particulier/endpoint_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe APIParticulier::Endpoint do
     its(:attributes) { is_expected.to be_an_instance_of(Hash) }
     its(:attributes) { is_expected.to have_key('allocataires') }
     its(:attributes) { is_expected.to have_key('adresse') }
+
+    its(:title) { is_expected.to eq('Quotient familial CAF & MSA') }
   end
 
   describe '#test_cases_external_url' do


### PR DESCRIPTION
This only impacts API Particulier.
All api part v3 endpoint are prefixed with the [modality] This PR removes from the title the modality to have a better display.

This is a temporary fix to enhance display waiting for more adaptation to the api part v3 swagger format