### PR TITLE
Catalogue API Particulier - migration V3

### DIFF
--- a/app/controllers/api_particulier/endpoints_controller.rb
+++ b/app/controllers/api_particulier/endpoints_controller.rb
@@ -16,6 +16,12 @@ class APIParticulier::EndpointsController < APIParticulierController
   private
 
   def extract_endpoint
-    @endpoint = APIParticulier::Endpoint.find(params[:uid])
+    @endpoint = endpoint_class.find(params[:uid])
+  end
+
+  def endpoint_class
+    return APIParticulier::EndpointV2 if params[:uid].include?('/v2/')
+
+    APIParticulier::Endpoint
   end
 end

--- a/app/models/abstract_endpoint.rb
+++ b/app/models/abstract_endpoint.rb
@@ -24,9 +24,11 @@ class AbstractEndpoint
 
   def self.all
     endpoints_store_class.all.map do |endpoint|
-      APIParticulier::EndpointV2.new(endpoint) if api_particulier_v2?(endpoint)
-
-      new(endpoint)
+      if api_particulier_v2?(endpoint)
+        APIParticulier::EndpointV2.new(endpoint) if api_particulier_v2?(endpoint)
+      else
+        new(endpoint)
+      end
     end
   end
 
@@ -57,13 +59,13 @@ class AbstractEndpoint
   end
 
   def title
-    if open_api_definition.present? && open_api_definition['summary'].present?
-      @title ||= open_api_definition['summary'].gsub(/\[.*?\]/, '').strip
-    else
-      @title ||= "Titre indisponible"
-    end
+    @title ||= if open_api_definition.present? && open_api_definition['summary'].present?
+                 open_api_definition['summary'].gsub(/\[.*?\]/, '').strip
+               else
+                 'Titre indisponible'
+               end
   end
-  
+
   def description
     @description ||= open_api_definition['description']
   end
@@ -137,11 +139,6 @@ class AbstractEndpoint
 
   def redoc_anchor
     @redoc_anchor ||= "tag/#{tag_for_redoc}/paths/#{path_for_redoc}/get"
-  end
-
-  def tag_for_redoc
-    uid_without_prefix = @endpoint.uid.sub(/^v\d+\//, '') # retire "v2/", "v3/", etc.
-    uid_without_prefix.tr('/', '-')
   end
 
   def example_payload

--- a/app/models/abstract_endpoint.rb
+++ b/app/models/abstract_endpoint.rb
@@ -23,11 +23,9 @@ class AbstractEndpoint
   attr_writer :new_endpoint_uids, :old_endpoint_uids
 
   def self.all
-    all_endpoints = endpoints_store_class.all.map do |endpoint|
-      new(endpoint) unless api_particulier_v2?(endpoint)
+    endpoints_store_class.all.map do |endpoint|
+      new(endpoint)
     end
-
-    all_endpoints.compact
   end
 
   def self.find(uid)
@@ -40,10 +38,6 @@ class AbstractEndpoint
 
   def self.not_found(uid)
     ActiveRecord::RecordNotFound.new("uid '#{uid}' does not exist in #{endpoints_store_class}", self, :uid, uid)
-  end
-
-  def self.api_particulier_v2?(endpoint)
-    api == 'api_particulier' && endpoint['swagger_version'] == 2
   end
 
   def self.endpoints_store_class

--- a/app/models/abstract_endpoint.rb
+++ b/app/models/abstract_endpoint.rb
@@ -90,6 +90,10 @@ class AbstractEndpoint
     novelty.present? && novelty
   end
 
+  def from_v2?
+    false
+  end
+
   def new_version?
     new_version.present? && new_version
   end

--- a/app/models/abstract_endpoint.rb
+++ b/app/models/abstract_endpoint.rb
@@ -57,9 +57,13 @@ class AbstractEndpoint
   end
 
   def title
-    @title ||= open_api_definition['summary'].gsub(/\[.*?\]/, '').strip
+    if open_api_definition.present? && open_api_definition['summary'].present?
+      @title ||= open_api_definition['summary'].gsub(/\[.*?\]/, '').strip
+    else
+      @title ||= "Titre indisponible"
+    end
   end
-
+  
   def description
     @description ||= open_api_definition['description']
   end

--- a/app/models/abstract_endpoint.rb
+++ b/app/models/abstract_endpoint.rb
@@ -4,6 +4,7 @@ class AbstractEndpoint
   include ActiveModel::Model
 
   attr_accessor :uid,
+    :swagger_version,
     :path,
     :beta,
     :alert,
@@ -23,6 +24,8 @@ class AbstractEndpoint
 
   def self.all
     endpoints_store_class.all.map do |endpoint|
+      APIParticulier::EndpointV2.new(endpoint) if api_particulier_v2?(endpoint)
+
       new(endpoint)
     end
   end
@@ -32,7 +35,13 @@ class AbstractEndpoint
 
     raise not_found(uid) if available_endpoint.blank?
 
+    return APIParticulier::EndpointV2.new(available_endpoint) if api_particulier_v2?(available_endpoint)
+
     new(available_endpoint)
+  end
+
+  def self.api_particulier_v2?(endpoint)
+    api == 'api_particulier' && endpoint['swagger_version'] == 2
   end
 
   def self.not_found(uid)

--- a/app/models/abstract_endpoint.rb
+++ b/app/models/abstract_endpoint.rb
@@ -139,6 +139,11 @@ class AbstractEndpoint
     @redoc_anchor ||= "tag/#{tag_for_redoc}/paths/#{path_for_redoc}/get"
   end
 
+  def tag_for_redoc
+    uid_without_prefix = @endpoint.uid.sub(/^v\d+\//, '') # retire "v2/", "v3/", etc.
+    uid_without_prefix.tr('/', '-')
+  end
+
   def example_payload
     @example_payload ||= response_schema['example'] ||
                          OpenAPISchemaToExample.new(response_schema).perform

--- a/app/models/abstract_endpoint.rb
+++ b/app/models/abstract_endpoint.rb
@@ -4,7 +4,6 @@ class AbstractEndpoint
   include ActiveModel::Model
 
   attr_accessor :uid,
-    :swagger_version,
     :path,
     :beta,
     :alert,

--- a/app/models/api_particulier/abstract_endpoint.rb
+++ b/app/models/api_particulier/abstract_endpoint.rb
@@ -15,6 +15,6 @@ class APIParticulier::AbstractEndpoint < AbstractEndpoint
   end
 
   def self.api_particulier_v2?(endpoint)
-    api == 'api_particulier' && endpoint['swagger_version'] == 2
+    api == 'api_particulier' && endpoint['uid'].include?('/v2/')
   end
 end

--- a/app/models/api_particulier/abstract_endpoint.rb
+++ b/app/models/api_particulier/abstract_endpoint.rb
@@ -1,0 +1,20 @@
+class APIParticulier::AbstractEndpoint < AbstractEndpoint
+  attr_accessor :call_id,
+    :opening
+
+  def description
+    "#{super.split('.').first}."
+  end
+
+  def collection?
+    false
+  end
+
+  def maintenances
+    open_api_definition['x-maintenances']
+  end
+
+  def self.api_particulier_v2?(endpoint)
+    api == 'api_particulier' && endpoint['swagger_version'] == 2
+  end
+end

--- a/app/models/api_particulier/endpoint.rb
+++ b/app/models/api_particulier/endpoint.rb
@@ -1,17 +1,11 @@
-class APIParticulier::Endpoint < AbstractEndpoint
-  attr_accessor :data,
-    :call_id,
-    :opening
+class APIParticulier::Endpoint < APIParticulier::AbstractEndpoint
+  attr_accessor :data
 
-  def description
-    "#{super.split('.').first}."
-  end
+  def self.all
+    all_endpoints = endpoints_store_class.all.map do |endpoint|
+      new(endpoint) unless api_particulier_v2?(endpoint)
+    end
 
-  def maintenances
-    open_api_definition['x-maintenances']
-  end
-
-  def collection?
-    false
+    all_endpoints.compact
   end
 end

--- a/app/models/api_particulier/endpoint_v2.rb
+++ b/app/models/api_particulier/endpoint_v2.rb
@@ -2,6 +2,14 @@ class APIParticulier::EndpointV2 < AbstractEndpoint
   attr_accessor :call_id,
     :opening
 
+  def self.all
+    v2_endpoints = endpoints_store_class.all.map do |endpoint|
+      new(endpoint) if api_particulier_v2?(endpoint)
+    end
+
+    v2_endpoints.compact
+  end
+
   def open_api_definition
     @open_api_definition ||= APIParticulier::OpenAPIDefinitionV2.get(path)
   end

--- a/app/models/api_particulier/endpoint_v2.rb
+++ b/app/models/api_particulier/endpoint_v2.rb
@@ -1,7 +1,4 @@
-class APIParticulier::EndpointV2 < AbstractEndpoint
-  attr_accessor :call_id,
-    :opening
-
+class APIParticulier::EndpointV2 < APIParticulier::AbstractEndpoint
   def self.all
     v2_endpoints = endpoints_store_class.all.map do |endpoint|
       new(endpoint) if api_particulier_v2?(endpoint)
@@ -16,18 +13,6 @@ class APIParticulier::EndpointV2 < AbstractEndpoint
 
   def open_api_definition
     @open_api_definition ||= APIParticulier::OpenAPIDefinitionV2.get(path)
-  end
-
-  def description
-    "#{super.split('.').first}."
-  end
-
-  def maintenances
-    open_api_definition['x-maintenances']
-  end
-
-  def collection?
-    false
   end
 
   def extract_data_from_schema

--- a/app/models/api_particulier/endpoint_v2.rb
+++ b/app/models/api_particulier/endpoint_v2.rb
@@ -1,0 +1,25 @@
+class APIParticulier::EndpointV2 < AbstractEndpoint
+  attr_accessor :call_id,
+    :opening
+
+  def open_api_definition
+    @open_api_definition ||= APIParticulier::OpenAPIDefinitionV2.get(path)
+  end
+
+  def description
+    "#{super.split('.').first}."
+  end
+
+  def maintenances
+    open_api_definition['x-maintenances']
+  end
+
+  def collection?
+    false
+  end
+
+  def extract_data_from_schema
+    data_attributes_to_dig = %w[responses 200 content application/json schema properties]
+    open_api_definition.dig(*data_attributes_to_dig)
+  end
+end

--- a/app/models/api_particulier/endpoint_v2.rb
+++ b/app/models/api_particulier/endpoint_v2.rb
@@ -10,6 +10,10 @@ class APIParticulier::EndpointV2 < AbstractEndpoint
     v2_endpoints.compact
   end
 
+  def from_v2?
+    true
+  end
+
   def open_api_definition
     @open_api_definition ||= APIParticulier::OpenAPIDefinitionV2.get(path)
   end

--- a/app/services/api_particulier/open_api_definition_v2.rb
+++ b/app/services/api_particulier/open_api_definition_v2.rb
@@ -1,0 +1,5 @@
+class APIParticulier::OpenAPIDefinitionV2 < APIParticulier::OpenAPIDefinition
+  def remote_url(_)
+    super('v2')
+  end
+end

--- a/app/views/api_entreprise/endpoints/_use_cases.html.erb
+++ b/app/views/api_entreprise/endpoints/_use_cases.html.erb
@@ -6,11 +6,10 @@
       <%= t('.main.title') %>
     </h2>
 
-    <div>
-      <%= t('.main.description') %>
-    </div>
-
     <% if @endpoint.use_cases.any? %>
+      <div>
+        <%= t('.main.description') %>
+      </div>
       <ul class="fr-tags-group fr-mt-2w">
         <% @endpoint.use_cases.each do |use_case| %>
           <li class="fr-mb-1w">

--- a/app/views/api_entreprise/endpoints/show.html.erb
+++ b/app/views/api_entreprise/endpoints/show.html.erb
@@ -43,7 +43,34 @@
           <%= markdown_to_html(@endpoint.extra_description) %>
         <% end %>
       </p>
+
+
+    <nav class="" role="navigation">
+        <ul class="">
+            <li>
+                <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#perimetre">Périmètre de l'API</a>
+            </li>
+            <li>
+                <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#parameters_details">Modalités d'appel</a>
+            </li>
+            <li>
+                <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#donnees">Données distribuées</a>
+            </li>
+            <li>
+                <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#faq">Q & R</a>
+            </li>
+             <% if @endpoint.historicized? %>
+             <li>
+                <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#cgu">Historique de version</a>
+            </li>
+            <% end %>
+            <li>
+                <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#cgu">Conditions d'utilisation</a>
+            </li>
+          </ul>
+      </nav>
     </div>
+
 
     <div class="providers fr-col-md-<%= 12 - layout_main_bloc %> fr-col-12">
       <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">

--- a/app/views/api_particulier/endpoints/_details.html.erb
+++ b/app/views/api_particulier/endpoints/_details.html.erb
@@ -58,9 +58,18 @@
     <%= t('.technical_specifications.title') %>
   </h3>
 
-  <%= link_to t('.technical_specifications.cta'), developers_openapi_path(anchor: @endpoint.redoc_anchor), data: { turbo: false }, class: %(fr-btn fr-btn--icon-right fr-icon-arrow-right-line) %>
+   <% if @endpoint.swagger_version.present? %>
+   
+    <%= link_to t('.technical_specifications.cta'), 
+    "https://particulier.api.gouv.fr/developpeurs/openapi-v2##{@endpoint.redoc_anchor}", 
+    data: { turbo: false }, 
+    class: "fr-btn fr-btn--icon-right fr-icon-arrow-right-line" %>
 
-  <a href="<%= @endpoint.test_cases_external_url %>" target="_blank" class="fr-btn fr-btn--secondary fr-mt-2w">
-    <%= t('.test_cases') %>
-  </a>
+  <% else %>
+    <%= link_to t('.technical_specifications.cta'), developers_openapi_path(anchor: @endpoint.redoc_anchor), data: { turbo: false }, class: %(fr-btn fr-btn--icon-right fr-icon-arrow-right-line) %>
+
+    <a href="<%= @endpoint.test_cases_external_url %>" target="_blank" class="fr-btn fr-btn--secondary fr-mt-2w">
+      <%= t('.test_cases') %>
+    </a>
+  <% end %>
 </div>

--- a/app/views/api_particulier/endpoints/_details.html.erb
+++ b/app/views/api_particulier/endpoints/_details.html.erb
@@ -58,8 +58,8 @@
     <%= t('.technical_specifications.title') %>
   </h3>
 
-   <% if @endpoint.swagger_version.present? %>
-   
+   <% if @endpoint.from_v2? %>
+
     <%= link_to t('.technical_specifications.cta'), 
     "https://particulier.api.gouv.fr/developpeurs/openapi-v2##{@endpoint.redoc_anchor}", 
     data: { turbo: false }, 

--- a/app/views/api_particulier/endpoints/_use_cases.html.erb
+++ b/app/views/api_particulier/endpoints/_use_cases.html.erb
@@ -1,21 +1,36 @@
 <% extra_classes ||= '' %>
 
-<% if @endpoint.use_cases.any? %>
+<% if @endpoint.use_cases.any? || @endpoint.use_cases_optional.any? %>
   <div class="details <%= extra_classes %>">
     <h2 class="fr-h3" id="<%= id %>">
       <%= t('.main.title') %>
     </h2>
+    
+    <% if @endpoint.use_cases.any? %>
+      <div>
+        <%= t('.main.description') %>
+      </div>
+      <ul class="fr-tags-group fr-mt-2w">
+        <% @endpoint.use_cases.each do |use_case| %>
+          <li class="fr-mb-1w">
+            <%= link_to use_case.name, cas_usage_path(uid: use_case.uid), class: %w[fr-tag] %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
 
-    <div>
-      <%= t('.main.description') %>
-    </div>
+    <% if @endpoint.use_cases_optional.any? %>
+      <div>
+        <%= t('.optional.description') %>
+      </div>
 
-    <ul class="fr-tags-group fr-mt-2w">
-      <% @endpoint.use_cases.each do |use_case| %>
-        <li class="fr-mb-1w">
-          <%= link_to use_case.name, cas_usage_path(uid: use_case.uid), class: %w[fr-tag] %>
-        </li>
-      <% end %>
-    </ul>
+      <ul class="fr-tags-group fr-mt-2w">
+        <% @endpoint.use_cases_optional.each do |use_case| %>
+          <li class="fr-mb-1w">
+            <%= link_to use_case.name, cas_usage_path(uid: use_case.uid), class: %w[fr-tag] %>
+          </li>
+        <% end %>
+      </ul>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/api_particulier/endpoints/index.html.erb
+++ b/app/views/api_particulier/endpoints/index.html.erb
@@ -21,7 +21,9 @@
     <div class="fr-grid-row">
       <div class="fr-col-12">
         <div class="fr-grid-row">
-          <%= render @endpoints %>
+          <%= @endpoints.each do |endpoint| %>
+            <%= render 'api_particulier/endpoints/endpoint', endpoint: %>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/api_particulier/endpoints/index.html.erb
+++ b/app/views/api_particulier/endpoints/index.html.erb
@@ -21,9 +21,7 @@
     <div class="fr-grid-row">
       <div class="fr-col-12">
         <div class="fr-grid-row">
-          <%= @endpoints.each do |endpoint| %>
-            <%= render 'api_particulier/endpoints/endpoint', endpoint: %>
-          <% end %>
+          <%= render @endpoints %>
         </div>
       </div>
     </div>

--- a/app/views/api_particulier/endpoints/show.html.erb
+++ b/app/views/api_particulier/endpoints/show.html.erb
@@ -49,6 +49,11 @@
             <li>
                 <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#faq">Q & R</a>
             </li>
+             <% if @endpoint.historicized? %>
+             <li>
+                <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#cgu">Historique de version</a>
+            </li>
+            <% end %>
             <li>
                 <a class="fr-link fr-fi-arrow-down-line fr-link--icon-right" href="#cgu">Conditions d'utilisation</a>
             </li>

--- a/app/views/api_particulier/endpoints/show.html.erb
+++ b/app/views/api_particulier/endpoints/show.html.erb
@@ -112,7 +112,7 @@
             <ul>
               <% @endpoint.new_endpoints.each do |endpoint| %>
                 <li>
-                  <%= link_to endpoint.title, endpoint_path(uid: endpoint.uid) %>
+                  <%= link_to endpoint.uid, endpoint_path(uid: endpoint.uid) %>
                 </li>
               <% end %>
             </ul>

--- a/app/views/api_particulier/endpoints/show.html.erb
+++ b/app/views/api_particulier/endpoints/show.html.erb
@@ -244,6 +244,7 @@
                 </li>
               <% end %>
             </ul>
+            <p class="fr-text--sm fr-mt-4w"><%= t('.historique.old_endpoints.link_documentation').html_safe %></p>
           <% end %>
         <% end %>
 

--- a/config/api-particulier-openapi-v2.yml
+++ b/config/api-particulier-openapi-v2.yml
@@ -1,0 +1,3316 @@
+---
+openapi: 3.0.0
+info:
+  title: API Particulier
+  version: 2.2.0
+  description: |
+    ## Bienvenue sur la documentation interactive d'API Particulier.
+
+    ### Commencer à utiliser l'API
+
+    API Particulier est une API en accès restreint, ce qui signifie qu'il vous faut remplir une [demande d'habilitation](https://datapass.api.gouv.fr) avant de pouvoir l'utiliser avec des vraies données.
+
+    Afin de tester l'API avant la validation de votre demande d'habilitation, nous avons mis en place un bac à sable de l'API qui reproduit les comportements de l'API en production.
+
+    Dans le bac à sable, pour chaque type de donnée disponible, un jeu de donnée libre en édition est mis à votre disposition, afin que vous puissiez faire vos tests en toute autonomie.
+
+    Le fonctionnement du bac à sable est identique à celui de la véritable API de production, à la différence près que les données sont fictives, éditables par tout le monde, et que les jetons d'accès sont en libre service.
+
+    Le bac à sable et l'API de production sont appelables par deux adresses distinctes :
+
+    - bac à sable : [https://staging.particulier.api.gouv.fr](https://staging.particulier.api.gouv.fr)
+    - production : [https://particulier.api.gouv.fr](https://particulier.api.gouv.fr)
+
+    Pour récupérer le jeton de production un portail développeur est mis à votre disposition à l'adresse suivante : [https://particulier.api.gouv.fr/compte](https://particulier.api.gouv.fr/compte)
+
+    Pour effectuer vos tests sur le bac à sable, référez-vous à ce dépôt github: [etalab/siade_staging_data](https://github.com/etalab/siade_staging_data/) (l'ancien système basé sur Airtable n'est plus maintenu et va être remplacé par le nouveau système). Un jeton nommé default est disponible ici: [tokens](https://github.com/etalab/siade_staging_data/tree/develop/tokens)
+
+    ### Accéder à la version 3 de l'API
+
+    L'API particulier v3 est actuellement en version beta, vous pouvez accéder à sa documentation [ici](https://particulier.api.gouv.fr/developpeurs/openapi-v3).
+
+
+    ### Périmètre des données retournées
+
+    **Important :** le contenu du jeu de données retourné dépend des _scopes_ ou _périmètres_ du jeton utilisé.
+
+    En effet, les disposition de l'article [L144-8](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000045213315) n'autorisent que l'échange des informations **strictement nécessaires** pour traiter une démarche.
+
+    Afin de respecter ce devoir de minimisation de la donnée, chaque jeton est associé, par la demande d'habilitation, à des _scopes_ agissant comme des masques sur la donnée.
+
+    Ainsi, pour pouvoir lire de la donnée, il est nécessaire de cocher lors de votre [demande d'habilitation](https://datapass.api.gouv.fr) une ou plusieurs cases correspondant aux données du même fournisseur, votre jeton possèdera alors les _scopes_ associés aux données cochées.
+
+    En conséquence, suivant le jeton utilisé, une même requête peut retourner des résultats différents.
+
+    **Attention :** La documentation ci-dessous ne prend pas en compte les _scopes_, qui agissent comme masques de la donnée retournée par l'API. Cette documentation suppose donc que votre jeton permet d'accéder à la donnée décrite.
+
+    ### Passer son service en production
+
+    Lors de votre passage en production :
+
+    - remplacez l'URL de staging.particulier.api.gouv.fr à particulier.api.gouv.fr
+    - remplacez le jeton de test par le jeton obtenu sur [le portail API Particulier](https://particulier.api.gouv.fr/compte)
+  termsOfService: https://api.gouv.fr/resources/CGU%20API%20Particulier.pdf
+  contact:
+    name: Contact API Particulier
+    email: api-particulier@api.gouv.fr
+    url: https://particulier.api.gouv.fr/
+  license:
+    name: GNU Affero General Public License v3.0
+    url: https://github.com/betagouv/api-particulier/blob/master/LICENSE
+tags: []
+paths:
+  "/api/v2/allocation-adulte-handicape":
+    get:
+      summary: Statut allocation adulte handicapé (AAH)
+      deprecated: true
+      tags:
+      - Prestations sociales
+      parameters:
+      - name: Cache-Control
+        in: header
+        description: Si cette valeur est fixée à "no-cache", le système de cache est
+          alors ignoré et la donnée est directement récupérée depuis le fournisseur
+          de données.
+        schema:
+          type: string
+      - name: X-Api-Key
+        in: header
+        schema:
+          type: string
+      - name: nomUsage
+        in: query
+        description: Nom d'usage. Ne pas renseigner si présence de jeton FranceConnect.
+        example: DUPONT
+        required: false
+        schema:
+          type: string
+      - name: nomNaissance
+        in: query
+        description: Nom de naissance. Ne pas renseigner si présence de jeton FranceConnect.
+          Le champ est obligatoire pour les appels non FranceConnecté
+        example: JEAN
+        required: false
+        schema:
+          type: string
+      - name: prenoms[]
+        in: query
+        schema:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          example:
+          - PIERRE
+          - RICHARD
+        description: Liste des prénoms. Ne pas renseigner si présence de jeton FranceConnect.
+        required: false
+      - name: anneeDateDeNaissance
+        in: query
+        description: Année de naissance. Ne pas la renseigner si celle-ci est inconnue
+          ou en cas de présence de jeton FranceConnect.
+        example: 1990
+        required: false
+        schema:
+          type: integer
+      - name: moisDateDeNaissance
+        in: query
+        description: Mois de naissance. Ne pas le renseigner si celui-ci est inconnu
+          ou en cas de présence de jeton FranceConnect. Cette valeur est ignorée si
+          anneeDateDeNaissance est vide.
+        example: 1
+        required: false
+        schema:
+          type: integer
+      - name: jourDateDeNaissance
+        in: query
+        description: Jour de naissance. Ne pas le renseigner si celui-ci est inconnu
+          ou en cas de présence de jeton FranceConnect. Cette valeur est ignorée si
+          moisDateDeNaissance ou anneeDateDeNaissance est vide.
+        example: 1
+        required: false
+        schema:
+          type: integer
+      - name: codeInseeLieuDeNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 5
+          maxLength: 5
+          example: '08480'
+        description: Code Insee à 5 chiffres du lieu de naissance de la personne sur
+          5 chiffres. Ne pas remplir si la personne est née à l'étranger ou si présence
+          de jeton FranceConnect. En l'absence de jeton FranceConnect et du triplet
+          (nomCommuneNaissance, anneeDateDeNaissance, codeInseeDepartementNaissance),
+          le champ est obligatoire si la personne est née en France
+        required: false
+      - name: codePaysLieuDeNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 5
+          maxLength: 5
+          example: '99100'
+        description: Code Insee à 5 chiffres du pays de naissance (France = 99100).
+          Obligatoire si absence de jeton FranceConnect.
+        required: false
+      - name: sexe
+        in: query
+        schema:
+          type: string
+          enum:
+          - M
+          - F
+        description: Sexe de la personne, masculin ou féminin. Obligatoire si absence
+          de jeton FranceConnect.
+        example: M
+        required: false
+      - name: nomCommuneNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 1
+          example: Gennevilliers
+        description: Nom de la commune de naissance. En l'absence de jeton FranceConnect
+          et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne
+          est née en France
+        required: false
+      - name: codeInseeDepartementNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 2
+          maxLength: 3
+          example: '92'
+        description: Code INSEE du département de naissance. En l'absence de jeton
+          FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire
+          si la personne est née en France
+        required: false
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données.
+          Ce paramètre est obligatoire dans le cadre des appels via FranceConnect"
+        example: '13002526500013'
+        required: false
+        schema:
+          type: string
+      security:
+      - franceConnectToken: []
+        apiKey: []
+      description: "Statut bénéficiaire de l'allocation adulte handicapé (AAH). \n\n
+        Retourne également des informations sur les dates d'ouverture des droits.
+        \n L'API peut être appellée avec les données identité pivot ou avec un jeton
+        FranceConnect."
+      responses:
+        '200':
+          description: Particulier trouvé
+          headers:
+            X-Response-Cached:
+              schema:
+                type: boolean
+                example: true
+                enum:
+                - true
+                - false
+                default: false
+              description: Indique si la réponse a été caché.
+            X-Cache-Expires-in:
+              schema:
+                type: number
+                nullable: true
+                example: 9001
+              description: Secondes avant que le cache n'expire. Si le cache est vide,
+                ce header est vide (mais présent). La durée du cache est de 1 heure.
+          x-operationId: api_particulier_v2_cnav_allocation_adulte_handicape
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    title: Statut bénéficiaire de l'allocation adulte handicapé (AAH)
+                    type: string
+                    description: Indique si le particulier est bénéficiaire de la
+                      complémentaire de santé solidaire au moment de l'appel.
+                    enum:
+                    - beneficiaire
+                    - non_beneficiaire
+                  dateDebut:
+                    title: Date d'ouverture du droit à l'AAH
+                    type: string
+                    nullable: true
+                    description: |
+                      "Date de début de droit à l'AAH si le particulier est bénéficiaire.
+                      Ce champs est null dans le cas où le particulier n'est pas bénéficiaire de l'AAH."
+                    example: '1992-11-29'
+        '400':
+          description: Mauvais paramètres d'appels
+          content:
+            application/json:
+              examples:
+                unprocessable_entity_error_gender_error:
+                  value:
+                    errors:
+                    - code: '00364'
+                      title: Entité non traitable
+                      detail: Le sexe n'est pas correctement formaté (m ou f)
+                      source:
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Le sexe n'est pas correctement formaté (m ou f)
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Dossier non trouvé
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '503':
+          description: Erreur du fournisseur
+          content:
+            application/json:
+              examples:
+                unknown_error:
+                  value:
+                    errors:
+                    - code: '37999'
+                      title: Erreur inconnue du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et inconnue de notre service. L'équipe technique
+                        a été notifiée de cette erreur pour investigation.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur inconnue du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et inconnue de notre service. L'équipe technique
+                    a été notifiée de cette erreur pour investigation.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '504':
+          description: Erreur d'intermédiaire
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                acces_non_autorise_50002:
+                  value:
+                    errors:
+                    - code: '50002'
+                      title: Accès non autorisé
+                      detail: Le jeton d'accès n'a pas été trouvé ou est expiré.
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: Le jeton d'accès n'a pas été trouvé ou est expiré.
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/api/v2/allocation-soutien-familial":
+    get:
+      summary: Statut allocation de soutien familial (ASF)
+      deprecated: true
+      tags:
+      - Prestations sociales
+      parameters:
+      - name: Cache-Control
+        in: header
+        description: Si cette valeur est fixée à "no-cache", le système de cache est
+          alors ignoré et la donnée est directement récupérée depuis le fournisseur
+          de données.
+        schema:
+          type: string
+      - name: X-Api-Key
+        in: header
+        schema:
+          type: string
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données.
+          Ce paramètre est obligatoire dans le cadre des appels via FranceConnect"
+        example: '13002526500013'
+        required: false
+        schema:
+          type: string
+      - name: nomUsage
+        in: query
+        description: Nom d'usage. Ne pas renseigner si présence de jeton FranceConnect.
+        example: DUPONT
+        required: false
+        schema:
+          type: string
+      - name: nomNaissance
+        in: query
+        description: Nom de naissance. Ne pas renseigner si présence de jeton FranceConnect.
+          Le champ est obligatoire pour les appels non FranceConnecté
+        example: JEAN
+        required: false
+        schema:
+          type: string
+      - name: prenoms[]
+        in: query
+        schema:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          example:
+          - PIERRE
+          - RICHARD
+        description: Liste des prénoms. Ne pas renseigner si présence de jeton FranceConnect.
+        required: false
+      - name: anneeDateDeNaissance
+        in: query
+        description: Année de naissance. Ne pas la renseigner si celle-ci est inconnue
+          ou en cas de présence de jeton FranceConnect.
+        example: 1990
+        required: false
+        schema:
+          type: integer
+      - name: moisDateDeNaissance
+        in: query
+        description: Mois de naissance. Ne pas le renseigner si celui-ci est inconnu
+          ou en cas de présence de jeton FranceConnect. Cette valeur est ignorée si
+          anneeDateDeNaissance est vide.
+        example: 1
+        required: false
+        schema:
+          type: integer
+      - name: jourDateDeNaissance
+        in: query
+        description: Jour de naissance. Ne pas le renseigner si celui-ci est inconnu
+          ou en cas de présence de jeton FranceConnect. Cette valeur est ignorée si
+          moisDateDeNaissance ou anneeDateDeNaissance est vide.
+        example: 1
+        required: false
+        schema:
+          type: integer
+      - name: codeInseeLieuDeNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 5
+          maxLength: 5
+          example: '08480'
+        description: Code Insee à 5 chiffres du lieu de naissance de la personne sur
+          5 chiffres. Ne pas remplir si la personne est née à l'étranger ou si présence
+          de jeton FranceConnect. En l'absence de jeton FranceConnect et du triplet
+          (nomCommuneNaissance, anneeDateDeNaissance, codeInseeDepartementNaissance),
+          le champ est obligatoire si la personne est née en France
+        required: false
+      - name: codePaysLieuDeNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 5
+          maxLength: 5
+          example: '99100'
+        description: Code Insee à 5 chiffres du pays de naissance (France = 99100).
+          Obligatoire si absence de jeton FranceConnect.
+        required: false
+      - name: sexe
+        in: query
+        schema:
+          type: string
+          enum:
+          - M
+          - F
+        description: Sexe de la personne, masculin ou féminin. Obligatoire si absence
+          de jeton FranceConnect.
+        example: M
+        required: false
+      - name: nomCommuneNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 1
+          example: Gennevilliers
+        description: Nom de la commune de naissance. En l'absence de jeton FranceConnect
+          et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne
+          est née en France
+        required: false
+      - name: codeInseeDepartementNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 2
+          maxLength: 3
+          example: '92'
+        description: Code INSEE du département de naissance. En l'absence de jeton
+          FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire
+          si la personne est née en France
+        required: false
+      security:
+      - franceConnectToken: []
+        apiKey: []
+      description: Savoir si un particulier est bénéficiaire de l'allocation de soutien
+        familial (ASF). Retourne également des informations sur les dates d'ouverture
+        et de fermeture des droits. L'API peut être appellée avec les données identité
+        pivot ou avec un jeton FranceConnect.
+      responses:
+        '200':
+          description: Dossier trouvé
+          headers:
+            X-Response-Cached:
+              schema:
+                type: boolean
+                example: true
+                enum:
+                - true
+                - false
+                default: false
+              description: Indique si la réponse a été caché.
+            X-Cache-Expires-in:
+              schema:
+                type: number
+                nullable: true
+                example: 9001
+              description: Secondes avant que le cache n'expire. Si le cache est vide,
+                ce header est vide (mais présent). La durée du cache est de 1 heure.
+          x-operationId: api_particulier_v2_cnav_allocation_soutien_familial
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    title: Statut bénéficiaire de l'allocation de soution familial
+                      (ASF)
+                    type: string
+                    description: Indique si le particulier est bénéficiaire de l'allocation
+                      de soution familial au moment de l'appel.
+                    enum:
+                    - beneficiaire
+                    - non_beneficiaire
+                  dateDebut:
+                    title: Date d'ouverture du droit à l'ASF
+                    type: string
+                    nullable: true
+                    description: "Date de début de droit à l'ASF si le particulier
+                      est bénéficiaire. \n Ce champ est null dans le cas où le particulier
+                      n'est pas bénéficiaire de l'ASF."
+                    example: '1992-11-29'
+                  dateFin:
+                    title: Date de fermeture du droit à l'ASF
+                    type: string
+                    nullable: true
+                    description: Ce champs ne délivrant pas l'information souhaitée à la base il est toujours à null désormais
+                    example: null
+        '400':
+          description: Mauvais paramètres d'appels
+          content:
+            application/json:
+              examples:
+                unprocessable_entity_error_gender_error:
+                  value:
+                    errors:
+                    - code: '00364'
+                      title: Entité non traitable
+                      detail: Le sexe n'est pas correctement formaté (m ou f)
+                      source:
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Le sexe n'est pas correctement formaté (m ou f)
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Dossier non trouvé
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '503':
+          description: Erreur du fournisseur
+          content:
+            application/json:
+              examples:
+                unknown_error:
+                  value:
+                    errors:
+                    - code: '37999'
+                      title: Erreur inconnue du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et inconnue de notre service. L'équipe technique
+                        a été notifiée de cette erreur pour investigation.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur inconnue du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et inconnue de notre service. L'équipe technique
+                    a été notifiée de cette erreur pour investigation.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '504':
+          description: Erreur d'intermédiaire
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                acces_non_autorise_50002:
+                  value:
+                    errors:
+                    - code: '50002'
+                      title: Accès non autorisé
+                      detail: Le jeton d'accès n'a pas été trouvé ou est expiré.
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: Le jeton d'accès n'a pas été trouvé ou est expiré.
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/api/v2/complementaire-sante-solidaire":
+    get:
+      summary: Statut complémentaire santé solidaire (C2S)
+      deprecated: true
+      tags:
+      - Prestations sociales
+      parameters:
+      - name: Cache-Control
+        in: header
+        description: Si cette valeur est fixée à "no-cache", le système de cache est
+          alors ignoré et la donnée est directement récupérée depuis le fournisseur
+          de données.
+        schema:
+          type: string
+      - name: X-Api-Key
+        in: header
+        schema:
+          type: string
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données.
+          Ce paramètre est obligatoire dans le cadre des appels via FranceConnect"
+        example: '13002526500013'
+        required: false
+        schema:
+          type: string
+      - name: nomUsage
+        in: query
+        description: Nom d'usage. Ne pas renseigner si présence de jeton FranceConnect.
+        example: DUPONT
+        required: false
+        schema:
+          type: string
+      - name: nomNaissance
+        in: query
+        description: Nom de naissance. Ne pas renseigner si présence de jeton FranceConnect.
+          Le champ est obligatoire pour les appels non FranceConnecté
+        example: JEAN
+        required: false
+        schema:
+          type: string
+      - name: prenoms[]
+        in: query
+        schema:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          example:
+          - PIERRE
+          - RICHARD
+        description: Liste des prénoms. Ne pas renseigner si présence de jeton FranceConnect.
+        required: false
+      - name: anneeDateDeNaissance
+        in: query
+        description: Année de naissance. Ne pas la renseigner si celle-ci est inconnue
+          ou en cas de présence de jeton FranceConnect.
+        example: 1990
+        required: false
+        schema:
+          type: integer
+      - name: moisDateDeNaissance
+        in: query
+        description: Mois de naissance. Ne pas le renseigner si celui-ci est inconnu
+          ou en cas de présence de jeton FranceConnect. Cette valeur est ignorée si
+          anneeDateDeNaissance est vide.
+        example: 1
+        required: false
+        schema:
+          type: integer
+      - name: jourDateDeNaissance
+        in: query
+        description: Jour de naissance. Ne pas le renseigner si celui-ci est inconnu
+          ou en cas de présence de jeton FranceConnect. Cette valeur est ignorée si
+          moisDateDeNaissance ou anneeDateDeNaissance est vide.
+        example: 1
+        required: false
+        schema:
+          type: integer
+      - name: codeInseeLieuDeNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 5
+          maxLength: 5
+          example: '08480'
+        description: Code Insee à 5 chiffres du lieu de naissance de la personne sur
+          5 chiffres. Ne pas remplir si la personne est née à l'étranger ou si présence
+          de jeton FranceConnect. En l'absence de jeton FranceConnect et du triplet
+          (nomCommuneNaissance, anneeDateDeNaissance, codeInseeDepartementNaissance),
+          le champ est obligatoire si la personne est née en France
+        required: false
+      - name: codePaysLieuDeNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 5
+          maxLength: 5
+          example: '99100'
+        description: Code Insee à 5 chiffres du pays de naissance (France = 99100).
+          Obligatoire si absence de jeton FranceConnect.
+        required: false
+      - name: sexe
+        in: query
+        schema:
+          type: string
+          enum:
+          - M
+          - F
+        description: Sexe de la personne, masculin ou féminin. Obligatoire si absence
+          de jeton FranceConnect.
+        example: M
+        required: false
+      - name: nomCommuneNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 1
+          example: Gennevilliers
+        description: Nom de la commune de naissance. En l'absence de jeton FranceConnect
+          et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne
+          est née en France
+        required: false
+      - name: codeInseeDepartementNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 2
+          maxLength: 3
+          example: '92'
+        description: Code INSEE du département de naissance. En l'absence de jeton
+          FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire
+          si la personne est née en France
+        required: false
+      security:
+      - franceConnectToken: []
+        apiKey: []
+      description: "Statut bénéficiaire de la complémentaire santé solidaire (C2S).
+        \n\n Retourne également des informations sur les dates d'ouverture des droits.
+        \n Pour plus d'informations sur cette API et obtenir un accès en avant-première,
+        veuillez contacter l'équipe API Particulier. \n **Données disponibles en bac
+        à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/complementaire_sante_solidaire)
+        \n L'API peut être appellée avec les données identité pivot ou avec un jeton
+        FranceConnect."
+      responses:
+        '200':
+          description: Complementaire Santé Solidaire trouvée
+          headers:
+            X-Response-Cached:
+              schema:
+                type: boolean
+                example: true
+                enum:
+                - true
+                - false
+                default: false
+              description: Indique si la réponse a été caché.
+            X-Cache-Expires-in:
+              schema:
+                type: number
+                nullable: true
+                example: 9001
+              description: Secondes avant que le cache n'expire. Si le cache est vide,
+                ce header est vide (mais présent). La durée du cache est de 1 heure.
+          x-operationId: api_particulier_v2_cnav_complementaire_sante_solidaire
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    title: Statut bénéficiaire de la C2S
+                    type: string
+                    description: "Indique si le particulier est bénéficiaire de la
+                      complémentaire de santé solidaire au moment de l'appel. Cet
+                      indicateur précise sous quelle forme la C2S est attribuée (avec
+                      ou sans participation financière). \n \n - Si le statut est
+                      'beneficiaire_sans_participation_financiere', cela signifie
+                      que le particulier est bénéficiaire d'une C2S sans participation
+                      financière. \n - Si le statut est 'beneficiaire_avec_participation_financiere',
+                      cela signifie que le particulier est d'une bénéficiaire de C2S
+                      avec participation financière. \n - Si le statut est 'non_beneficiaire_css',
+                      cela signifie que le particulier n'est pas concerné par la C2S."
+                    enum:
+                    - beneficiaire_sans_participation_financiere
+                    - beneficiaire_avec_participation_financiere
+                    - non_beneficiaire_css
+                  dateDebut:
+                    title: Date d'ouverture du droit à la C2S
+                    type: string
+                    nullable: true
+                    description: "Date de début de droit à la complémentaire santé
+                      solidaire (C2S) si le particulier est bénéficiaire. \n Ce champ
+                      est null dans le cas où le particulier n'est pas bénéficiaire
+                      de la C2S."
+                    example: '1992-11-29'
+                  dateFin:
+                    title: Date de fermeture du droit à la C2S
+                    type: string
+                    nullable: true
+                    description: Ce champs ne délivrant pas l'information souhaitée à la base il est toujours à null désormais
+                    example: null
+        '400':
+          description: Mauvais paramètres d'appels
+          content:
+            application/json:
+              examples:
+                unprocessable_entity_error_gender_error:
+                  value:
+                    errors:
+                    - code: '00364'
+                      title: Entité non traitable
+                      detail: Le sexe n'est pas correctement formaté (m ou f)
+                      source:
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Le sexe n'est pas correctement formaté (m ou f)
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Dossier complémentaire inexistant. Le document ne peut être
+            édité.
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '503':
+          description: Erreur du fournisseur
+          content:
+            application/json:
+              examples:
+                unknown_error:
+                  value:
+                    errors:
+                    - code: '37999'
+                      title: Erreur inconnue du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et inconnue de notre service. L'équipe technique
+                        a été notifiée de cette erreur pour investigation.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur inconnue du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et inconnue de notre service. L'équipe technique
+                    a été notifiée de cette erreur pour investigation.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '504':
+          description: Erreur d'intermédiaire
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                acces_non_autorise_50002:
+                  value:
+                    errors:
+                    - code: '50002'
+                      title: Accès non autorisé
+                      detail: Le jeton d'accès n'a pas été trouvé ou est expiré.
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: Le jeton d'accès n'a pas été trouvé ou est expiré.
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/api/v2/prime-activite":
+    get:
+      summary: Statut prime d'activité
+      deprecated: true
+      tags:
+      - Prestations sociales
+      parameters:
+      - name: Cache-Control
+        in: header
+        description: Si cette valeur est fixée à "no-cache", le système de cache est
+          alors ignoré et la donnée est directement récupérée depuis le fournisseur
+          de données.
+        schema:
+          type: string
+      - name: X-Api-Key
+        in: header
+        schema:
+          type: string
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données.
+          Ce paramètre est obligatoire dans le cadre des appels via FranceConnect"
+        example: '13002526500013'
+        required: false
+        schema:
+          type: string
+      - name: nomUsage
+        in: query
+        description: Nom d'usage. Ne pas renseigner si présence de jeton FranceConnect.
+        example: DUPONT
+        required: false
+        schema:
+          type: string
+      - name: nomNaissance
+        in: query
+        description: Nom de naissance. Ne pas renseigner si présence de jeton FranceConnect.
+          Le champ est obligatoire pour les appels non FranceConnecté
+        example: JEAN
+        required: false
+        schema:
+          type: string
+      - name: prenoms[]
+        in: query
+        schema:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          example:
+          - PIERRE
+          - RICHARD
+        description: Liste des prénoms. Ne pas renseigner si présence de jeton FranceConnect.
+        required: false
+      - name: anneeDateDeNaissance
+        in: query
+        description: Année de naissance. Ne pas la renseigner si celle-ci est inconnue
+          ou en cas de présence de jeton FranceConnect.
+        example: 1990
+        required: false
+        schema:
+          type: integer
+      - name: moisDateDeNaissance
+        in: query
+        description: Mois de naissance. Ne pas le renseigner si celui-ci est inconnu
+          ou en cas de présence de jeton FranceConnect. Cette valeur est ignorée si
+          anneeDateDeNaissance est vide.
+        example: 1
+        required: false
+        schema:
+          type: integer
+      - name: jourDateDeNaissance
+        in: query
+        description: Jour de naissance. Ne pas le renseigner si celui-ci est inconnu
+          ou en cas de présence de jeton FranceConnect. Cette valeur est ignorée si
+          moisDateDeNaissance ou anneeDateDeNaissance est vide.
+        example: 1
+        required: false
+        schema:
+          type: integer
+      - name: codeInseeLieuDeNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 5
+          maxLength: 5
+          example: '08480'
+        description: Code Insee à 5 chiffres du lieu de naissance de la personne sur
+          5 chiffres. Ne pas remplir si la personne est née à l'étranger ou si présence
+          de jeton FranceConnect. En l'absence de jeton FranceConnect et du triplet
+          (nomCommuneNaissance, anneeDateDeNaissance, codeInseeDepartementNaissance),
+          le champ est obligatoire si la personne est née en France
+        required: false
+      - name: codePaysLieuDeNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 5
+          maxLength: 5
+          example: '99100'
+        description: Code Insee à 5 chiffres du pays de naissance (France = 99100).
+          Obligatoire si absence de jeton FranceConnect.
+        required: false
+      - name: sexe
+        in: query
+        schema:
+          type: string
+          enum:
+          - M
+          - F
+        description: Sexe de la personne, masculin ou féminin. Obligatoire si absence
+          de jeton FranceConnect.
+        example: M
+        required: false
+      - name: nomCommuneNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 1
+          example: Gennevilliers
+        description: Nom de la commune de naissance. En l'absence de jeton FranceConnect
+          et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne
+          est née en France
+        required: false
+      - name: codeInseeDepartementNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 2
+          maxLength: 3
+          example: '92'
+        description: Code INSEE du département de naissance. En l'absence de jeton
+          FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire
+          si la personne est née en France
+        required: false
+      security:
+      - franceConnectToken: []
+        apiKey: []
+      description: "Statut bénéficiaire de la prime d'activité, majorée ou non. \n\n
+        Retourne également des informations sur les dates d'ouverture des droits.
+        \n L'API peut être appellée avec les données identité pivot ou avec un jeton
+        FranceConnect."
+      responses:
+        '200':
+          description: Dossier trouvé
+          headers:
+            X-Response-Cached:
+              schema:
+                type: boolean
+                example: true
+                enum:
+                - true
+                - false
+                default: false
+              description: Indique si la réponse a été caché.
+            X-Cache-Expires-in:
+              schema:
+                type: number
+                nullable: true
+                example: 9001
+              description: Secondes avant que le cache n'expire. Si le cache est vide,
+                ce header est vide (mais présent). La durée du cache est de 1 heure.
+          x-operationId: api_particulier_v2_cnav_prime_activite
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    title: Statut bénéficiaire de la prime d'activité
+                    type: string
+                    description: Indique si le particulier est bénéficiaire de la
+                      prime d'activité au moment de l'appel.
+                    enum:
+                    - beneficiaire
+                    - non_beneficiaire
+                  majoration:
+                    title: Statut bénéficiaire de la majoration de la prime d'activité
+                    type: boolean
+                    nullable: true
+                    description: Indique si le particulier est bénéficiaire de la
+                      prime d'activité majorée au moment de l'appel. Ce champ est
+                      renvoyé si les droits du jeton (obtenus par habilitation) le
+                      permettent. Ce champ sera null si le particulier n'est pas bénéficiaire
+                      de la prime d'activité.
+                    example: false
+                  dateDebut:
+                    title: Date d'ouverture du droit à la prime d'activité
+                    type: string
+                    nullable: true
+                    description: "Date de début de droit à la prime d'activité si
+                      le particulier est bénéficiaire. \n Ce champ est null dans le
+                      cas où le particulier n'est pas bénéficiaire de la prime d'activité."
+                    example: '1992-11-20'
+                  dateFin:
+                    title: Date de fermeture du droit à la prime d'activité
+                    type: string
+                    nullable: true
+                    description: Ce champs ne délivrant pas l'information souhaitée à la base il est toujours à null désormais
+                    example: null
+        '400':
+          description: Mauvais paramètres d'appels
+          content:
+            application/json:
+              examples:
+                unprocessable_entity_error_gender_error:
+                  value:
+                    errors:
+                    - code: '00364'
+                      title: Entité non traitable
+                      detail: Le sexe n'est pas correctement formaté (m ou f)
+                      source:
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Le sexe n'est pas correctement formaté (m ou f)
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Dossier non trouvé
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '503':
+          description: Erreur du fournisseur
+          content:
+            application/json:
+              examples:
+                unknown_error:
+                  value:
+                    errors:
+                    - code: '37999'
+                      title: Erreur inconnue du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et inconnue de notre service. L'équipe technique
+                        a été notifiée de cette erreur pour investigation.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur inconnue du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et inconnue de notre service. L'équipe technique
+                    a été notifiée de cette erreur pour investigation.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '504':
+          description: Erreur d'intermédiaire
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                acces_non_autorise_50002:
+                  value:
+                    errors:
+                    - code: '50002'
+                      title: Accès non autorisé
+                      detail: Le jeton d'accès n'a pas été trouvé ou est expiré.
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: Le jeton d'accès n'a pas été trouvé ou est expiré.
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/api/v2/composition-familiale-v2":
+    get:
+      summary: Quotient familial MSA & CAF
+      deprecated: true
+      tags:
+      - Quotient familial
+      parameters:
+      - name: Cache-Control
+        in: header
+        description: Si cette valeur est fixée à "no-cache", le système de cache est
+          alors ignoré et la donnée est directement récupérée depuis le fournisseur
+          de données.
+        schema:
+          type: string
+      - name: X-Api-Key
+        in: header
+        schema:
+          type: string
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données.
+          Ce paramètre est obligatoire dans le cadre des appels via FranceConnect"
+        example: '13002526500013'
+        required: false
+        schema:
+          type: string
+      - name: nomUsage
+        in: query
+        description: Nom d'usage. Ne pas renseigner si présence de jeton FranceConnect.
+        example: DUPONT
+        required: false
+        schema:
+          type: string
+      - name: nomNaissance
+        in: query
+        description: Nom de naissance. Ne pas renseigner si présence de jeton FranceConnect.
+          Le champ est obligatoire pour les appels non FranceConnecté
+        example: JEAN
+        required: false
+        schema:
+          type: string
+      - name: prenoms[]
+        in: query
+        schema:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          example:
+          - PIERRE
+          - RICHARD
+        description: Liste des prénoms. Ne pas renseigner si présence de jeton FranceConnect.
+        required: false
+      - name: anneeDateDeNaissance
+        in: query
+        description: Année de naissance. Ne pas la renseigner si celle-ci est inconnue
+          ou en cas de présence de jeton FranceConnect.
+        example: 1990
+        required: false
+        schema:
+          type: integer
+      - name: moisDateDeNaissance
+        in: query
+        description: Mois de naissance. Ne pas le renseigner si celui-ci est inconnu
+          ou en cas de présence de jeton FranceConnect. Cette valeur est ignorée si
+          anneeDateDeNaissance est vide.
+        example: 1
+        required: false
+        schema:
+          type: integer
+      - name: jourDateDeNaissance
+        in: query
+        description: Jour de naissance. Ne pas le renseigner si celui-ci est inconnu
+          ou en cas de présence de jeton FranceConnect. Cette valeur est ignorée si
+          moisDateDeNaissance ou anneeDateDeNaissance est vide.
+        example: 1
+        required: false
+        schema:
+          type: integer
+      - name: codeInseeLieuDeNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 5
+          maxLength: 5
+          example: '08480'
+        description: Code Insee à 5 chiffres du lieu de naissance de la personne sur
+          5 chiffres. Ne pas remplir si la personne est née à l'étranger ou si présence
+          de jeton FranceConnect. En l'absence de jeton FranceConnect et du triplet
+          (nomCommuneNaissance, anneeDateDeNaissance, codeInseeDepartementNaissance),
+          le champ est obligatoire si la personne est née en France
+        required: false
+      - name: codePaysLieuDeNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 5
+          maxLength: 5
+          example: '99100'
+        description: Code Insee à 5 chiffres du pays de naissance (France = 99100).
+          Obligatoire si absence de jeton FranceConnect.
+        required: false
+      - name: sexe
+        in: query
+        schema:
+          type: string
+          enum:
+          - M
+          - F
+        description: Sexe de la personne, masculin ou féminin. Obligatoire si absence
+          de jeton FranceConnect.
+        example: M
+        required: false
+      - name: nomCommuneNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 1
+          example: Gennevilliers
+        description: Nom de la commune de naissance. En l'absence de jeton FranceConnect
+          et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne
+          est née en France
+        required: false
+      - name: codeInseeDepartementNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 2
+          maxLength: 3
+          example: '92'
+        description: Code INSEE du département de naissance. En l'absence de jeton
+          FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire
+          si la personne est née en France
+        required: false
+      - name: annee
+        in: query
+        description: Année du quotient familial recherché. Si l'année n'est pas renseignée,
+          l'année utilisée par défaut est celle en cours. L'API permet d'accéder à
+          un historique de maximum 2 ans.
+        example: 2023
+        required: false
+        schema:
+          type: integer
+      - name: mois
+        in: query
+        description: Mois du quotient familial recherché. Si le mois n'est pas renseigné,
+          le mois utilisé par défaut est celui en cours.
+        example: 12
+        required: false
+        schema:
+          type: integer
+      security:
+      - franceConnectToken: []
+        apiKey: []
+      description: "Quotient familial et composition de la famille d'un allocataire
+        du régime agricole (régime général à venir). \n Pour plus d'informations sur
+        cette API et obtenir un accès en avant-première, veuillez contacter l'équipe
+        API Particulier. \n **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2)
+        \n L'API peut être appellée avec les données identité pivot ou avec un jeton
+        FranceConnect."
+      responses:
+        '200':
+          description: Quotient Familial trouvé
+          headers:
+            X-Response-Cached:
+              schema:
+                type: boolean
+                example: true
+                enum:
+                - true
+                - false
+                default: false
+              description: Indique si la réponse a été caché.
+            X-Cache-Expires-in:
+              schema:
+                type: number
+                nullable: true
+                example: 9001
+              description: Secondes avant que le cache n'expire. Si le cache est vide,
+                ce header est vide (mais présent). La durée du cache est de 24 heure.
+          content:
+            application/json:
+              examples:
+                Quotient Familial trouvée:
+                  value:
+                    quotientFamilial: 464
+                    mois: 12
+                    annee: 2023
+                    allocataires:
+                    - nomNaissance: CHAMPION
+                      nomUsuel: DU MONDE
+                      prenoms: JEAN-PASCAL ROMAIN
+                      anneeDateDeNaissance: '1980'
+                      moisDateDeNaissance: '06'
+                      jourDateDeNaissance: '12'
+                      sexe: M
+                    - nomNaissance: NIDOUILLET
+                      nomUsuel:
+                      prenoms: JOSIANE
+                      anneeDateDeNaissance: '1981'
+                      moisDateDeNaissance: '05'
+                      jourDateDeNaissance: '02'
+                      sexe: F
+                    enfants:
+                    - nomNaissance: CHAMPION
+                      nomUsuel:
+                      prenoms: AURELIE
+                      anneeDateDeNaissance: '2014'
+                      moisDateDeNaissance: '05'
+                      jourDateDeNaissance: '02'
+                      sexe: F
+                    - nomNaissance: CHAMPION
+                      nomUsuel:
+                      prenoms: AURELIEN
+                      anneeDateDeNaissance: '2012'
+                      moisDateDeNaissance: '04'
+                      jourDateDeNaissance:
+                      sexe: M
+                    adresse:
+                      identite: DU MONDE JEAN-PASCAL
+                      complementInformation: APPARTEMENT 2
+                      complementInformationGeographique:
+                      numeroLibelleVoie:
+                      lieuDit:
+                      codePostalVille: 81700 GARREVAQUES
+                      pays: FRANCE
+              schema:
+                type: object
+                properties:
+                  allocataires:
+                    title: Informations sur les parents composant la famille
+                    type: array
+                    minItems: 1
+                    items:
+                      type: object
+                      properties:
+                        nomNaissance:
+                          title: Nom
+                          type: string
+                          description: Nom de naissance de l'allocataire
+                          example: JACQUES
+                        nomUsuel:
+                          title: Nom d'usage
+                          type: string
+                          description: Nom d'usage de l'allocataire
+                          example: JACQUES
+                          nullable: true
+                        prenoms:
+                          title: Prénoms
+                          type: string
+                          description: Prénoms de l'allocataire
+                          example: JEAN-PIERRE THOMAS
+                        anneeDateDeNaissance:
+                          title: Année de naissance
+                          type: string
+                          example: '2000'
+                          description: Année de la date de naissance de l'allocataire.
+                            Peut-être vide si inconnue.
+                          nullable: true
+                        moisDateDeNaissance:
+                          title: Mois de naissance
+                          type: string
+                          example: '01'
+                          description: Mois de la date de naissance de l'allocataire.
+                            Peut-être vide si inconnu.
+                          nullable: true
+                        jourDateDeNaissance:
+                          title: Jour de naissance
+                          type: string
+                          example: '31'
+                          description: Jour de la date de naissance de l'allocataire.
+                            Peut-être vide si inconnu.
+                          nullable: true
+                        sexe:
+                          title: Sexe
+                          type: string
+                          description: Sexe de l'allocataire
+                          example: M
+                          enum:
+                          - F
+                          - M
+                  enfants:
+                    type: array
+                    title: Informations sur les enfants composant la famille
+                    items:
+                      type: object
+                      properties:
+                        nomNaissance:
+                          title: Nom de naissance
+                          type: string
+                          description: Nom de naissance de l'enfant
+                          example: JACQUES
+                        nomUsuel:
+                          title: Nom d'usage
+                          type: string
+                          description: Nom d'usage de l'enfant
+                          example: JACQUES
+                          nullable: true
+                        prenoms:
+                          title: Prénoms
+                          type: string
+                          description: Prénoms de l'enfant
+                          example: JEAN-PIERRE THOMAS
+                        anneeDateDeNaissance:
+                          title: Année de naissance
+                          type: string
+                          example: '2000'
+                          description: Année de la date de naissance de l'enfant.
+                            Peut-être vide si inconnue.
+                          nullable: true
+                        moisDateDeNaissance:
+                          title: Mois de naissance
+                          type: string
+                          example: '01'
+                          description: Mois de la date de naissance de l'enfant. Peut-être
+                            vide si inconnu.
+                          nullable: true
+                        jourDateDeNaissance:
+                          title: Jour de naissance
+                          type: string
+                          example: '31'
+                          description: Jour de la date de naissance de l'enfant. Peut-être
+                            vide si inconnu.
+                          nullable: true
+                        sexe:
+                          title: Sexe
+                          type: string
+                          description: Sexe de l'enfant
+                          example: M
+                          enum:
+                          - F
+                          - M
+                  adresse:
+                    title: Adresse de la famille
+                    type: object
+                    description: Adresse au format de la poste
+                    properties:
+                      identite:
+                        title: Identité du destinataire
+                        type: string
+                        example: Monsieur JEAN JACQUES
+                        description: 'Identité du destinataire : Civilité, titre ou
+                          qualité + nom et prénom'
+                      complementInformation:
+                        title: Complément d'information du destinataire ou point de
+                          remise
+                        type: string
+                        nullable: true
+                        example:
+                      complementInformationGeographique:
+                        title: Complément d'information du point géographique
+                        type: string
+                        nullable: true
+                        example:
+                        description: Complément d'information du point géographique.
+                      numeroLibelleVoie:
+                        title: Voie
+                        type: string
+                        description: Numéro et libellé de la voie
+                        example: 1 RUE DE LA GARE
+                        nullable: true
+                      lieuDit:
+                        title: Lieu-dit
+                        type: string
+                        nullable: true
+                        example:
+                        description: 'Lieu-dit ou service particulier de distribution
+                          : poste restante, boîte postale'
+                      codePostalVille:
+                        title: Code postal
+                        type: string
+                        description: Code postal et localité de destination
+                        example: '75002'
+                      pays:
+                        title: Pays
+                        type: string
+                        description: Pays
+                        example: FRANCE
+                    required:
+                    - identite
+                    - complementInformation
+                    - complementInformationGeographique
+                    - numeroLibelleVoie
+                    - lieuDit
+                    - codePostalVille
+                    - pays
+                  quotientFamilial:
+                    title: Quotient familial CAF ou MSA
+                    type: integer
+                    description: Valeur du quotient familial calculé par la CAF ou
+                      la MSA
+                    example: 1045
+                  annee:
+                    title: Année effective du QF
+                    type: integer
+                    description: "Année effective du quotient familial appelé. \n\n
+                      - Si aucune année et aucun mois n'ont été renseignés en paramètres
+                      d'appel, le quotient familial retourné sera celui du mois de
+                      l'année en cours. - Si aucune année, ni aucun mois sont renseignés,
+                      l'appel est effectué par défaut avec l'année et le mois en cours.
+                      - Si aucune année n'a été renseignée, et que le mois est renseigné,
+                      le quotient familial retourné sera celui du mois spécifié pour
+                      l'année en cours. En revanche, si la date finalement composée
+                      avec cette règle s'avère dans le futur (mois postérieur au moins
+                      en cours), l'API renvoie un erreur 400. "
+                    example: 2023
+                  mois:
+                    title: Mois effectif du QF
+                    type: integer
+                    description: "Mois effectif du quotient familial. \n\n - Si aucun
+                      mois n'est renseigné, le mois en cours est utilisé par défaut.
+                      - Si le mois renseigné est postérieur au mois en cours, et qu'il
+                      compose une date dans le futur avec l'année appelée, l'API renvoie
+                      une erreur 400. \n - Si aucun mois n'a été renseigné mais que
+                      l'année a été spécifiée en paramètres d'appel, le quotient familial
+                      retourné sera celui du mois en cours pour l'année spécifiée."
+                    example: 6
+          x-operationId: api_particulier_v2_cnav_quotient_familial_v2
+        '400':
+          description: Mauvais paramètres d'appels
+          content:
+            application/json:
+              examples:
+                Mauvais paramètres d'appels:
+                  value:
+                    error: bad_request
+                    reason: L'année demandée n'est pas correctement formatée ou est
+                      dans le futur.
+                    message: L'année demandée n'est pas correctement formatée ou est
+                      dans le futur.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Dossier allocataire inexistant. Le document ne peut être édité.
+          content:
+            application/json:
+              examples:
+                Allocataire non identifié:
+                  value:
+                    error: not_found
+                    reason: Dossier allocataire inexistant. Le document ne peut être
+                      édité.
+                    message: Dossier allocataire inexistant. Le document ne peut être
+                      édité.
+                Dossier non trouvé MSA:
+                  value:
+                    error: not_found
+                    reason: Le dossier allocataire n'a pas été trouvé auprès de la
+                      MSA.
+                    message: Le dossier allocataire n'a pas été trouvé auprès de la
+                      MSA.
+                Dossier non trouvé CNAF:
+                  value:
+                    error: not_found
+                    reason: Le dossier allocataire n'a pas été trouvé auprès de la
+                      CNAF.
+                    message: Le dossier allocataire n'a pas été trouvé auprès de la
+                      CNAF.
+                Allocataire non référencé:
+                  value:
+                    error: not_found
+                    reason: L'allocataire n'est pas référencé auprès de la CNAF ni
+                      de la MSA
+                    message: L'allocataire n'est pas référencé auprès de la CNAF ni
+                      de la MSA
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '503':
+          description: Erreur du fournisseur
+          content:
+            application/json:
+              examples:
+                Erreur du fournisseur:
+                  value:
+                    error: provider_unknown_error
+                    reason: La réponse retournée par le fournisseur de données est
+                      invalide et inconnue de notre service. L'équipe technique a
+                      été notifiée de cette erreur pour investigation.
+                    message: La réponse retournée par le fournisseur de données est
+                      invalide et inconnue de notre service. L'équipe technique a
+                      été notifiée de cette erreur pour investigation.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '504':
+          description: Erreur d'intermédiaire
+          content:
+            application/json:
+              examples:
+                Erreur d'intermédiaire:
+                  value:
+                    error: timeout_error
+                    reason: Temps d’attente d’une réponse du fournisseur de données
+                      écoulé.
+                    message: Temps d’attente d’une réponse du fournisseur de données
+                      écoulé.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                acces_non_autorise_50002:
+                  value:
+                    errors:
+                    - code: '50002'
+                      title: Accès non autorisé
+                      detail: Le jeton d'accès n'a pas été trouvé ou est expiré.
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: Le jeton d'accès n'a pas été trouvé ou est expiré.
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/api/v2/revenu-solidarite-active":
+    get:
+      summary: Statut revenu de solidarité active (RSA)
+      deprecated: true
+      tags:
+      - Prestations sociales
+      parameters:
+      - name: Cache-Control
+        in: header
+        description: Si cette valeur est fixée à "no-cache", le système de cache est
+          alors ignoré et la donnée est directement récupérée depuis le fournisseur
+          de données.
+        schema:
+          type: string
+      - name: X-Api-Key
+        in: header
+        schema:
+          type: string
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données.
+          Ce paramètre est obligatoire dans le cadre des appels via FranceConnect"
+        example: '13002526500013'
+        required: false
+        schema:
+          type: string
+      - name: nomUsage
+        in: query
+        description: Nom d'usage. Ne pas renseigner si présence de jeton FranceConnect.
+        example: DUPONT
+        required: false
+        schema:
+          type: string
+      - name: nomNaissance
+        in: query
+        description: Nom de naissance. Ne pas renseigner si présence de jeton FranceConnect.
+          Le champ est obligatoire pour les appels non FranceConnecté
+        example: JEAN
+        required: false
+        schema:
+          type: string
+      - name: prenoms[]
+        in: query
+        schema:
+          type: array
+          minItems: 1
+          items:
+            type: string
+          example:
+          - PIERRE
+          - RICHARD
+        description: Liste des prénoms. Ne pas renseigner si présence de jeton FranceConnect.
+        required: false
+      - name: anneeDateDeNaissance
+        in: query
+        description: Année de naissance. Ne pas la renseigner si celle-ci est inconnue
+          ou en cas de présence de jeton FranceConnect.
+        example: 1990
+        required: false
+        schema:
+          type: integer
+      - name: moisDateDeNaissance
+        in: query
+        description: Mois de naissance. Ne pas le renseigner si celui-ci est inconnu
+          ou en cas de présence de jeton FranceConnect. Cette valeur est ignorée si
+          anneeDateDeNaissance est vide.
+        example: 1
+        required: false
+        schema:
+          type: integer
+      - name: jourDateDeNaissance
+        in: query
+        description: Jour de naissance. Ne pas le renseigner si celui-ci est inconnu
+          ou en cas de présence de jeton FranceConnect. Cette valeur est ignorée si
+          moisDateDeNaissance ou anneeDateDeNaissance est vide.
+        example: 1
+        required: false
+        schema:
+          type: integer
+      - name: codeInseeLieuDeNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 5
+          maxLength: 5
+          example: '08480'
+        description: Code Insee à 5 chiffres du lieu de naissance de la personne sur
+          5 chiffres. Ne pas remplir si la personne est née à l'étranger ou si présence
+          de jeton FranceConnect. En l'absence de jeton FranceConnect et du triplet
+          (nomCommuneNaissance, anneeDateDeNaissance, codeInseeDepartementNaissance),
+          le champ est obligatoire si la personne est née en France
+        required: false
+      - name: codePaysLieuDeNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 5
+          maxLength: 5
+          example: '99100'
+        description: Code Insee à 5 chiffres du pays de naissance (France = 99100).
+          Obligatoire si absence de jeton FranceConnect.
+        required: false
+      - name: sexe
+        in: query
+        schema:
+          type: string
+          enum:
+          - M
+          - F
+        description: Sexe de la personne, masculin ou féminin. Obligatoire si absence
+          de jeton FranceConnect.
+        example: M
+        required: false
+      - name: nomCommuneNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 1
+          example: Gennevilliers
+        description: Nom de la commune de naissance. En l'absence de jeton FranceConnect
+          et du codeInseeLieuDeNaissance, ce paramètre est obligatoire si la personne
+          est née en France
+        required: false
+      - name: codeInseeDepartementNaissance
+        in: query
+        schema:
+          type: string
+          minLength: 2
+          maxLength: 3
+          example: '92'
+        description: Code INSEE du département de naissance. En l'absence de jeton
+          FranceConnect et du codeInseeLieuDeNaissance, ce paramètre est obligatoire
+          si la personne est née en France
+        required: false
+      security:
+      - franceConnectToken: []
+        apiKey: []
+      description: "Statut bénéficiaire du revenu de solidarité active (RSA), majoré
+        ou non. \n\n Retourne également des informations sur les dates d'ouverture
+        des droits. \n L'API peut être appellée avec les données identité pivot ou
+        avec un jeton FranceConnect."
+      responses:
+        '200':
+          description: Dossier trouvé
+          headers:
+            X-Response-Cached:
+              schema:
+                type: boolean
+                example: true
+                enum:
+                - true
+                - false
+                default: false
+              description: Indique si la réponse a été caché.
+            X-Cache-Expires-in:
+              schema:
+                type: number
+                nullable: true
+                example: 9001
+              description: Secondes avant que le cache n'expire. Si le cache est vide,
+                ce header est vide (mais présent). La durée du cache est de 1 heure.
+          x-operationId: api_particulier_v2_cnav_revenu_solidarite_active
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    title: Statut bénéficiaire du revenu de solidarité active (RSA)
+                    type: string
+                    description: Indique si le particulier est bénéficiaire du revenu
+                      de solidarité active au moment de l'appel.
+                    enum:
+                    - beneficiaire
+                    - non_beneficiaire
+                  majoration:
+                    title: Statut bénéficiaire de la majoration du RSA
+                    type: boolean
+                    nullable: true
+                    description: Indique si le particulier est bénéficiaire du RSA
+                      majoré au moment de l'appel. Nécessite un scope spécifique pour
+                      être envoyé. Sera null si le particulier n'est pas bénéficiaire
+                      du RSA.
+                    example: false
+                  dateDebut:
+                    title: Date d'ouverture du droit au RSA
+                    type: string
+                    nullable: true
+                    description: "Date de début de droit au RSA si le particulier
+                      est bénéficiaire. \n Ce champ est null dans le cas où le particulier
+                      n'est pas bénéficiaire du RSA."
+                    example: '1992-11-29'
+                  dateFin:
+                    title: Date de fermeture du droit au revenu de solidarité active
+                    type: string
+                    nullable: true
+                    description: Ce champs ne délivrant pas l'information souhaitée à la base il est toujours à null désormais
+                    example: null
+        '400':
+          description: Mauvais paramètres d'appels
+          content:
+            application/json:
+              examples:
+                unprocessable_entity_error_gender_error:
+                  value:
+                    errors:
+                    - code: '00364'
+                      title: Entité non traitable
+                      detail: Le sexe n'est pas correctement formaté (m ou f)
+                      source:
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Le sexe n'est pas correctement formaté (m ou f)
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Dossier non trouvé
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '503':
+          description: Erreur du fournisseur
+          content:
+            application/json:
+              examples:
+                unknown_error:
+                  value:
+                    errors:
+                    - code: '37999'
+                      title: Erreur inconnue du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et inconnue de notre service. L'équipe technique
+                        a été notifiée de cette erreur pour investigation.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur inconnue du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et inconnue de notre service. L'équipe technique
+                    a été notifiée de cette erreur pour investigation.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '504':
+          description: Erreur d'intermédiaire
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              examples:
+                acces_non_autorise_50002:
+                  value:
+                    errors:
+                    - code: '50002'
+                      title: Accès non autorisé
+                      detail: Le jeton d'accès n'a pas été trouvé ou est expiré.
+                      source:
+                      meta: {}
+                  summary: Accès non autorisé
+                  description: Le jeton d'accès n'a pas été trouvé ou est expiré.
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/api/v2/scolarites":
+    get:
+      summary: Statut élève scolarisé et boursier
+      deprecated: true
+      tags:
+      - Éducation et études
+      parameters:
+      - name: X-Api-Key
+        in: header
+        schema:
+          type: string
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données."
+        example: '13002526500013'
+        required: false
+        schema:
+          type: string
+      - name: nom
+        in: query
+        description: Nom de l'élève
+        example: Martin
+        required: true
+        schema:
+          type: string
+      - name: prenom
+        in: query
+        description: Prénom de l'élève
+        example: Justine
+        required: true
+        schema:
+          type: string
+      - name: sexe
+        in: query
+        description: Sexe de l'élève, masculin ou féminin
+        example: m
+        required: true
+        schema:
+          type: string
+      - name: dateNaissance
+        in: query
+        description: Date de naissance de l'élève au format AAAA-MM-JJ
+        example: '2000-01-20'
+        required: true
+        schema:
+          type: string
+      - name: codeEtablissement
+        in: query
+        description: |
+          Code d'unité administrative immatriculée (code UAI) de l'établissement où est scolarisé l'élève. Ce code unique inscrit au répertoire national des établissements est composé de 7 chiffres et d'une lettre ; les trois premiers chiffres correspondent au numéro de département de l'établissement.
+
+          Pour retrouver facilement le code UAI d'un établissement à partir d' informations plus facilement connues des usagers (commune, code postal, etc.), vous pouvez utiliser l'[API "Annuaire de l'éducation nationale"](https://api.gouv.fr/les-api/api-annuaire-education).
+
+          ⚠️ L'établissement 0861288H (CNED Direction générale) n'existe pas dans l'API annuaire de l'éducation nationale, il faudra donc compléter la liste des établissements avec une ligne CNED à laquelle sera associée le code UAI qui sera en passé en entrée.
+        example: 0210015C
+        required: true
+        schema:
+          type: string
+      - name: anneeScolaire
+        in: query
+        description: 'Année scolaire recherchée au format AAAA-AAAA ou AAAA. Les informations
+          connues par l''API concerne surtout l''année en cours et parfois l''année
+          scolaire à venir. Pour en savoir plus consulter la fiche métier : https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise#faq_entry_answer_0_api_particulier_endpoint_education_nationale_statut_eleve_scolarise.'
+        example: 2022-2023
+        required: true
+        schema:
+          type: string
+      description: Statut scolarisé et statut boursier d'un élève du primaire, collège
+        ou lycée.
+      responses:
+        '200':
+          description: Scolarité trouvée
+          x-operationId: api_particulier_v2_men_scolarites
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  eleve:
+                    title: Informations sur l'élève
+                    description: Les informations retournées ici sont celles transmises
+                      en paramètre d'appel. S'il y a eu des erreurs de frappe à la
+                      saisie, elles seront renvoyées.
+                    type: object
+                    properties:
+                      nom:
+                        title: Nom
+                        description: Nom de l'élève
+                        type: string
+                        example: Martin
+                      prenom:
+                        title: Prénom
+                        description: Prénom de l'élève
+                        type: string
+                        example: Justine
+                      sexe:
+                        title: Sexe
+                        description: Sexe de l'élève, masculin ou féminin
+                        type: string
+                        example: F
+                        enum:
+                        - M
+                        - F
+                      date_naissance:
+                        title: Date de naissance
+                        description: Date de naissance de l'élève au format AAAA-MM-JJ
+                        type: string
+                        example: '2000-01-20'
+                    required:
+                    - nom
+                    - prenom
+                    - sexe
+                    - date_naissance
+                  code_etablissement:
+                    title: Code UAI de l'établissement
+                    description: |
+                      Code d'unité administrative immatriculée (code UAI) de l'établissement où est scolarisé l'élève. Ce code unique inscrit au répertoire national des établissements est composé de 7 chiffres et d'une lettre ; les trois premiers chiffres correspondent au numéro de département de l'établissement.
+
+                      Pour retrouver facilement le code UAI d'un établissement à partir d' informations plus facilement connues des usagers (commune, code postal, etc.), vous pouvez utiliser l'[API "Annuaire de l'éducation nationale"](https://api.gouv.fr/les-api/api-annuaire-education).
+
+                      ⚠️ L'établissement 0861288H (CNED Direction générale) n'existe pas dans l'API annuaire de l'éducation nationale, il faudra donc compléter la liste des établissements avec une ligne CNED à laquelle sera associée le code UAI qui sera en passé en entrée.
+                    type: string
+                    pattern: "^\\d{7}\\w$"
+                    example: 0210015C
+                  annee_scolaire:
+                    title: Année scolaire
+                    description: Année scolaire de l'élève au format AAAA-AAAA
+                    type: string
+                    pattern: "^\\d{4}$|^\\d{4}-\\d{4}$"
+                    example: 2022-2023
+                  est_scolarise:
+                    description: Indique si l'élève est scolarisé dans l'établissement.
+                    type: boolean
+                    example: true
+                  est_boursier:
+                    description: |
+                      Indique si l'élève est boursier dans l'établissement. Les bourses concernent uniquement les élèves des collèges et lycées.
+
+                      ⚠️ Si le statut boursier est à "false" avant mi-octobre, cela ne signifie pas forcément que l'élève n'est pas boursier. Il peut s'agir d'un faux négatif lié à une absence de l'information en base. Pour en savoir plus consulter la fiche métier : https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise#faq_entry_answer_1_api_particulier_endpoint_education_nationale_statut_eleve_scolarise.
+
+                      Ce champs prend la valeur null lorsque l'on ne sait pas si l'élève est boursier ou non
+                    type: boolean
+                    example: true
+                    nullable: true
+                  niveau_bourse:
+                    description: |
+                      Indique l'échelon de la bourse de l'élève. Est à "null" quand "est_boursier" est "false". Les bourses concernent uniquement les élèves des collèges et lycées.
+
+                      Il existe trois échelons de bourses pour les collégiens (1 à 3) et six échelons pour les lycéens (1 à 6), correspondant aux montants reçus par l'élève pour l'année scolaire. Pour en savoir plus, consulter la FAQ : https://particulier.api.gouv.fr/catalogue/education_nationale/statut_eleve_scolarise#faq_entry_answer_2_api_particulier_endpoint_education_nationale_statut_eleve_scolarise"
+                    type: integer
+                    example: 1
+                    nullable: true
+                    enum:
+                    - null
+                    - 1
+                    - 2
+                    - 3
+                    - 4
+                    - 5
+                    - 6
+                  status_eleve:
+                    title: Statut de l'élève
+                    description: |
+                      Indique le statut sous lequel l'élève est scolarisé dans l'établissement. Les valeurs sont susceptibles d'évoluer :
+
+                      - ST : Scolaire, il s'agit du statut de base renvoyé pour près de 95% des élèves.
+                      - AP : Apprenti
+                      - CQ : Contrat de qualification
+                      - FC : Formation continue
+                      - ED : Enseignement à distance
+                      - IN : Candidat individuel
+                      - FQ : Stagiaire de la formation Professionnelle
+                      - SC : Scolaire ou formation initiale
+                      - CP : Contrat de professionnalisation.
+                      - NC : Non connu ou non communiqué.
+                    type: object
+                    properties:
+                      code:
+                        title: Code statut de l'élève
+                        description: Code du statut sous lequel l'élève est scolarisé
+                          dans l'établissement.
+                        type: string
+                        example: ST
+                      libelle:
+                        title: Libellé du statut de l'élève
+                        description: Libellé du statut sous lequel l'élève est scolarisé
+                          dans l'établissement.
+                        type: string
+                        example: SCOLAIRE
+                    required:
+                    - code
+                    - libelle
+        '400':
+          description: Paramètre(s) invalide(s)
+          content:
+            application/json:
+              examples:
+                unprocessable_entity_error_gender_error:
+                  value:
+                    errors:
+                    - code: '00364'
+                      title: Entité non traitable
+                      detail: Le sexe n'est pas correctement formaté (m ou f)
+                      source:
+                      meta: {}
+                  summary: Entité non traitable
+                  description: Le sexe n'est pas correctement formaté (m ou f)
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Non trouvée
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '503':
+          description: Erreur du fournisseur
+          content:
+            application/json:
+              examples:
+                unknown_error:
+                  value:
+                    errors:
+                    - code: '30999'
+                      title: Erreur inconnue du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et inconnue de notre service. L'équipe technique
+                        a été notifiée de cette erreur pour investigation.
+                      source:
+                      meta:
+                        provider: MEN
+                  summary: Erreur inconnue du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et inconnue de notre service. L'équipe technique
+                    a été notifiée de cette erreur pour investigation.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '504':
+          description: Erreur d'intermédiaire
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/api/v2/paiements-pole-emploi":
+    get:
+      summary: Paiements versés par France Travail
+      deprecated: true
+      tags:
+      - Demandeurs d'emploi
+      parameters:
+      - name: X-Api-Key
+        in: header
+        schema:
+          type: string
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données."
+        example: '13002526500013'
+        required: false
+        schema:
+          type: string
+      - name: identifiant
+        in: query
+        description: Identifiant France Travail choisi par le particulier lors de
+          la création de son espace personnel en ligne.
+        example: jean.dupont33
+        required: true
+        schema:
+          type: string
+      description: Ensemble des paiements versés par France Travail au particulier
+      responses:
+        '200':
+          description: Paiements trouvées
+          x-operationId: api_particulier_v2_pole_emploi_indemnites
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  identifiant:
+                    title: Nom d'utilisateur France Travail
+                    type: string
+                    description: Identifiant France Travail, tel qu'il a été renseigné
+                      en paramètre d'appel. Cet identifiant est le nom d'utilisateur
+                      tel que choisi par le particulier lors de la création de son
+                      espace personnel en ligne.
+                    example: jean.dupont33
+                  paiements:
+                    title: Paiements
+                    description: Liste des paiements versés
+                    type: array
+                    minItems: 1
+                    items:
+                      title: Paiement
+                      type: object
+                      properties:
+                        date:
+                          title: Date du paiement
+                          type: string
+                          example: '2021-01-01'
+                        montant:
+                          title: Montant total
+                          description: Montant total du paiement. Il s'agit de la
+                            somme des allocations, aides et autres paiements, moins
+                            le prélèvement de l'impôt à la source.
+                          type: number
+                          example: 123.4
+                        allocations:
+                          title: Allocations
+                          description: Part du montant correspondant aux paiements
+                            d’allocations (Allocation d'aide au retour à l'emploi,
+                            Allocation de sécurisation professionnelle, Allocation
+                            de solidarité spécifique, Allocation pour les travailleurs
+                            indépendants, Rémunération de formation France Travail,
+                            Rémunération de fin de formation, Allocation de fin de
+                            droit, Allocation d'accompagnement personnalisé, Allocation
+                            de professionnalisation et de solidarité, Allocation décès,
+                            Allocation contrat engagement jeune).
+                          type: number
+                          example: 45.1
+                        aides:
+                          title: Aides
+                          description: Part du montant correspondant aux paiements
+                            d’aides (Aide à la reprise et à la création d’entreprise,
+                            Aide à la mobilité, Aide à la garde d'enfant pour parent
+                            isolé, Aide fin de droit, Aide aux congés non payés, Aide
+                            à la valorisation des acquis par l'expérience, Aide du
+                            fond de sécurisation du secteur automobile, Aide ponctuelle
+                            jeune, Aide régionale, Aide aux demandeurs d'emploi longue
+                            durée, Aide exceptionnelle de solidarité, Prime de reclassement).
+                          type: number
+                          example: 12.21
+                        autres:
+                          title: Autres paiements
+                          description: Part du montant correspondant à d’autres paiements
+                            (Prime de Noel, Indemnité différentielle de reclassement,
+                            Acompte, Avance, Reversement).
+                          type: number
+                          example: 2.34
+        '400':
+          description: Paramètre(s) invalide(s)
+          content:
+            application/json:
+              examples:
+                entite_non_traitable_00380:
+                  value:
+                    errors:
+                    - code: '00380'
+                      title: Entité non traitable
+                      detail: L'identifiant France Travail est manquant
+                      source:
+                      meta: {}
+                  summary: Entité non traitable
+                  description: L'identifiant France Travail est manquant
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '404':
+          description: Non trouvée
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '503':
+          description: Erreur du fournisseur
+          content:
+            application/json:
+              examples:
+                unknown_error:
+                  value:
+                    errors:
+                    - code: '24999'
+                      title: Erreur inconnue du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et inconnue de notre service. L'équipe technique
+                        a été notifiée de cette erreur pour investigation.
+                      source:
+                      meta:
+                        provider: France Travail
+                  summary: Erreur inconnue du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et inconnue de notre service. L'équipe technique
+                    a été notifiée de cette erreur pour investigation.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '504':
+          description: Erreur d'intermédiaire
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Error"
+  "/api/v2/composition-familiale":
+    get:
+      summary: Quotient familial (CAF)
+      deprecated: true
+      description: |-
+        Quotient familial et composition de la famille d'un allocataire de la Caisse nationale des allocations familiales (CNAV). Attention, le quotient familial de la CAF n'a rien à voir avec le quotient familial fiscal utilisé pour le calcul de l'impôt sur le revenu
+
+        **Paramètres d'appel :** numéro d'allocataire et code postal
+
+        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnaf_quotient_familial)
+      parameters:
+      - name: Cache-Control
+        in: header
+        description: Si cette valeur est fixée à "no-cache", le système de cache est
+          alors ignoré et la donnée est directement récupérée depuis le fournisseur
+          de données.
+        schema:
+          type: string
+      - name: numeroAllocataire
+        in: query
+        description: Numéro d'allocataire. Numéro de 1 à 7 chiffres. Le numéro d'allocataire
+          n'est pas un numéro unique. Pour être identifiant, il doit être accompagné
+          d'un code postal.
+        required: true
+        schema:
+          type: number
+          format: string
+          example: 1234567
+      - name: codePostal
+        in: query
+        description: Code postal français (métropôle & DROM COM). Cette donnée permet
+          de faire la correspondance avec la CAF de rattachement de l’allocataire.
+        required: true
+        schema:
+          type: number
+          format: string
+          example: 75001
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données."
+        example: '13002526500013'
+        required: false
+        schema:
+          type: string
+      tags:
+      - Quotient familial
+      responses:
+        '200':
+          x-operationId: api_particulier_v2_cnaf_quotient_familial
+          description: Foyer tel qu'il est déclaré à la CAF
+          headers:
+            X-Response-Cached:
+              schema:
+                type: boolean
+                example: true
+                enum:
+                - true
+                - false
+                default: false
+              description: Indique si la réponse a été caché.
+            X-Cache-Expires-in:
+              schema:
+                type: number
+                nullable: true
+                example: 9001
+              description: Secondes avant que le cache n'expire. Si le cache est vide,
+                ce header est vide (mais présent). La durée du cache est de 1 heure.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  allocataires:
+                    title: Informations sur les parents composant la famille
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        nomPrenom:
+                          title: Nom et prénoms
+                          type: string
+                          description: Nom et prénoms du parent allocataire de la
+                            CAF
+                          example: JEAN JACQUES
+                        dateDeNaissance:
+                          title: Date de naissance
+                          type: string
+                          pattern: "^\\d{8}$"
+                          description: Date de naissance au format JJMMAAAA
+                          example: '01021970'
+                        sexe:
+                          title: Sexe
+                          description: Sexe du parent
+                          type: string
+                          example: M
+                          enum:
+                          - F
+                          - M
+                  enfants:
+                    title: Informations sur les enfants composant la famille
+                    description: 'La liste des enfants correspond à la notion d''enfant
+                      à charge au sens de la législation familiale. Il n''y a notamment
+                      pas d''obligation de lien de parenté avec l’enfant. Pour en
+                      savoir plus, consultez la FAQ https://particulier.api.gouv.fr/catalogue/cnav/quotient_familial#faq_entry_2_api_particulier_endpoint_cnav_quotient_familial:'
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        nomPrenom:
+                          title: Nom et prénoms
+                          type: string
+                          description: Nom et prénoms de l'enfant des allocataires
+                          example: JESSICA JACQUES
+                        dateDeNaissance:
+                          title: Date de naissance
+                          type: string
+                          pattern: "^\\d{8}$"
+                          description: Date de naissance au format JJMMAAAA
+                          example: '01031995'
+                        sexe:
+                          title: Sexe
+                          description: Sexe de l'enfant
+                          type: string
+                          example: F
+                          enum:
+                          - F
+                          - M
+                  adresse:
+                    title: Adresse de la famille
+                    type: object
+                    description: Adresse structurée au format de la poste. C'est l'adresse
+                      connue de la CNAV, il s'agit d'une information déclarative.
+                    properties:
+                      identite:
+                        title: Identité du destinataire
+                        type: string
+                        example: Monsieur JEAN JACQUES
+                        description: L'identité se compose de la civilité, du titre
+                          ou de la qualité, suivis du nom et du prénom.
+                      complementIdentite:
+                        title: Complément d'information du destinataire ou point de
+                          remise
+                        description: Numéro d'appartement, escalier
+                        type: string
+                        nullable: true
+                        example:
+                      complementIdentiteGeo:
+                        title: Complément d'information du point géographique
+                        type: string
+                        nullable: true
+                        example:
+                        description: Entrée, tour, immeuble, bâtiment, résidence
+                      numeroRue:
+                        title: Voie
+                        type: string
+                        description: Numéro et libellé de la voie
+                        example: 1 RUE DE LA GARE
+                      lieuDit:
+                        title: Lieu-dit
+                        type: string
+                        nullable: true
+                        example:
+                        description: 'Lieu-dit ou service particulier de distribution
+                          : poste restante, boîte postale'
+                      codePostalVille:
+                        title: Code postal
+                        type: string
+                        description: Code postal et localité de destination
+                        example: '75002'
+                      pays:
+                        title: Pays
+                        type: string
+                        example: FRANCE
+                  quotientFamilial:
+                    title: Quotient familial CAF de la famille
+                    type: integer
+                    description: Valeur du quotient familial calculée par la CAF
+                    example: 1045
+                  annee:
+                    title: Année du quotient familial
+                    type: integer
+                    description: Il s'agit toujours de l'année du mois précédent l'appel.
+                    example: 2021
+                  mois:
+                    title: Mois du quotient familial
+                    type: integer
+                    description: Le quotient familial transmis correspond au QF du
+                      mois M-1 (M étant le mois de l'appel).
+                    example: 6
+        '401': &1
+          description: Votre jeton d'API n'a pas été trouvé ou n'est pas actif
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: access_denied
+                  reason:
+                    type: string
+                    example: Token not found or inactive
+                  message:
+                    type: string
+                    example: Votre jeton d'API n'a pas été trouvé ou n'est pas actif
+        '404':
+          description: Dossier allocataire inexistant. Le document ne peut être édité.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: not_found
+                  reason:
+                    type: string
+                    example: Dossier allocataire inexistant. Le document ne peut être
+                      édité.
+                  message:
+                    type: string
+                    example: Dossier allocataire inexistant. Le document ne peut être
+                      édité.
+        '500': &2
+          description: Une erreur interne s'est produite, l'équipe a été prévenue.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: error
+                  reason:
+                    type: string
+                    example: Internal server error
+                  message:
+                    type: string
+                    example: Une erreur interne s'est produite, l'équipe a été prévenue.
+        '503':
+          description: Erreur inconnue du fournisseur de donnée (CNAV)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: data_provider_error
+                  reason:
+                    type: string
+                    example: Unknown error code 134
+                  message:
+                    type: string
+                    example: Erreur inconnue du fournisseur de donnée (CNAV)
+  "/api/v2/situations-pole-emploi":
+    get:
+      summary: Statut demandeur d'emploi
+      deprecated: true
+      description: |-
+        Données d'identité, de contact et de statut du demandeur d'emploi.
+        **Paramètres d'appel :** Nom d’utilisateur France Travail choisi par le particulier lors de la création de son espace personnel en ligne
+        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_pole_emploi_statut)
+      parameters:
+      - name: identifiant
+        required: true
+        in: query
+        description: Identifiant France Travail choisi par le particulier lors de
+          la création de son espace personnel en ligne.
+        schema:
+          type: string
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données."
+        example: '13002526500013'
+        required: false
+        schema:
+          type: string
+      tags:
+      - Demandeurs d'emploi
+      responses:
+        '200':
+          x-operationId: api_particulier_v2_pole_emploi_statut
+          description: La situation France Travail d'un individu
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  identifiant:
+                    title: Nom d'utilisateur France Travail
+                    type: string
+                    description: Identifiant France Travail, tel qu'il a été renseigné
+                      en paramètre d'appel. Cet identifiant est le nom d'utilisateur
+                      tel que choisi par le particulier lors de la création de son
+                      espace personnel en ligne.
+                    example: martin.jacques
+                  civilite:
+                    title: Civilité
+                    description: Civilité du demandeur d'emploi, Madame ou Monsieur
+                    type: string
+                    example: M.
+                    enum:
+                    - MME
+                    - M.
+                  nom:
+                    title: Nom de naissance
+                    type: string
+                    description: Nom de naissance du demandeur d'emploi
+                    example: MARTIN
+                  nomUsage:
+                    title: Nom d'usage
+                    type: string
+                    description: Nom d'usage du demandeur d'emploi
+                    nullable: true
+                    example:
+                  prenom:
+                    title: Prénom
+                    type: string
+                    example: JACQUES
+                    description: Prénom ddu demandeur d'emploi, limité à 13 caractères
+                  sexe:
+                    title: Sexe
+                    type: string
+                    description: Sexe du demandeur d'emploi
+                    example: Masculin
+                  dateNaissance:
+                    title: Date de naissance
+                    format: date
+                    type: string
+                    description: Date de naissance du demandeur d'emploi au format
+                      YYYY-MM-DD
+                    example: 1995-02-02
+                  codeCertificationCNAV:
+                    title: Code du statut de certification d'identité CNAV
+                    type: string
+                    description: 'France Travail dépend d''un flux de certification
+                      d''identité émis par la CNAV, un particulier peut avoir été
+                      certifié ou non. Sont considérés comme certifés, les statuts
+                      suivants : - VC IDENTITE CERTIFIEE - IC : IDENTITE ASSIMILEE
+                      CERTIFIEE - PC : IDENTITE CERTIFIEE PARTIELLEMENT Sont considérés
+                      comme non-certifiés : - AC : ATTENTE TRAITEMENT RETOUR CNAV
+                      - DC : DEMANDE CERTIF. ENVOYEE - EC : ECHEC DE CERTIFICATION
+                      CNAV - null : IDENTITE NON CERTIFIEE - RC : REFUS PROPOSITION
+                      DE CERTIFICATION'
+                    example: VC
+                    enum:
+                    - VC
+                    - IC
+                    - PC
+                    - AC
+                    - DC
+                    - RC
+                    -
+                  telephone:
+                    title: Téléphone principal
+                    type: string
+                    description: Numéro de téléphone principal du demandeur d'emploi
+                    example: '0636676767'
+                  telephone2:
+                    title: Téléphone secondaire
+                    type: string
+                    description: Numéro de téléphone secondaire du demandeur d'emploi
+                    nullable: true
+                    example: '1122334455'
+                  email:
+                    title: E-mail
+                    type: string
+                    nullable: true
+                    description: Adresse e-mail du demandeur d'emploi
+                    example: martin.jacques@france.fr
+                  adresse:
+                    title: Adresse
+                    type: object
+                    description: Adresse du demandeur d'emploi, déclarée par le particulier
+                      lors de son inscription à France Travail ou suite à une déclaration
+                      de changement d’adresse.
+                    properties:
+                      codePostal:
+                        type: string
+                        description: Code postal
+                        example: '75001'
+                      INSEECommune:
+                        type: string
+                        example: '75101'
+                      localite:
+                        type: string
+                        example: 75001 Paris
+                      ligneVoie:
+                        type: string
+                        example: 21 RUE DES MARMOTS
+                      ligneComplementDestinataire:
+                        type: string
+                        nullable: true
+                        example:
+                      ligneComplementAdresse:
+                        type: string
+                        nullable: true
+                        example:
+                      ligneComplementDistribution:
+                        type: string
+                        nullable: true
+                        example:
+                      ligneNom:
+                        type: string
+                        example: MARTIN
+                  dateInscription:
+                    title: Date d'inscription
+                    format: date
+                    type: string
+                    description: Date d'inscription à France Travail au format YYYY-MM-DD
+                    example: 2021-01-07
+                  dateCessationInscription:
+                    title: Date de cessation d'inscription au format YYYY-MM-DD
+                    description: Date de cessation d'inscription à France Travail
+                    type: string
+                    format: date
+                    nullable: true
+                    example: 2023-03-12
+                  codeCategorieInscription:
+                    title: Code de la catégorie d'inscription
+                    description: |
+                      Code de la catégorie d'inscription du particulier à France Travail.
+                        - 1 : PERSONNE SANS EMPLOI DISPONIBLE DUREE INDETERMINEE PLEIN TPS
+                        - 2 : PERSONNE SANS EMPLOI DISPONIBLE DUREE INDETERMINEE PARTIEL
+                        - 3 : PERSONNE SANS EMPLOI DISPONIBLE DUREE DETERMINEE OU SAISON
+                        - 4 : PERSONNE SANS EMPLOI NON DISPONIBLE IMMEDIATEMENT
+                        - 5 : PERSONNE POURVUE D'UN EMPLOI A LA RECHERCHE D'UN AUTRE"
+                    type: integer
+                    example: 1
+                    enum:
+                    - 1
+                    - 2
+                    - 3
+                    - 4
+                    - 5
+                  libelleCategorieInscription:
+                    title: Libellé de la catégorie d'inscription
+                    description: Libellé de la catégorie d'inscription du particulier
+                      à France Travail, associé au cod précédent.
+                    type: string
+                    example: PERSONNE SANS EMPLOI DISPONIBLE DUREE INDETERMINEE PLEIN
+                      TPS
+                    enum:
+                    - PERSONNE SANS EMPLOI DISPONIBLE DUREE INDETERMINEE PLEIN TPS
+                    - PERSONNE SANS EMPLOI DISPONIBLE DUREE INDETERMINEE PARTIEL
+                    - PERSONNE SANS EMPLOI DISPONIBLE DUREE DETERMINEE OU SAISON
+                    - PERSONNE SANS EMPLOI NON DISPONIBLE IMMEDIATEMENT
+                    - PERSONNE POURVUE D'UN EMPLOI A LA RECHERCHE D'UN AUTRE
+        '401': *1
+        '404':
+          description: Aucune situation France Travail n'a pu être trouvée avec les
+            critères de recherche fournis
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: not_found
+                  reason:
+                    type: string
+                    example: Situation not found
+                  message:
+                    type: string
+                    example: Aucune situation France Travail n'a pu être trouvée avec
+                      les critères de recherche fournis
+        '500':
+          description: La réponse du fournisseur de donnée est inexploitable
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: invalid_response
+                  reason:
+                    type: string
+                    example: Data provider returned an invalid data format.
+                  message:
+                    type: string
+                    example: La réponse du fournisseur de donnée est inexploitable
+        '503': &3
+          description: Une erreur est survenue lors de l'appel au fournisseur de donnée
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: network_error
+                  reason:
+                    type: string
+                    example: timeout of 10000 ms exceeded
+                  message:
+                    type: string
+                    example: Une erreur est survenue lors de l'appel au fournisseur
+                      de donnée
+  "/api/v2/etudiants":
+    get:
+      deprecated: true
+      tags:
+      - Éducation et études
+      parameters:
+      - name: ine
+        description: Identifiant National Étudiant (INE). Cet identifiant est unique
+          à chaque étudiant sur le territoire français. Il est composé de 11 caractères,
+          10 chiffres et 1 lettre, et depuis la rentrée 2018, 9 chiffres et 2 lettres.
+          Les étudiants peuvent retrouver leur numéro INE sur leur carte étudiant
+          et leur certificat de scolarité.
+        in: query
+        schema:
+          type: string
+          pattern: "^[0-9a-zA-Z]{11}$"
+          example: 1234567890G
+      - name: nom
+        description: Nom de naissance de l'étudiant
+        in: query
+        schema:
+          type: string
+      - name: prenom
+        description: Prénom de l'étudiant
+        in: query
+        schema:
+          type: string
+      - name: dateDeNaissance
+        description: Date de naissance de l'étudiant
+        in: query
+        schema:
+          type: string
+          pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+          example: '1992-11-29'
+      - name: lieuDeNaissance
+        description: |
+          Le lieu de naissance est donné par le code Insee composé de 5 caractères.
+
+          - Dans le cas d'un étudiant né en France, il s'agit du code Insee de la commune de naissance.
+
+          - Dans le cas d'un étudiant né à l'étranger, il s'agit du code Insee du pays de naissance, construit avec deux caractères « 99 » auxquels sont concaténés les 3 caractères du code pays de la BCN. Ce champ est facultatif, même s'il est recommandé en cas de doublon."
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: sexe
+        description: Sexe de l'étudiant
+        in: query
+        schema:
+          type: string
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données."
+        example: '13002526500013'
+        required: false
+        schema:
+          type: string
+      summary: Statut étudiant
+      description: |-
+        Admissions et inscriptions d'un étudiant aux établissements d'enseignement supérieur.
+        **Paramètres d'appel :** Pour appeler l'API statut étudiant, deux modes d'appel sont possibles :
+         - INE, l'identifiant national étudiant ;
+         - l'état civil de l'étudiant: nom, prénom, date de naissance, sexe et lieu de naissance.
+
+        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_mesri_student_status)
+      security:
+      - franceConnectToken: []
+        apiKey: []
+      responses:
+        '200':
+          x-operationId: api_particulier_v2_mesri_student_status
+          description: La situation d'un étudiant et ses inscriptions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  nom:
+                    title: Nom de naissance
+                    type: string
+                    description: Nom de naissance de l'étudiant
+                    example: Moustaki
+                  prenom:
+                    title: Prénom
+                    type: string
+                    description: Prénom de l'étudiant
+                    example: Georges
+                  dateNaissance:
+                    title: Date de naissance
+                    type: string
+                    format: date
+                    description: Date de naissance de l'étudiant
+                    example: 1992-11-29
+                  inscriptions:
+                    title: Liste des admissions et inscriptions de l'étudiant pour
+                      l'année en cours
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        dateDebutInscription:
+                          title: Date de début d'inscription
+                          type: string
+                          format: date
+                          description: Date de début de la période d'études dans l'établissement
+                          example: 2022-09-01
+                        dateFinInscription:
+                          title: Date de fin d'inscription
+                          type: string
+                          format: date
+                          description: Date de fin de la période d'étude dans l'établissement
+                          example: 2023-08-31
+                        statut:
+                          title: Statut de l'inscription
+                          type: string
+                          description: |
+                            Statut de l'inscription de l'étudiant. Il existe deux modalités différentes :
+                            - admis : l'étudiant est pré-inscrit dans l'établissement mais la procédure complète d'inscription et le règlement des droits d'inscription ne sont pas terminés. Les étudiants "admis" passent au statut "inscrit" une fois leurs droits d'inscription régularisés (paiement des droits, premier versement des droits ou acquittement des droits selon la situation de l'étudiant et les règles de l'établissement.) Tous les étudiants "admis" ne sont donc pas forcément de futurs étudiants "inscrits".
+
+                            - inscrit : l'étudiant est inscrit dans l'établissement car il est en règle de ses droits d'inscription. L'étudiant peut être inscrit dans plusieurs établissements."
+                          example: admis
+                          enum:
+                          - admis
+                          - inscrit
+                        regime:
+                          title: Régime de formation
+                          type: string
+                          description: |
+                            Régime de formation de l'étudiant. Il existe deux modalités différentes :
+                            - formation initiale : Ce champ indique que l'étudiant est en formation initiale, soit dans une des situations suivantes : formation initiale classique, reprise d'études non financée sans convention et contrat d'apprentissage ;
+                            - formation continue : Ce champ indique que l'étudiant est en formation continue ou en contrat de professionalisation."
+                          example: formation initiale
+                          enum:
+                          - formation initiale
+                          - formation continue
+                        codeCommune:
+                          title: Lieu d'études
+                          type: string
+                          description: Code officiel géographique (code COG de l'Insee)
+                            de la commune du lieu d'études.
+                          example: '29085'
+                        etablissement:
+                          title: Établissement de l'inscription
+                          type: object
+                          properties:
+                            uai:
+                              title: Identifiant de l'établissement UAI
+                              type: string
+                              description: Code UAI (Unité administrative immatriculée)
+                                de l'établissement. Cet identifiant unique de l'établissement
+                                scolaire est composé de 7 chiffres et d’une lettre,
+                                les trois premiers chiffres correspondant au numéro
+                                de département de l’établissement.
+                              example: 0011402U
+                            nom:
+                              title: Nom de l'établissement
+                              type: string
+                              description: Appelation officielle de l'établissement
+                                associée au code UAI
+                              example: EGC AIN BOURG EN BRESSE EC GESTION ET COMMERCE
+                                (01000)
+        '401': *1
+        '404': &4
+          description: Aucun étudiant n'a pu être trouvé avec les critères de recherche
+            fournis
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: not_found
+                  reason:
+                    type: string
+                    example: Student not found
+                  message:
+                    type: string
+                    example: Aucun étudiant n'a pu être trouvé avec les critères de
+                      recherche fournis
+        '500': *2
+        '503': *3
+  "/api/v2/etudiants-boursiers":
+    get:
+      deprecated: true
+      tags:
+      - Éducation et études
+      parameters:
+      - name: ine
+        description: Identifiant National Étudiant (INE). Cet identifiant est unique
+          à chaque étudiant sur le territoire français. Il est composé de 11 caractères,
+          10 chiffres et 1 lettre, et depuis la rentrée 2018, 9 chiffres et 2 lettres.
+          Les étudiants peuvent retrouver leur numéro INE sur leur carte étudiant
+          et leur certificat de scolarité.
+        in: query
+        schema:
+          type: string
+          pattern: "^[0-9a-zA-Z]{11}$"
+          example: 1234567890G
+      - name: nom
+        description: Nom de naissance de l'étudiant
+        in: query
+        schema:
+          type: string
+      - name: prenoms
+        description: Prénoms de l'étudiant, à séparer uniquement avec des espaces
+          et non des virgules ou points-virgules.
+        in: query
+        schema:
+          type: string
+      - name: dateDeNaissance
+        description: 'Date de naissance de l''étudiant. Format: YYYY-MM-DD'
+        in: query
+        schema:
+          type: string
+          pattern: "^\\d{4}-\\d{2}-\\d{2}$"
+          example: '1992-11-29'
+      - name: lieuDeNaissance
+        description: Lieu de naissance de l'étudiant
+        in: query
+        required: false
+        schema:
+          type: string
+          example: Angers
+      - name: sexe
+        description: Sexe de l'étudiant
+        in: query
+        schema:
+          type: string
+          enum:
+          - M
+          - F
+      - name: recipient
+        in: query
+        description: |-
+          "**Bénéficiaire de l’appel**
+
+          SIRET de l’administration destinatrice des données."
+        example: '13002526500013'
+        required: false
+        schema:
+          type: string
+      summary: Statut étudiant boursier
+      description: |-
+        Statut et échelon boursier d'un étudiant, délivrés par le Cnous.
+        **Paramètres d'appel :** Pour appeler l'API statut boursier, deux modes d'appel sont possibles :
+         - INE, l'identifiant national étudiant ;
+         - l'état civil de l'étudiant: nom, prénom, date de naissance, sexe (optionnel) et lieu de naissance (optionnel).
+
+        **Données disponibles en bac à sable :** [liste](https://github.com/etalab/siade_staging_data/blob/develop/payloads/api_particulier_v2_cnous_student_scholarship)
+      security:
+      - franceConnectToken: []
+        apiKey: []
+      responses:
+        '200':
+          x-operationId: api_particulier_v2_cnous_student_scholarship
+          description: La situation d'un étudiant boursier
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  nom:
+                    title: Nom de naissance
+                    type: string
+                    description: Nom de naissance de l'étudiant
+                    example: Moustaki
+                  prenom:
+                    title: Prénom 1
+                    type: string
+                    description: Premier prénom de l'étudiant
+                    example: Georges
+                  prenom2:
+                    title: Prénom 2
+                    type: string
+                    description: Deuxième prénom de l'étudiant
+                    example: Claude
+                  dateNaissance:
+                    title: Date de naissance
+                    type: string
+                    format: date
+                    description: Date de naissance de l'étudiant
+                    example: 1992-11-29
+                  lieuNaissance:
+                    title: Lieu de naissance
+                    type: string
+                    description: Libellé de la commune de naissance de l'étudiant
+                    example: Poitiers
+                  sexe:
+                    title: Sexe
+                    type: string
+                    description: Sexe de l'étudiant
+                    example: M
+                    enum:
+                    - M
+                    - F
+                  boursier:
+                    title: Statut boursier
+                    type: boolean
+                    description: Indique si l'étudiant est boursier
+                    example: true
+                  echelonBourse:
+                    title: Échelon de la bourse
+                    type: string
+                    description: '"Il existe 8 échelons de bourse, de 0bis à 7, correspondant
+                      aux montants reçus par l''étudiant pour l''année scolaire. Pour
+                      en savoir plus, consulter la FAQ : https://particulier.api.gouv.fr/catalogue/cnous/statut_etudiant_boursier#faq_entry_answer_0_api_particulier_endpoint_cnous_statut_etudiant_boursier."
+
+                      '
+                    example: '6'
+                    enum:
+                    - 0bis
+                    - '1'
+                    - '2'
+                    - '3'
+                    - '4'
+                    - '5'
+                    - '6'
+                    - '7'
+                  email:
+                    title: E-mail
+                    type: string
+                    description: Adresse email de l'étudiant
+                    example: georges@moustaki.fr
+                  dateDeRentree:
+                    title: Date de rentrée
+                    type: string
+                    format: date
+                    description: Date de début de rentrée scolaire ou universitaire
+                    example: 2019-09-01
+                  dureeVersement:
+                    title: Durée de versement de la bourse
+                    type: number
+                    description: Nombre de mois de versement de la bourse
+                    example: 12
+                  statut:
+                    title: Code de statut de la bourse
+                    type: number
+                    description: Code du statut de la bourse, 0 si définitif, >0 si
+                      provisoire (conditionnel)
+                    example: 0
+                  statutLibelle:
+                    title: Libellé du statut de la bourse
+                    type: string
+                    description: Le libellé associé au code de statut de la bourse
+                    example: définitif
+                  villeEtudes:
+                    title: Ville d'études
+                    type: string
+                    description: Libellé de la ville d'études de l'étudiant
+                    example: Brest
+                  etablissement:
+                    title: Établissement d'études
+                    type: string
+                    description: L'établissement d'études de l'étudiant
+                    example: Carnot
+        '400':
+          description: Mauvais paramètres d'appels
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: bad_request
+                  reason:
+                    type: string
+                    example: Le sexe est manquant
+                  message:
+                    type: string
+                    example: Le sexe est manquant
+        '401': *1
+        '404': *4
+        '409':
+          description: Des doublons ont été trouvé, merci d'affiner vos critères.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    example: conflict
+                  reason:
+                    type: string
+                    example: Plusieurs ressources correspondent aux critères
+                  message:
+                    type: string
+                    example: Plusieurs ressources correspondent aux critères
+        '500': *2
+        '503': *3
+  "/api/ping":
+    get:
+      summary: Statut des serveurs applicatifs API Particulier
+      description: |
+        Cet endpoint permet de connaître l'état du serveur API Particulier.
+        Si le résultat est autre qu'un code HTTP 200, le serveur rencontre un problème.
+        On peut alors considérer que les résultats des autres endpoints seront perturbés.
+      tags:
+      - Ping
+      security: []
+      responses: &5
+        '200':
+          description: pong
+          content:
+            application/json:
+              schema:
+                type: string
+                example: pong
+                pattern: "^pong$"
+        '500': *2
+  "/api/impots/ping":
+    get:
+      summary: Statut des serveurs de la DGFIP
+      description: |
+        Cet endpoint permet de connaitre l'état du serveur de la DGFIP sur lequel s'appuie API Particulier pour vous restituer les données impôts.
+        Si le résultat est autre qu'un code HTTP 200, le serveur de la DGFIP rencontre un problème.
+        On peut alors considérer que les résultats de l'endpoint /impots/svair seront perturbés.
+      tags:
+      - Ping
+      security: []
+      deprecated: true
+      responses: *5
+  "/api/caf/ping":
+    get:
+      summary: Statut des serveurs de la CAF
+      description: |
+        Cet endpoint permet de connaitre l'état du serveur de la CAF sur lequel s'appuie API Particulier pour vous restituer les données famille.
+        Si le résultat est autre qu'un code HTTP 200, le serveur de la CAF rencontre un problème.
+        On peut alors considérer que les résultats de l'endpoint /caf/famille seront perturbés.
+      tags:
+      - Ping
+      deprecated: true
+      security: []
+      responses: *5
+  "/api/introspect":
+    get:
+      summary: Introspection du jeton donné en paramètre
+      description: Cet endpoint permet de découvrir les informations correspondant
+        à un jeton donné
+      tags:
+      - Jeton
+      responses:
+        '200':
+          description: L'introspection du jeton
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  _id:
+                    type: string
+                    description: Id du jeton introspecté
+                  name:
+                    type: string
+                    description: Ce champ est systématiquement vide. Celui-ci correspondant
+                      avant au nom du jeton.
+                  scopes:
+                    type: array
+                    description: Scopes techniques associés au jeton
+                    items:
+                      type: string
+        '401': *1
+        '500': *2
+security:
+- apiKey: []
+servers:
+- url: https://particulier.api.gouv.fr
+  description: Environnement de production
+- url: https://staging.particulier.api.gouv.fr
+  description: Environnement de staging
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        error:
+          type: string
+          example:
+        reason:
+          type: string
+          example:
+        message:
+          type: string
+          example:
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      name: X-Api-Key
+      in: header
+      description: Jeton d'authentification obtenu suite à la validation de votre
+        <a href='https://datapass.api.gouv.fr/'>demande d'habilitation</a>, visible
+        sur <a href='https://particulier.api.gouv.fr/compte'>le portail API Particulier</a>.
+        Obligatoire, sauf sur une API FranceConnectée lorsqu'un jeton FranceConnect
+        est présent.
+    franceConnectToken:
+      type: http
+      scheme: bearer
+      bearerFormat: Jeton FranceConnect
+      description: Jeton FranceConnect obtenu suite à une cinématique de connexion
+        FranceConnect. Ne fonctionne que sur les APIs FranceConnectées. Remplace l'authentification
+        par X-Api-Key sur les APIs FranceConnectées.

--- a/config/api-particulier-openapi-v3.yml
+++ b/config/api-particulier-openapi-v3.yml
@@ -26,7 +26,7 @@ info:
 
     ### Accéder à la version 2 de l'API
 
-    Vous pouvez accéder à la documentation v2 [ici](https://particulier.api.gouv.fr/developpeurs/openapi).
+    Vous pouvez accéder à la documentation v2 [ici](https://particulier.api.gouv.fr/developpeurs/openapi-v2).
 
     ### Périmètre des données retournées
 
@@ -343,8 +343,7 @@ paths:
                     type: object
                     properties:
                       est_beneficiaire:
-                        title: Statut bénéficiaire de l'allocation adulte handicapé
-                          (AAH)
+                        title: Est bénéficiaire de l'allocation adulte handicapé (AAH)
                         type: boolean
                         example: true
                         description: Indique que le particulier est bénéficiaire de
@@ -612,8 +611,7 @@ paths:
                     type: object
                     properties:
                       est_beneficiaire:
-                        title: Statut bénéficiaire de l'allocation adulte handicapé
-                          (AAH)
+                        title: Est bénéficiaire de l'allocation adulte handicapé (AAH)
                         type: boolean
                         example: true
                         description: Indique que le particulier est bénéficiaire de
@@ -1003,7 +1001,7 @@ paths:
                     type: object
                     properties:
                       est_beneficiaire:
-                        title: Statut bénéficiaire de l'allocation de soutien familial
+                        title: Est bénéficiaire de l'allocation de soutien familial
                           (ASF)
                         type: boolean
                         example: true
@@ -1273,7 +1271,7 @@ paths:
                     type: object
                     properties:
                       est_beneficiaire:
-                        title: Statut bénéficiaire de l'allocation de soutien familial
+                        title: Est bénéficiaire de l'allocation de soutien familial
                           (ASF)
                         type: boolean
                         example: true
@@ -1666,7 +1664,7 @@ paths:
                     type: object
                     properties:
                       est_beneficiaire:
-                        title: Statut bénéficiaire de la complémentaire de santé solidaire
+                        title: Est bénéficiaire de la complémentaire de santé solidaire
                           (C2S)
                         type: boolean
                         example: true
@@ -1944,7 +1942,7 @@ paths:
                     type: object
                     properties:
                       est_beneficiaire:
-                        title: Statut bénéficiaire de la complémentaire de santé solidaire
+                        title: Est bénéficiaire de la complémentaire de santé solidaire
                           (C2S)
                         type: boolean
                         example: true
@@ -2055,9 +2053,9 @@ paths:
                     des données
               schema:
                 "$ref": "#/components/schemas/Error"
-  "/v3/dss/participation_familial_psu/identite":
+  "/v3/dss/participation_familiale_aeje/identite":
     get:
-      summary: "[Identité] API Prestation de service unique (PSU)"
+      summary: "[Identité] Participation familiale EAJE"
       tags:
       - Prochainement
       parameters:
@@ -2227,7 +2225,7 @@ paths:
         required: false
       security:
       - jwt_bearer_token: []
-      description: API Prestation de service unique (PSU)
+      description: Participation familiale EAJE
       responses:
         '401':
           description: Non autorisé
@@ -2346,7 +2344,7 @@ paths:
                 type: integer
               description: La fin de la période courante (en format timestamp)
               example: 1637223155
-          x-operationId: api_particulier_v3_cnav_participation_familial_psu_with_civility
+          x-operationId: api_particulier_v3_cnav_participation_familiale_aeje_with_civility
           content:
             application/json:
               schema:
@@ -2367,7 +2365,7 @@ paths:
                           type: object
                           properties:
                             nom_naissance:
-                              title: Nom
+                              title: Nom de naissance
                               type: string
                               description: Nom de naissance de l'allocataire ou du
                                 conjoint.
@@ -2398,13 +2396,14 @@ paths:
                               - F
                               - M
                             code_cog_insee_commune_naissance:
-                              title: Code Cog de la ville de naissance
+                              title: COG de la commune de naissance
                               type: string
-                              description: Code Cog de la ville de naissance
+                              description: Code officiel géographique (COG) de la
+                                commune de naissance
                               example: '75113'
                       enfants:
                         type: array
-                        title: Données d'identité des enfants composant la famille
+                        title: Données d'identité des enfants
                         description: Liste des données d'identité des enfants composant
                           la famille, le cas échéant. La provenance de ces données
                           n'est pas sourcée précisément et diffère selon la CAF ou
@@ -2443,9 +2442,10 @@ paths:
                               - F
                               - M
                             code_cog_insee_commune_naissance:
-                              title: Code Cog de la ville de naissance
+                              title: COG de la commune de naissance
                               type: string
-                              description: Code Cog de la ville de naissance
+                              description: Code officiel géographique (COG) de la
+                                commune de naissance
                               example: '75113'
                       adresse:
                         title: Adresse de la famille
@@ -2456,11 +2456,11 @@ paths:
                           la MSA, l'information sera donc obsolète.
                         properties:
                           destinataire:
-                            title: Identité du destinataire
+                            title: Destinataire
                             type: string
                             example: Monsieur JEAN JACQUES
-                            description: 'Identité du destinataire : Civilité, titre
-                              ou qualité + nom et prénom'
+                            description: Civilité, titre ou qualité, nom et prénom
+                              du destinataire.
                           complement_information:
                             title: Complément d'information du destinataire ou point
                               de remise
@@ -2502,7 +2502,7 @@ paths:
                         - lieu_dit
                         - code_postal_ville
                         - pays
-                      parametres_calcul_psu:
+                      parametres_calcul_participation_familiale:
                         title: Paramètre pris en compte pour le calcul du tarif
                         description: Liste des paramètres pris en compte lors du calcul
                           tarifaire de l'allocation
@@ -2552,7 +2552,7 @@ paths:
                     - allocataires
                     - enfants
                     - adresse
-                    - parametres_calcul_psu
+                    - parametres_calcul_participation_familiale
                     additionalProperties: false
                   links:
                     type: object
@@ -2676,9 +2676,9 @@ paths:
                     effectuées, veuillez réessayer plus tard.'
               schema:
                 "$ref": "#/components/schemas/Error"
-  "/v3/dss/participation_familial_psu/france_connect":
+  "/v3/dss/participation_familiale_aeje/france_connect":
     get:
-      summary: "[FranceConnect] API Prestation de service unique (PSU)"
+      summary: "[FranceConnect] Participation familiale EAJE"
       tags:
       - Prochainement
       parameters:
@@ -2694,7 +2694,7 @@ paths:
           type: string
       security:
       - jwt_bearer_token: []
-      description: API Prestation de service unique (PSU)
+      description: Participation familiale EAJE
       responses:
         '403':
           description: Accès interdit
@@ -2735,7 +2735,7 @@ paths:
                 example: 9001
               description: Secondes avant que le cache n'expire. Si le cache est vide,
                 ce header est vide (mais présent). La durée du cache est de 1 heure.
-          x-operationId: api_particulier_v3_cnav_participation_familial_psu_with_france_connect
+          x-operationId: api_particulier_v3_cnav_participation_familiale_aeje_with_france_connect
           content:
             application/json:
               schema:
@@ -2756,7 +2756,7 @@ paths:
                           type: object
                           properties:
                             nom_naissance:
-                              title: Nom
+                              title: Nom de naissance
                               type: string
                               description: Nom de naissance de l'allocataire ou du
                                 conjoint.
@@ -2787,13 +2787,14 @@ paths:
                               - F
                               - M
                             code_cog_insee_commune_naissance:
-                              title: Code Cog de la ville de naissance
+                              title: COG de la commune de naissance
                               type: string
-                              description: Code Cog de la ville de naissance
+                              description: Code officiel géographique (COG) de la
+                                commune de naissance
                               example: '75113'
                       enfants:
                         type: array
-                        title: Données d'identité des enfants composant la famille
+                        title: Données d'identité des enfants
                         description: Liste des données d'identité des enfants composant
                           la famille, le cas échéant. La provenance de ces données
                           n'est pas sourcée précisément et diffère selon la CAF ou
@@ -2832,9 +2833,10 @@ paths:
                               - F
                               - M
                             code_cog_insee_commune_naissance:
-                              title: Code Cog de la ville de naissance
+                              title: COG de la commune de naissance
                               type: string
-                              description: Code Cog de la ville de naissance
+                              description: Code officiel géographique (COG) de la
+                                commune de naissance
                               example: '75113'
                       adresse:
                         title: Adresse de la famille
@@ -2845,11 +2847,11 @@ paths:
                           la MSA, l'information sera donc obsolète.
                         properties:
                           destinataire:
-                            title: Identité du destinataire
+                            title: Destinataire
                             type: string
                             example: Monsieur JEAN JACQUES
-                            description: 'Identité du destinataire : Civilité, titre
-                              ou qualité + nom et prénom'
+                            description: Civilité, titre ou qualité, nom et prénom
+                              du destinataire.
                           complement_information:
                             title: Complément d'information du destinataire ou point
                               de remise
@@ -2891,7 +2893,7 @@ paths:
                         - lieu_dit
                         - code_postal_ville
                         - pays
-                      parametres_calcul_psu:
+                      parametres_calcul_participation_familiale:
                         title: Paramètre pris en compte pour le calcul du tarif
                         description: Liste des paramètres pris en compte lors du calcul
                           tarifaire de l'allocation
@@ -2941,7 +2943,7 @@ paths:
                     - allocataires
                     - enfants
                     - adresse
-                    - parametres_calcul_psu
+                    - parametres_calcul_participation_familiale
                     additionalProperties: false
                   links:
                     type: object
@@ -3254,13 +3256,13 @@ paths:
                     type: object
                     properties:
                       est_beneficiaire:
-                        title: Statut bénéficiaire de la prime d'activité
+                        title: Est bénéficiaire de la prime d'activité
                         type: boolean
                         example: true
                         description: Indique que le particulier est bénéficiaire de
                           la prime d'activité au moment de l'appel.
                       avec_majoration:
-                        title: Prime d'activité majorée
+                        title: Prime d'activité avec majoration
                         type: boolean
                         nullable: true
                         description: "Indique que la prime d'activité du particulier
@@ -3369,6 +3371,100 @@ paths:
                     des données
               schema:
                 "$ref": "#/components/schemas/Error"
+        '502':
+          description: Erreur du fournisseur
+          content:
+            application/json:
+              examples:
+                provider_unknown_error:
+                  value:
+                    errors:
+                    - code: '37999'
+                      title: Erreur inconnue du fournisseur de données
+                      detail: La réponse retournée par le fournisseur de données est
+                        invalide et inconnue de notre service. L'équipe technique
+                        a été notifiée de cette erreur pour investigation.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur inconnue du fournisseur de données
+                  description: La réponse retournée par le fournisseur de données
+                    est invalide et inconnue de notre service. L'équipe technique
+                    a été notifiée de cette erreur pour investigation.
+              schema:
+                "$ref": "#/components/schemas/Error"
+        '504':
+          description: Erreur d'intermédiaire
+          content:
+            application/json:
+              examples:
+                timeout_error:
+                  value:
+                    errors:
+                    - code: '37002'
+                      title: Intermédiaire hors-délai
+                      detail: Temps d’attente d’une réponse du fournisseur de données
+                        écoulé.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Intermédiaire hors-délai
+                  description: Temps d’attente d’une réponse du fournisseur de données
+                    écoulé.
+                provider_unavailable_error:
+                  value:
+                    errors:
+                    - code: '37001'
+                      title: Service non disponible
+                      detail: Service du fournisseur de données temporairement indisponible
+                        ou en maintenance.
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Service non disponible
+                  description: Service du fournisseur de données temporairement indisponible
+                    ou en maintenance.
+                network_error:
+                  value:
+                    errors:
+                    - code: '00501'
+                      title: Erreur réseau
+                      detail: Problème de connexion au serveur distant. L'erreur peut
+                        venir soit du fournisseur, soit de API Entreprise. Il s'agit
+                        souvent d'une erreur temporaire.
+                      source:
+                      meta:
+                        retry_in: 10
+                  summary: Erreur réseau
+                  description: Problème de connexion au serveur distant. L'erreur
+                    peut venir soit du fournisseur, soit de API Entreprise. Il s'agit
+                    souvent d'une erreur temporaire.
+                dns_resolution_error:
+                  value:
+                    errors:
+                    - code: '37004'
+                      title: Erreur de résolution DNS
+                      detail: Problème de résolution DNS de l'adresse du serveur
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: Erreur de résolution DNS
+                  description: Problème de résolution DNS de l'adresse du serveur
+                provider_error:
+                  value:
+                    errors:
+                    - code: '37008'
+                      title: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                      detail: 'Erreur de fournisseur de donnée : Trop de requêtes
+                        effectuées, veuillez réessayer plus tard.'
+                      source:
+                      meta:
+                        provider: CNAV
+                  summary: 'Erreur auprès du fournisseur de données : trop de requêtes'
+                  description: 'Erreur de fournisseur de donnée : Trop de requêtes
+                    effectuées, veuillez réessayer plus tard.'
+              schema:
+                "$ref": "#/components/schemas/Error"
   "/v3/dss/prime_activite/france_connect":
     get:
       summary: "[FranceConnect] Statut prime d'activité"
@@ -3439,13 +3535,13 @@ paths:
                     type: object
                     properties:
                       est_beneficiaire:
-                        title: Statut bénéficiaire de la prime d'activité
+                        title: Est bénéficiaire de la prime d'activité
                         type: boolean
                         example: true
                         description: Indique que le particulier est bénéficiaire de
                           la prime d'activité au moment de l'appel.
                       avec_majoration:
-                        title: Prime d'activité majorée
+                        title: Prime d'activité avec majoration
                         type: boolean
                         nullable: true
                         description: "Indique que la prime d'activité du particulier
@@ -3946,7 +4042,7 @@ paths:
                           type: object
                           properties:
                             nom_naissance:
-                              title: Nom
+                              title: Nom de naissance
                               type: string
                               description: Nom de naissance de l'allocataire ou du
                                 conjoint.
@@ -3978,7 +4074,7 @@ paths:
                               - M
                       enfants:
                         type: array
-                        title: Données d'identité des enfants composant la famille
+                        title: Données d'identité des enfants
                         description: Liste des données d'identité des enfants composant
                           la famille, le cas échéant. La provenance de ces données
                           n'est pas sourcée précisément et diffère selon la CAF ou
@@ -4025,11 +4121,11 @@ paths:
                           la MSA, l'information sera donc obsolète.
                         properties:
                           destinataire:
-                            title: Identité du destinataire
+                            title: Destinataire
                             type: string
                             example: Monsieur JEAN JACQUES
-                            description: 'Identité du destinataire : Civilité, titre
-                              ou qualité + nom et prénom'
+                            description: Civilité, titre ou qualité, nom et prénom
+                              du destinataire.
                           complement_information:
                             title: Complément d'information du destinataire ou point
                               de remise
@@ -4089,8 +4185,8 @@ paths:
                           valeur:
                             title: Valeur du QF
                             type: integer
-                            description: Valeur du quotient familial calculé par la
-                              CAF ou la MSA.
+                            description: Valeur du quotient familial calculée par
+                              la CAF ou la MSA.
                             example: 1045
                           annee:
                             title: Année effective du QF
@@ -4430,7 +4526,7 @@ paths:
                           type: object
                           properties:
                             nom_naissance:
-                              title: Nom
+                              title: Nom de naissance
                               type: string
                               description: Nom de naissance de l'allocataire ou du
                                 conjoint.
@@ -4462,7 +4558,7 @@ paths:
                               - M
                       enfants:
                         type: array
-                        title: Données d'identité des enfants composant la famille
+                        title: Données d'identité des enfants
                         description: Liste des données d'identité des enfants composant
                           la famille, le cas échéant. La provenance de ces données
                           n'est pas sourcée précisément et diffère selon la CAF ou
@@ -4509,11 +4605,11 @@ paths:
                           la MSA, l'information sera donc obsolète.
                         properties:
                           destinataire:
-                            title: Identité du destinataire
+                            title: Destinataire
                             type: string
                             example: Monsieur JEAN JACQUES
-                            description: 'Identité du destinataire : Civilité, titre
-                              ou qualité + nom et prénom'
+                            description: Civilité, titre ou qualité, nom et prénom
+                              du destinataire.
                           complement_information:
                             title: Complément d'information du destinataire ou point
                               de remise
@@ -4573,8 +4669,8 @@ paths:
                           valeur:
                             title: Valeur du QF
                             type: integer
-                            description: Valeur du quotient familial calculé par la
-                              CAF ou la MSA.
+                            description: Valeur du quotient familial calculée par
+                              la CAF ou la MSA.
                             example: 1045
                           annee:
                             title: Année effective du QF
@@ -5023,14 +5119,13 @@ paths:
                     type: object
                     properties:
                       est_beneficiaire:
-                        title: Statut bénéficiaire du revenu de solidarité active
-                          (RSA)
+                        title: Est bénéficiaire du revenu de solidarité active (RSA)
                         type: boolean
                         example: true
                         description: Indique que le particulier est bénéficiaire du
                           revenu de solidarité active au moment de l'appel.
                       avec_majoration:
-                        title: RSA majoré
+                        title: RSA avec majoration
                         type: boolean
                         nullable: true
                         description: "Indique que le RSA du particulier bénéficiaire
@@ -5303,14 +5398,13 @@ paths:
                     type: object
                     properties:
                       est_beneficiaire:
-                        title: Statut bénéficiaire du revenu de solidarité active
-                          (RSA)
+                        title: Est bénéficiaire du revenu de solidarité active (RSA)
                         type: boolean
                         example: true
                         description: Indique que le particulier est bénéficiaire du
                           revenu de solidarité active au moment de l'appel.
                       avec_majoration:
-                        title: RSA majoré
+                        title: RSA avec majoration
                         type: boolean
                         nullable: true
                         description: "Indique que le RSA du particulier bénéficiaire
@@ -5420,7 +5514,7 @@ paths:
                 "$ref": "#/components/schemas/Error"
   "/v3/cnous/etudiant_boursier/identite":
     get:
-      summary: "[Identité] Status étudiant boursier"
+      summary: "[Identité] Statut étudiant boursier"
       tags:
       - Statut étudiant boursier
       parameters:
@@ -5644,9 +5738,9 @@ paths:
                     type: object
                     properties:
                       est_boursier:
-                        title: Statut boursier
+                        title: Est boursier
                         type: boolean
-                        description: Indique si l'étudiant est boursier
+                        description: Indique que l'étudiant est boursier.
                         example: true
                       periode_versement_bourse:
                         title: Période de versement de la bourse
@@ -5674,25 +5768,25 @@ paths:
                       etablissement_etudes:
                         title: Établissement d'études de l'étudiant
                         description: Contient le détail des informations concernant
-                          l'établissement dans lequel l'étudiant fait ses études
+                          l'établissement dans lequel l'étudiant fait ses études.
                         type: object
                         properties:
                           nom_commune:
-                            title: Ville d'études
+                            title: Commune d'études
                             type: string
-                            description: Libellé de la ville d'études de l'étudiant
+                            description: Libellé de la commune d'études de l'étudiant
                             example: Brest
                           nom_etablissement:
                             title: Établissement d'études
                             type: string
-                            description: L'établissement d'études de l'étudiant
+                            description: Nom de l'établissement d'études de l'étudiant.
                             example: Carnot
                         required:
                         - nom_commune
                         - nom_etablissement
                       echelon_bourse:
-                        title: Échelon de la bourse
-                        description: Informations relatives à l'échelon de la bourse
+                        title: Informations concernant l'échelon de la bourse
+                        description: Informations relatives à l'échelon de la bourse.
                         type: object
                         properties:
                           echelon:
@@ -5714,12 +5808,10 @@ paths:
                             - '6'
                             - '7'
                           echelon_bourse_regionale_provisoire:
-                            title: Statut provisoire de l'échelon (bourses régionales
-                              uniquement)
-                            description: Ce champs indique que l'échelon de la bourse
-                              est provisoire. Ce statut provisoire de l'échelon n'est
-                              effectif que pour les boursiers bénéficiaires d'une
-                              bourse régionale.
+                            title: Statut provisoire (bourses régionales uniquement)
+                            description: Ce champ indique que l'échelon de la bourse
+                              indiqué est provisoire. Ce statut provisoire n'est indiqué
+                              que pour les boursiers bénéficiaires d'une bourse régionale.
                             type: boolean
                             example: true
                             enum:
@@ -5904,7 +5996,7 @@ paths:
                 "$ref": "#/components/schemas/Error"
   "/v3/cnous/etudiant_boursier/france_connect":
     get:
-      summary: "[FranceConnect] Status étudiant boursier"
+      summary: "[FranceConnect] Statut étudiant boursier"
       tags:
       - Statut étudiant boursier
       parameters:
@@ -5954,9 +6046,9 @@ paths:
                     type: object
                     properties:
                       est_boursier:
-                        title: Statut boursier
+                        title: Est boursier
                         type: boolean
-                        description: Indique si l'étudiant est boursier
+                        description: Indique que l'étudiant est boursier.
                         example: true
                       periode_versement_bourse:
                         title: Période de versement de la bourse
@@ -5984,25 +6076,25 @@ paths:
                       etablissement_etudes:
                         title: Établissement d'études de l'étudiant
                         description: Contient le détail des informations concernant
-                          l'établissement dans lequel l'étudiant fait ses études
+                          l'établissement dans lequel l'étudiant fait ses études.
                         type: object
                         properties:
                           nom_commune:
-                            title: Ville d'études
+                            title: Commune d'études
                             type: string
-                            description: Libellé de la ville d'études de l'étudiant
+                            description: Libellé de la commune d'études de l'étudiant
                             example: Brest
                           nom_etablissement:
                             title: Établissement d'études
                             type: string
-                            description: L'établissement d'études de l'étudiant
+                            description: Nom de l'établissement d'études de l'étudiant.
                             example: Carnot
                         required:
                         - nom_commune
                         - nom_etablissement
                       echelon_bourse:
-                        title: Échelon de la bourse
-                        description: Informations relatives à l'échelon de la bourse
+                        title: Informations concernant l'échelon de la bourse
+                        description: Informations relatives à l'échelon de la bourse.
                         type: object
                         properties:
                           echelon:
@@ -6024,12 +6116,10 @@ paths:
                             - '6'
                             - '7'
                           echelon_bourse_regionale_provisoire:
-                            title: Statut provisoire de l'échelon (bourses régionales
-                              uniquement)
-                            description: Ce champs indique que l'échelon de la bourse
-                              est provisoire. Ce statut provisoire de l'échelon n'est
-                              effectif que pour les boursiers bénéficiaires d'une
-                              bourse régionale.
+                            title: Statut provisoire (bourses régionales uniquement)
+                            description: Ce champ indique que l'échelon de la bourse
+                              indiqué est provisoire. Ce statut provisoire n'est indiqué
+                              que pour les boursiers bénéficiaires d'une bourse régionale.
                             type: boolean
                             example: true
                             enum:
@@ -6078,7 +6168,7 @@ paths:
                 "$ref": "#/components/schemas/Error"
   "/v3/cnous/etudiant_boursier/ine":
     get:
-      summary: "[INE] Status étudiant boursier"
+      summary: "[INE] Statut étudiant boursier"
       tags:
       - Statut étudiant boursier
       parameters:
@@ -6201,9 +6291,9 @@ paths:
                     type: object
                     properties:
                       est_boursier:
-                        title: Statut boursier
+                        title: Est boursier
                         type: boolean
-                        description: Indique si l'étudiant est boursier
+                        description: Indique que l'étudiant est boursier.
                         example: true
                       periode_versement_bourse:
                         title: Période de versement de la bourse
@@ -6231,25 +6321,25 @@ paths:
                       etablissement_etudes:
                         title: Établissement d'études de l'étudiant
                         description: Contient le détail des informations concernant
-                          l'établissement dans lequel l'étudiant fait ses études
+                          l'établissement dans lequel l'étudiant fait ses études.
                         type: object
                         properties:
                           nom_commune:
-                            title: Ville d'études
+                            title: Commune d'études
                             type: string
-                            description: Libellé de la ville d'études de l'étudiant
+                            description: Libellé de la commune d'études de l'étudiant
                             example: Brest
                           nom_etablissement:
                             title: Établissement d'études
                             type: string
-                            description: L'établissement d'études de l'étudiant
+                            description: Nom de l'établissement d'études de l'étudiant.
                             example: Carnot
                         required:
                         - nom_commune
                         - nom_etablissement
                       echelon_bourse:
-                        title: Échelon de la bourse
-                        description: Informations relatives à l'échelon de la bourse
+                        title: Informations concernant l'échelon de la bourse
+                        description: Informations relatives à l'échelon de la bourse.
                         type: object
                         properties:
                           echelon:
@@ -6271,12 +6361,10 @@ paths:
                             - '6'
                             - '7'
                           echelon_bourse_regionale_provisoire:
-                            title: Statut provisoire de l'échelon (bourses régionales
-                              uniquement)
-                            description: Ce champs indique que l'échelon de la bourse
-                              est provisoire. Ce statut provisoire de l'échelon n'est
-                              effectif que pour les boursiers bénéficiaires d'une
-                              bourse régionale.
+                            title: Statut provisoire (bourses régionales uniquement)
+                            description: Ce champ indique que l'échelon de la bourse
+                              indiqué est provisoire. Ce statut provisoire n'est indiqué
+                              que pour les boursiers bénéficiaires d'une bourse régionale.
                             type: boolean
                             example: true
                             enum:
@@ -6576,7 +6664,8 @@ paths:
         required: true
       security:
       - jwt_bearer_token: []
-      description: API Service National
+      description: Statut de conformité au service national des jeunes entre 16 et
+        25 ans
       responses:
         '401':
           description: Non autorisé
@@ -6870,7 +6959,8 @@ paths:
           type: string
       security:
       - jwt_bearer_token: []
-      description: API Service National
+      description: Statut de conformité au service national des jeunes entre 16 et
+        25 ans
       responses:
         '403':
           description: Accès interdit
@@ -7099,10 +7189,10 @@ paths:
                       identifiant:
                         title: Nom d'utilisateur France Travail
                         type: string
-                        description: Identifiant France Travail, tel qu'il a été renseigné
-                          en paramètre d'appel. Cet identifiant est le nom d'utilisateur
-                          tel que choisi par le particulier lors de la création de
-                          son espace personnel en ligne.
+                        description: Identifiant du compte utilisateur France Travail,
+                          tel qu'il a été renseigné en paramètre d'appel. Cet identifiant
+                          est le nom d'utilisateur tel que choisi par le particulier
+                          lors de la création de son espace personnel en ligne.
                         example: jean.dupont33
                       paiements:
                         title: Liste des paiements versés
@@ -7398,10 +7488,10 @@ paths:
                     type: object
                     properties:
                       identifiant:
-                        title: Nom d'utilisateur France Travail
+                        title: Identifiant France Travail
                         type: string
                         description: |
-                          Identifiant France Travail, tel qu'il a été renseigné
+                          Identifiant du compte utilisateur France Travail, tel qu'il a été renseigné
                           en paramètre d'appel. Cet identifiant est le nom d'utilisateur
                           tel que choisi par le particulier lors de la création de son
                           espace personnel en ligne.
@@ -7410,7 +7500,7 @@ paths:
                         title: Données d'identité de l'utilisateur France Travail
                         description: 'Les informations d''identité retournées ici
                           sont issues de l''espace FranceTravail où l''utilisateur
-                          les a  saisies. Elles sont vérifiées par un agent, à l''aide
+                          les a saisies. Elles sont vérifiées par un agent, à l''aide
                           de la pièce d''identité fournie, et corrigées le cas échéant.
                           Les justificatifs d''identité qui servent à la vérification
                           des données sont listés ici : https://www.service-public.fr/particuliers/vosdroits/F24465'
@@ -7418,8 +7508,7 @@ paths:
                         properties:
                           civilite:
                             title: Civilité
-                            description: Civilité du demandeur d'emploi, Madame ou
-                              Monsieur.
+                            description: Civilité, Madame ou Monsieur.
                             type: string
                             example: M.
                             enum:
@@ -7428,31 +7517,29 @@ paths:
                           nom_naissance:
                             title: Nom de naissance
                             type: string
-                            description: Nom de naissance du demandeur d'emploi.
+                            description: Nom de naissance.
                             example: MARTIN
                           nom_usage:
                             title: Nom d'usage
                             type: string
-                            description: Nom d'usage du demandeur d'emploi.
+                            description: Nom d'usage.
                             nullable: true
                             example:
                           prenom:
                             title: Prénom
                             type: string
                             example: JACQUES
-                            description: Prénom ddu demandeur d'emploi, limité à 13
-                              caractères
+                            description: Prénom, limité à 13 caractères.
                           sexe:
                             title: Sexe
                             type: string
-                            description: Sexe du demandeur d'emploi.
+                            description: Sexe.
                             example: Masculin
                           date_naissance:
                             title: Date de naissance
                             format: date
                             type: string
-                            description: Date de naissance du demandeur d'emploi au
-                              format YYYY-MM-DD.
+                            description: Date de naissance au format YYYY-MM-DD.
                             example: '1995-02-02'
                         required:
                         - civilite
@@ -7462,28 +7549,26 @@ paths:
                         - sexe
                         - date_naissance
                       contact:
-                        title: Contact
-                        description: Données de contact de l'utilisateur France Travail.
+                        title: Données de contact
+                        description: Données de contact de l'utilisateur France Travail
                         type: object
                         properties:
                           telephone:
                             title: Téléphone principal
                             type: string
-                            description: Numéro de téléphone principal du demandeur
-                              d'emploi.
+                            description: Numéro de téléphone principal.
                             example: '0636676767'
                           telephone2:
                             title: Téléphone secondaire
                             type: string
-                            description: Numéro de téléphone secondaire du demandeur
-                              d'emploi.
+                            description: Numéro de téléphone secondaire.
                             nullable: true
                             example: '1122334455'
                           email:
                             title: E-mail
                             type: string
                             nullable: true
-                            description: Adresse e-mail du demandeur d'emploi.
+                            description: Adresse e-mail.
                             example: martin.jacques@france.fr
                         required:
                         - telephone
@@ -7492,16 +7577,17 @@ paths:
                       adresse:
                         title: Adresse
                         type: object
-                        description: Adresse du demandeur d'emploi, déclarée par le
-                          particulier lors de son inscription à France Travail ou
-                          suite à une déclaration de changement d’adresse.
+                        description: Adresse déclarée par le particulier lors de son
+                          inscription à France Travail ou suite à une déclaration
+                          de changement d’adresse.
                         properties:
                           code_postal:
                             type: string
                             title: Code postal
                             example: '75001'
                           code_cog_insee_commune:
-                            title: Code COG Insee de la commune
+                            title: COG de la commune
+                            description: Code officiel géographique (COG) de la commune
                             type: string
                             example: '75101'
                           localite:
@@ -7754,7 +7840,7 @@ paths:
                 "$ref": "#/components/schemas/Error"
   "/v3/men/scolarites/identite":
     get:
-      summary: Statut élève scolarisé
+      summary: Statut élève scolarisé et boursier
       tags:
       - Statut élève scolarisé
       parameters:
@@ -7861,7 +7947,8 @@ paths:
           type: string
       security:
       - jwt_bearer_token: []
-      description: Statut scolarisé d'un élève du primaire, collège ou lycée.
+      description: Statut scolarisé d'un élève du primaire, collège ou lycée et statut
+        boursier.
       responses:
         '401':
           description: Non autorisé
@@ -7993,8 +8080,9 @@ paths:
                         - sexe
                         - date_naissance
                       module_elementaire_formation:
-                        title: Information MEF
-                        description: Les informations relatives aux données MEF
+                        title: Module élémentaire de formation (MEF)
+                        description: Libellé et code du module élémentaire de formation
+                          (MEF)
                         type: object
                         properties:
                           code_mef_stat:
@@ -8044,7 +8132,7 @@ paths:
                         pattern: "^\\d{4}$|^\\d{4}-\\d{4}$"
                         example: 2022-2023
                       est_scolarise:
-                        title: Statut scolarisé
+                        title: Est scolarisé
                         description: Indique si l'élève est scolarisé dans un établissement.
                         type: boolean
                         example: true
@@ -8423,7 +8511,7 @@ paths:
                     type: object
                     properties:
                       admissions:
-                        title: Admissions de l'étudiant dans un ou plusieurs établissements
+                        title: Liste des admissions de l'étudiant dans les établissements
                         description: "Liste des admissions de l'étudiant dans un ou
                           plusieurs établissements d'enseignement supérieur pour l'année
                           en cours. \n\nChaque objet listé correspond à un établissement
@@ -8451,7 +8539,7 @@ paths:
                                 l'établissement.
                               example: '2023-08-31'
                             est_inscrit:
-                              title: Statut étudiant inscrit
+                              title: Est inscrit
                               type: boolean
                               example: true
                               enum:
@@ -8507,10 +8595,10 @@ paths:
                                   - RF6
                                   - RF7
                             code_cog_insee_commune:
-                              title: Commune de l'établissement d'études
+                              title: COG de la commune de l'établissement d'études
                               type: string
-                              description: Code Insee à 5 chiffres de la commune de
-                                l'établissement d'études de l'étudiant.
+                              description: Code officiel géographique (COG) de la
+                                commune de l'établissement d'études de l'étudiant.
                               example: '29085'
                             etablissement_etudes:
                               title: Établissement d'études
@@ -8741,7 +8829,7 @@ paths:
                     type: object
                     properties:
                       admissions:
-                        title: Admissions de l'étudiant dans un ou plusieurs établissements
+                        title: Liste des admissions de l'étudiant dans les établissements
                         description: "Liste des admissions de l'étudiant dans un ou
                           plusieurs établissements d'enseignement supérieur pour l'année
                           en cours. \n\nChaque objet listé correspond à un établissement
@@ -8769,7 +8857,7 @@ paths:
                                 l'établissement.
                               example: '2023-08-31'
                             est_inscrit:
-                              title: Statut étudiant inscrit
+                              title: Est inscrit
                               type: boolean
                               example: true
                               enum:
@@ -8825,10 +8913,10 @@ paths:
                                   - RF6
                                   - RF7
                             code_cog_insee_commune:
-                              title: Commune de l'établissement d'études
+                              title: COG de la commune de l'établissement d'études
                               type: string
-                              description: Code Insee à 5 chiffres de la commune de
-                                l'établissement d'études de l'étudiant.
+                              description: Code officiel géographique (COG) de la
+                                commune de l'établissement d'études de l'étudiant.
                               example: '29085'
                             etablissement_etudes:
                               title: Établissement d'études
@@ -9015,7 +9103,7 @@ paths:
                     type: object
                     properties:
                       admissions:
-                        title: Admissions de l'étudiant dans un ou plusieurs établissements
+                        title: Liste des admissions de l'étudiant dans les établissements
                         description: "Liste des admissions de l'étudiant dans un ou
                           plusieurs établissements d'enseignement supérieur pour l'année
                           en cours. \n\nChaque objet listé correspond à un établissement
@@ -9043,7 +9131,7 @@ paths:
                                 l'établissement.
                               example: '2023-08-31'
                             est_inscrit:
-                              title: Statut étudiant inscrit
+                              title: Est inscrit
                               type: boolean
                               example: true
                               enum:
@@ -9099,10 +9187,10 @@ paths:
                                   - RF6
                                   - RF7
                             code_cog_insee_commune:
-                              title: Commune de l'établissement d'études
+                              title: COG de la commune de l'établissement d'études
                               type: string
-                              description: Code Insee à 5 chiffres de la commune de
-                                l'établissement d'études de l'étudiant.
+                              description: Code officiel géographique (COG) de la
+                                commune de l'établissement d'études de l'étudiant.
                               example: '29085'
                             etablissement_etudes:
                               title: Établissement d'études

--- a/config/api-particulier-openapi.yml
+++ b/config/api-particulier-openapi.yml
@@ -63,6 +63,7 @@ paths:
   "/api/v2/allocation-adulte-handicape":
     get:
       summary: Statut allocation adulte handicapé (AAH)
+      deprecated: true
       tags:
       - Prestations sociales
       parameters:
@@ -316,6 +317,7 @@ paths:
   "/api/v2/allocation-soutien-familial":
     get:
       summary: Statut allocation de soutien familial (ASF)
+      deprecated: true
       tags:
       - Prestations sociales
       parameters:
@@ -576,6 +578,7 @@ paths:
   "/api/v2/complementaire-sante-solidaire":
     get:
       summary: Statut complémentaire santé solidaire (C2S)
+      deprecated: true
       tags:
       - Prestations sociales
       parameters:
@@ -849,6 +852,7 @@ paths:
   "/api/v2/prime-activite":
     get:
       summary: Statut prime d'activité
+      deprecated: true
       tags:
       - Prestations sociales
       parameters:
@@ -1118,6 +1122,7 @@ paths:
   "/api/v2/composition-familiale-v2":
     get:
       summary: Quotient familial MSA & CAF
+      deprecated: true
       tags:
       - Quotient familial
       parameters:
@@ -1634,6 +1639,7 @@ paths:
   "/api/v2/revenu-solidarite-active":
     get:
       summary: Statut revenu de solidarité active (RSA)
+      deprecated: true
       tags:
       - Prestations sociales
       parameters:
@@ -1902,6 +1908,7 @@ paths:
   "/api/v2/scolarites":
     get:
       summary: Statut élève scolarisé et boursier
+      deprecated: true
       tags:
       - Éducation et études
       parameters:
@@ -2147,6 +2154,7 @@ paths:
   "/api/v2/paiements-pole-emploi":
     get:
       summary: Paiements versés par France Travail
+      deprecated: true
       tags:
       - Demandeurs d'emploi
       parameters:
@@ -2554,6 +2562,7 @@ paths:
   "/api/v2/situations-pole-emploi":
     get:
       summary: Statut demandeur d'emploi
+      deprecated: true
       description: |-
         Données d'identité, de contact et de statut du demandeur d'emploi.
         **Paramètres d'appel :** Nom d’utilisateur France Travail choisi par le particulier lors de la création de son espace personnel en ligne
@@ -2801,6 +2810,7 @@ paths:
                       de donnée
   "/api/v2/etudiants":
     get:
+      deprecated: true
       tags:
       - Éducation et études
       parameters:
@@ -2985,6 +2995,7 @@ paths:
         '503': *3
   "/api/v2/etudiants-boursiers":
     get:
+      deprecated: true
       tags:
       - Éducation et études
       parameters:

--- a/config/blog_posts/api_particulier/migration-api-particulier-v3.md
+++ b/config/blog_posts/api_particulier/migration-api-particulier-v3.md
@@ -399,7 +399,7 @@ Suite aux changements de structure de l'API, les scopes (droits d'accès) ont é
 {:.fr-h6 .fr-mt-2w}
 #### Scopes : 
 - Un nouveau scope a été créé, permettant d'accéder à la donnée `identite` autrefois par défaut incluse lorsque l'API était demandée. **Ce scope sera par défaut distribué aux utilisateurs ayant déjà un accès l'API Statut élève V.2.**
-- Un nouveau scope a été créé pour la nouvelle donnée `module_elementaire_formation`, **pour accéder à cette novuelle donnée, veuillez faire une demande de modification de votre habilitation depuis votre [compte utilisateur](<%= user_profile_path %>)**.
+- Un nouveau scope a été créé pour la nouvelle donnée `module_elementaire_formation`, **pour accéder à cette nouvelle donnée, veuillez faire une demande de modification de votre habilitation depuis votre [compte utilisateur](<%= user_profile_path %>)**.
 
 
 {:.fr-h6 .fr-mt-4w}

--- a/config/blog_posts/api_particulier/migration-api-particulier-v3.md
+++ b/config/blog_posts/api_particulier/migration-api-particulier-v3.md
@@ -280,7 +280,7 @@ Pour l'API statut étudiant et statut étudiant boursier; comme pour toutes les 
 
 ### <a name="correspondance-api-quotient-familial-msa-caf"></a> API Quotient familial CAF & MSA
 
-[Swagger V.2](<%= api_particulier_developers_openapi_path %>#tag/Quotient-familial){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
+[Swagger V.2](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Quotient-familial){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
 [Swagger V.3](<%= api_particulier_developers_openapi_v3_path %>#tag/Quotient-familial-CAF-and-MSA){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill}
 
 
@@ -309,7 +309,7 @@ Pour l'API statut étudiant et statut étudiant boursier; comme pour toutes les 
 
 ### <a name="correspondance-api-statut-etudiant"></a> API Statut étudiant
 
-[Swagger V.2](<%= api_particulier_developers_openapi_path %>#tag/Education-et-etudes/paths/~1api~1v2~1etudiants/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
+[Swagger V.2](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Education-et-etudes/paths/~1api~1v2~1etudiants/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
 [Swagger V.3](<%= api_particulier_developers_openapi_v3_path %>#tag/Statut-etudiant){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill}
 
 
@@ -351,7 +351,7 @@ Suite aux changements de structure de l'API, les scopes (droits d'accès) ont é
 
 ### <a name="correspondance-api-statut-etudiant-boursier"></a> API Statut étudiant boursier
 
-[Swagger V.2](<%= api_particulier_developers_openapi_path %>#tag/Education-et-etudes/paths/~1api~1v2~1etudiants-boursiers/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
+[Swagger V.2](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Education-et-etudes/paths/~1api~1v2~1etudiants-boursiers/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
 [Swagger V.3](<%= api_particulier_developers_openapi_v3_path %>#tag/Statut-etudiant-boursier){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill}
 
 
@@ -385,7 +385,7 @@ Suite aux changements de structure de l'API, les scopes (droits d'accès) ont é
 ### <a name="correspondance-api-statut-eleve-scolarise"></a> API Statut élève scolarisé
 
 
-[Swagger V.2](<%= api_particulier_developers_openapi_path %>#tag/Education-et-etudes/paths/~1api~1v2~1scolarites/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
+[Swagger V.2](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Education-et-etudes/paths/~1api~1v2~1scolarites/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
 [Swagger V.3](<%= api_particulier_developers_openapi_v3_path %>#tag/Statut-eleve-scolarise){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill}
 
 
@@ -422,7 +422,7 @@ Suite aux changements de structure de l'API, les scopes (droits d'accès) ont é
 
 ### <a name="correspondance-api-statut-demandeur-emploi"></a> API Statut demandeur d'emploi
 
-[Swagger V.2](<%= api_particulier_developers_openapi_path %>#tag/Demandeurs-d'emploi/paths/~1api~1v2~1situations-pole-emploi/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
+[Swagger V.2](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Demandeurs-d'emploi/paths/~1api~1v2~1situations-pole-emploi/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
 [Swagger V.3](<%= api_particulier_developers_openapi_v3_path %>#tag/Statut-demandeurs-d'emploi){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill}
 
 
@@ -461,7 +461,7 @@ Un nouveau scope a été créé, permettant d'accéder à la donnée `identifian
 
 ### <a name="correspondance-api-paiements-france-travail"></a> API Paiements versés par France Travail
 
-[Swagger V.2](<%= api_particulier_developers_openapi_path %>#tag/Demandeurs-d'emploi/paths/~1api~1v2~1paiements-pole-emploi/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
+[Swagger V.2](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Demandeurs-d'emploi/paths/~1api~1v2~1paiements-pole-emploi/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
 [Swagger V.3](<%= api_particulier_developers_openapi_v3_path %>#tag/Paiements-verses-par-France-Travail){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill}
 
 
@@ -485,7 +485,7 @@ Un nouveau scope a été créé, permettant d'accéder à la donnée `identifian
 
 ### <a name="correspondance-api-statut-rsa"></a> API Statut revenu de solidarité active (RSA) 
 
-[Swagger V.2](<%= api_particulier_developers_openapi_path %>#tag/Prestations-sociales/paths/~1api~1v2~1revenu-solidarite-active/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
+[Swagger V.2](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Prestations-sociales/paths/~1api~1v2~1revenu-solidarite-active/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
 [Swagger V.3](<%= api_particulier_developers_openapi_v3_path %>#tag/Statut-Revenu-Solidarite-Active-(RSA)){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill}
 
 {:.fr-h6}
@@ -512,7 +512,7 @@ Un nouveau scope a été créé, permettant d'accéder à la donnée `identifian
 
 ### <a name="correspondance-api-statut-prime-activite"></a> API Statut prime d'activité  
 
-[Swagger V.2](<%= api_particulier_developers_openapi_path %>#tag/Prestations-sociales/paths/~1api~1v2~1prime-activite/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
+[Swagger V.2](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Prestations-sociales/paths/~1api~1v2~1prime-activite/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
 [Swagger V.3](<%= api_particulier_developers_openapi_v3_path %>#tag/Statut-Prime-Activite){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill}
 
 
@@ -539,7 +539,7 @@ Un nouveau scope a été créé, permettant d'accéder à la donnée `identifian
 ### <a name="correspondance-api-statut-aah"></a> API Statut allocation adulte handicapé (AAH) 
 
 
-[Swagger V.2](<%= api_particulier_developers_openapi_path %>#tag/Prestations-sociales/paths/~1api~1v2~1allocation-adulte-handicape/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
+[Swagger V.2](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Prestations-sociales/paths/~1api~1v2~1allocation-adulte-handicape/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
 [Swagger V.3](<%= api_particulier_developers_openapi_v3_path %>#tag/Statut-Allocation-Adulte-Handicape-(AAH)){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill}
 
 
@@ -565,7 +565,7 @@ Un nouveau scope a été créé, permettant d'accéder à la donnée `identifian
 
 ### <a name="correspondance-api-statut-asf"></a> API Statut allocation de soutien familial (ASF)
 
-[Swagger V.2](<%= api_particulier_developers_openapi_path %>#tag/Prestations-sociales/paths/~1api~1v2~1allocation-soutien-familial/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
+[Swagger V.2](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Prestations-sociales/paths/~1api~1v2~1allocation-soutien-familial/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
 [Swagger V.3](<%= api_particulier_developers_openapi_v3_path %>#tag/Statut-Allocation-Soutien-Familial-(ASF)){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill}
 
 
@@ -591,7 +591,7 @@ Un nouveau scope a été créé, permettant d'accéder à la donnée `identifian
 
 ### <a name="correspondance-api-statut-c2s"></a> API Statut complémentaire santé solidaire (C2S) 
 
-[Swagger V.2](<%= api_particulier_developers_openapi_path %>#tag/Prestations-sociales/paths/~1api~1v2~1complementaire-sante-solidaire/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
+[Swagger V.2](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Prestations-sociales/paths/~1api~1v2~1complementaire-sante-solidaire/get){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill .fr-btn--secondary}
 [Swagger V.3](<%= api_particulier_developers_openapi_v3_path %>#tag/Statut-Complementaire-Sante-Solidaire-(C2S)){:target="_blank"}{:.fr-btn .fr-btn--md fr-btn--icon-right fr-icon-arrow-right-fill}
 
 

--- a/config/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
+++ b/config/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
@@ -182,6 +182,7 @@
   historique: |+
     **Ce que change le passage à la V.3 d'API Particulier:**
 
-    Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-quotient-familial-msa-caf){:target="_blank"}
+    - Le passage à la V.3 n'a pas eu d'impact sur la donnée distribuée qui reste identique ; 
+    - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-quotient-familial-msa-caf){:target="_blank"}
 
 

--- a/config/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
+++ b/config/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
@@ -1,5 +1,5 @@
 ---
-- uid: 'cnav/quotient_familial_v2'
+- uid: 'cnav/quotient_familial'
   opening: protected
   new_version: true
   old_endpoint_uids:
@@ -182,20 +182,8 @@
         > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
 
   historique: |+
-    **Ce que change cette API CNAF-MSA par rapport à l'API précédente de la CNAF :**
-    - Le périmètre des particuliers concernés s'élargit avec l'**ajout des bénéficiaires de la MSA** qui sont au régime agricole.
-    - **Les paramètres d'appel évoluent**. Dans l'API précédente, l'usager devait renseigner son numéro d'allocataire et son code postal. Avec cette API l'usager renseigne [ses données d'identité](#parameters_details).
+    **Ce que change le passage à la V.3 d'API Particulier:**
 
-
-    <div class="fr-callout fr-icon-information-line">
-      <h3 class="fr-h4 fr-callout__title">Migration V.3</h3>
-      <p class="fr-callout__text">
-          Cette fiche métier correspond à la nouvelle version 3 de l'API Particulier. Vos systèmes d'information utilisent encore la V.2 ?
-
-      </p>
-      <a class="fr-btn" href="/blog/migration-api-particulier-v3">
-          Consultez le guide de migration
-      </a>
-    </div>
+    Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-quotient-familial-msa-caf){:target="_blank"}
 
 

--- a/config/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
+++ b/config/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
@@ -94,9 +94,7 @@
         <span class="fr-text--xs fr-m-0">
         <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
         </span>
-        <blockquote class="fr-highlight fr-highlight--caution">
-        ⚠️ <strong>Message API Particulier du 04.06.2024</strong> : Nous avons constaté que les appels effectués sans nom de naissance et <strong>avec le nom d'usage ne fonctionnent pas</strong> dans une très grande partie des cas. Après investigation auprès de la CNAV (opérateur de l'API source), API Particulier a donc décidé de passer le paramètre "Nom de naissance" en obligatoire.
-        </blockquote>
+       
         </div>
       </section>
 

--- a/config/endpoints/api_particulier/cnav_allocation_adulte_handicape.yml
+++ b/config/endpoints/api_particulier/cnav_allocation_adulte_handicape.yml
@@ -85,4 +85,12 @@
 
         {:.fr-highlight}
         > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
+  historique: |+
+    **Ce que change le passage à la V.3 d'API Particulier:**
+
+    - Le passage à la V.3 n'a pas eu d'impact sur la donnée distribuée qui reste identique ; 
+    - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-statut-aah){:target="_blank"}
+
+
+
 

--- a/config/endpoints/api_particulier/cnav_allocation_soutien_familial.yml
+++ b/config/endpoints/api_particulier/cnav_allocation_soutien_familial.yml
@@ -1,8 +1,8 @@
 ---
 - uid: 'cnav/allocation_soutien_familial'
   opening: protected
-  new_endpoint_uids:
-    - 'cnav_msa/allocation_soutien_familial'
+  old_endpoint_uids:
+    - 'cnav/v2/allocation_soutien_familial'
   path: '/v3/dss/allocation_soutien_familial/identite'
   ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
   position: 900
@@ -44,13 +44,11 @@
       <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
       </span>
 
-      {:.fr-highlight.fr-highlight--caution}
-      > ⚠️ **Message API Particulier du 04.06.2024** : Nous avons constaté que les appels effectués sans nom de naissance et **avec le nom d'usage ne fonctionnent pas** dans une très grande partie des cas. Après investigation auprès de la CNAV (opérateur de l'API source), API Particulier a donc décidé de passer le paramètre "Nom de naissance" en obligatoire.
+     
   data:
     description: |+
-      Cette API **indique si le particulier est bénéficiaire de l'allocation de soutien familial**. En précisant :
-        - la date d'ouverture du droit ;
-        - la date de fermeture du droit.
+      Cette API **indique si le particulier est bénéficiaire de l'allocation de soutien familial**, en précisant la date d'ouverture du droit.
+        
   provider_uids:
     - 'cnav'
   keywords:
@@ -81,3 +79,11 @@
 
         {:.fr-highlight}
         > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
+
+  historique: |+
+    **Ce que change le passage à la V.3 d'API Particulier:**
+
+    - Suppression de la date de fin car cette donnée était calculée et présentait le risque de ne pas être juste dans toutes les situations ;
+    - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-statut-asf){:target="_blank"}
+
+

--- a/config/endpoints/api_particulier/cnav_complementaire_sante_solidaire.yml
+++ b/config/endpoints/api_particulier/cnav_complementaire_sante_solidaire.yml
@@ -42,9 +42,6 @@
       <span class="fr-text--xs fr-m-0">
       <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
       </span>
-
-      {:.fr-highlight.fr-highlight--caution}
-      > ⚠️ **Message API Particulier du 04.06.2024** : Nous avons constaté que les appels effectués sans nom de naissance et **avec le nom d'usage ne fonctionnent pas** dans une très grande partie des cas. Après investigation auprès de la CNAV (opérateur de l'API source), API Particulier a donc décidé de passer le paramètre "Nom de naissance" en obligatoire.
   data:
     description: |+
       Cette API **indique si le particulier est bénéficiaire de la complémentaire santé solidaire**. En précisant :

--- a/config/endpoints/api_particulier/cnav_prime_activite.yml
+++ b/config/endpoints/api_particulier/cnav_prime_activite.yml
@@ -1,8 +1,8 @@
 ---
 - uid: 'cnav/prime_activite'
   opening: protected
-  new_endpoint_uids:
-    - 'cnav_msa/prime_activite'
+  old_endpoint_uids:
+    - 'cnav/v2/prime_activite'
   path: '/v3/dss/prime_activite/identite'
   ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
   position: 700
@@ -52,9 +52,7 @@
       > ⚠️ **Message API Particulier du 04.06.2024** : Nous avons constaté que les appels effectués sans nom de naissance et **avec le nom d'usage ne fonctionnent pas** dans une très grande partie des cas. Après investigation auprès de la CNAV (opérateur de l'API source), API Particulier a donc décidé de passer le paramètre "Nom de naissance" en obligatoire.
   data:
     description: |+
-      Cette API **indique si le particulier est bénéficiaire de la prime d'activité**. En précisant :
-        - la date d'ouverture du droit ;
-        - la date de fermeture du droit.
+      Cette API **indique si le particulier est bénéficiaire de la prime d'activité**, En précisant la date d'ouverture du droit.
   provider_uids:
     - 'cnav'
   keywords:
@@ -87,3 +85,8 @@
         {:.fr-highlight}
         > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
 
+  historique: |+
+    **Ce que change le passage à la V.3 d'API Particulier:**
+
+    - Suppression de la date de fin car cette donnée était calculée et présentait le risque de ne pas être juste dans toutes les situations ;
+    - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-statut-prime-activite){:target="_blank"}

--- a/config/endpoints/api_particulier/cnav_prime_activite.yml
+++ b/config/endpoints/api_particulier/cnav_prime_activite.yml
@@ -47,9 +47,6 @@
       <span class="fr-text--xs fr-m-0">
       <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
       </span>
-
-      {:.fr-highlight.fr-highlight--caution}
-      > ⚠️ **Message API Particulier du 04.06.2024** : Nous avons constaté que les appels effectués sans nom de naissance et **avec le nom d'usage ne fonctionnent pas** dans une très grande partie des cas. Après investigation auprès de la CNAV (opérateur de l'API source), API Particulier a donc décidé de passer le paramètre "Nom de naissance" en obligatoire.
   data:
     description: |+
       Cette API **indique si le particulier est bénéficiaire de la prime d'activité**, En précisant la date d'ouverture du droit.

--- a/config/endpoints/api_particulier/cnav_revenu_solidarite_active.yml
+++ b/config/endpoints/api_particulier/cnav_revenu_solidarite_active.yml
@@ -42,9 +42,6 @@
       <span class="fr-text--xs fr-m-0">
       <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
       </span>
-
-      {:.fr-highlight.fr-highlight--caution}
-      > ⚠️ **Message API Particulier du 04.06.2024** : Nous avons constaté que les appels effectués sans nom de naissance et **avec le nom d'usage ne fonctionnent pas** dans une très grande partie des cas. Après investigation auprès de la CNAV (opérateur de l'API source), API Particulier a donc décidé de passer le paramètre "Nom de naissance" en obligatoire.
   data:
     description: |+
       Cette API **indique si le particulier est bénéficiaire du revenu de solidarité active**, en précisant la date d'ouverture du droit.

--- a/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
+++ b/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
@@ -98,7 +98,6 @@
   historique: |+
     **Ce que change le passage à la V.3 d'API Particulier:**
 
-    - Suppression des données de bourse : le fournisseur de données ne renvoie plus le statut boursier ;
     - Ajout de nouvelles données : Le module élémentaire de formation, ainsi que le ministère de tutelle de l’établissement sont désormais indiqués ;
     - Les données d'identité ne sont plus renvoyées lorsque la modalité d'appel est FranceConnect ;
     - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-statut-eleve-scolarise){:target="_blank"}

--- a/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
+++ b/config/endpoints/api_particulier/education_nationale_statut_eleve.yml
@@ -6,6 +6,10 @@
   path: '/v3/men/scolarites/identite'
   ping_url: 'https://particulier.api.gouv.fr/api/men_scolarite/ping'
   position: 500
+  alert:
+    title: "💡 Données de bourse bientôt disponibles"
+    description: |+
+      Le statut boursier et l'échelon de bourse de l'élève seront bientôt redistribués par le fournisseur de données. La mise en production de ces nouvelles données est attendue pour juin.
   perimeter:
     entity_type_description: |+
       Cette API concerne les **✅ élèves de la maternelle, du primaire, du collège et du lycée**.
@@ -17,6 +21,7 @@
       - ✅ lycées maritimes dépendant du ministère de la mer ;
       - ✅ une partie des formations à distance du CNED.
 
+      **Concernant le statut boursier des élèves** : seules les bourses sur critères sociaux à l'échelle nationale sont couvertes par l'API. Par ailleurs, les bourses ne concernent que les collégiens et lycéens.
 
       **Les établissements et formations suivants ne sont pas couverts par l'API** :
       - ❌ établissements privés hors contrat ;
@@ -27,11 +32,14 @@
       - ✅ France métropolitaine
       - ✅ DROM-COM
     updating_rules_description: |+
-      Cette API délivre les informations de l'[année scolaire en cours et l'année scolaire à venir seulement pour le second degré avec différentes échéances (N+1)](#faq_entry_0_api_particulier_endpoint_education_nationale_statut_eleve_scolarise).
+      Cette API délivre les informations de l'[année scolaire en cours et l'année scolaire à venir seulement pour le second degré avec différentes échéances (N+1)](#annee-scolaire-donnees).
 
       Les données du **premier degré** (primaire) sont mises à jour en **temps réel**. Les données du **second degré** (collèges et lycées) sont mises à jour **quotidiennement toutes les nuits**.
 
       Les informations, même si elles évoluent principalement lors de la rentrée scolaire en septembre, peuvent changer en cours d'année (déménagements, etc.).
+
+      {:.fr-highlight.fr-highlight--caution}
+      > Attention, si un élève est indiqué "non-boursier" avant mi-octobre, il ne faut pas prendre en compte cette information. Le **statut non-boursier est véritablement fiable à partir de mi-octobre**. [En savoir plus](#fiabilite-statut-boursier-octobre).
   parameters_details:
     description: |+
       Cette API propose une modalité d'appel :
@@ -42,7 +50,8 @@
       </span>
   data:
     description: |+
-      Cette API **indique si l'élève est scolarisé et sous quel statut** pour l'[année scolaire en cours et bientôt N+1](#faq_entry_0_api_particulier_endpoint_education_nationale_statut_eleve_scolarise).
+      Cette API **indique si l'élève est scolarisé et sous quel statut** pour l'[année scolaire en cours et bientôt N+1](#annee-scolaire-donnees).
+      Le **statut boursier ainsi que l'échelon de bourse** est également précisé le cas échéant.
   provider_uids:
     - 'education_nationale'
   keywords: []
@@ -52,7 +61,7 @@
   parameters:
     - Identité pivot
   faq:
-    - q: De quelle année scolaire sont les données transmises ?
+    - q: <a name="annee-scolaire-donnees"></a> Quelle est l'année scolaire des données transmises ?
       a: |+
         #### Année scolaire en cours :
         Cette API permet d'appeler les informations de scolarité d'un élève de l'année scolaire en cours.
@@ -70,6 +79,21 @@
 
         {:.fr-highlight}
         ⚠️ Les données transmises pour l'année scolaire N+1 sont et seront toujours des informations susceptibles d'évoluer car l'élève peut changer d'avis jusqu'à la rentrée.
+
+    - q: <a name="fiabilite-statut-boursier-octobre"></a> Pourquoi le statut non-boursier est-il fiable seulement à partir de mi-octobre ?
+      a: |+
+        Pour cette première mouture de l'API scolarité de l'élève, le statut boursier n'est pas encore complètement fiable.
+        Au mois d'août de chaque année, la **base des élèves boursiers est entièrement purgée**. La constitution de la base des élèves boursiers est donc refaite chaque année au compte-goutte, à partir des transmissions des établissements.
+        **Par conséquent, jusqu'à mi-octobre** :
+        - le **statut non-boursier** (`"est_boursier" : "false"`) peut représenter deux situations :
+            - l'élève n'est pas boursier ;
+            - le statut boursier est inconnu par l'API.
+        - le **statut boursier positif** (`"est_boursier" : "true"`) **est fiable.**
+        <br>
+        Le Ministère de l'éducation nationale est en recherche d'une meilleure alternative dont le calendrier pourrait être 2024.
+    - q: <a name="definition-echelons-bourse"></a>À quoi correspondent les échelons de bourse ?
+      a:
+        "Il existe trois échelons de bourses pour les collégiens, de 1 à 3 et six échelons pour les lycéens, de 1 à 6. Chaque échelon de bourse indique **le montant reçu par l'élève pour l'année scolaire**. Le montant de la bourse dépend d'un barème en fonction du revenu fiscal et du nombre enfants à charge du foyer."
    
   historique: |+
     **Ce que change le passage à la V.3 d'API Particulier:**

--- a/config/endpoints/api_particulier/mesri_student_status.yml
+++ b/config/endpoints/api_particulier/mesri_student_status.yml
@@ -64,18 +64,13 @@
   data:
     description: |+
       Cette API délivre la **liste des admissions d'un étudiant**, en précisant pour chacune d'elles : 
-      - si l'étudiant est isncrit ;
+      - si l'étudiant est inscrit, en savoir plus sur la [différence entre le statut inscrit et admis](#diff-statut-admis-inscrit) ;
       - les dates de début et de fin d'études ; 
       - le régime de formation
       - le lieu et l'établissement d'études. 
       
       {:.fr-highlight}
-      💡 L'obtention de ces informations permet d'éviter de demander un certificat étudiant.
-
-      {:.fr-highlight fr-highlight--caution"}
-      > ⚠️ **Tous les établissements ne délivrent pas les informations des étudiants admis**. Par conséquent si l'API ne vous renvoie pas d'informations concernant un particulier, il n'est pas possible de considérer de façon définitive que cet étudiant n'est pas admis.
-      >
-      > En savoir plus sur la [différence entre le statut inscrit et admis](#diff-statut-admis-inscrit).
+      💡 Ces informations sont l'équivalent d'un certificat étudiant.
   provider_uids:
     - 'mesri'
   keywords: []
@@ -107,4 +102,7 @@
     - Afin de faciliter la compréhension de l’API, la liste "Inscriptions" a été renommée en "Admissions". En effet, c’est bien la liste des admissions qui est délivrée pour chaque étudiant. Parmi elles, l’étudiant peut être allé jusqu’à l’inscription, qui est alors indiquée par le champ "Statut étudiant inscrit".
     - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-statut-etudiant){:target="_blank"}
 
-
+  api_cgu:
+    description: |+
+      {:.fr-highlight}
+      > 💡 Dans la mesure où l’API ne couvre pas l’ensemble des étudiants, il est nécessaire de prévoir dans votre service **un mécanisme alternatif permettant aux usagers de transmettre manuellement leur certificat de scolarité**.

--- a/config/endpoints/api_particulier/mesri_student_status.yml
+++ b/config/endpoints/api_particulier/mesri_student_status.yml
@@ -64,13 +64,13 @@
   data:
     description: |+
       Cette API délivre la **liste des admissions d'un étudiant**, en précisant pour chacune d'elles : 
-      - si l'étudiant est inscrit, en savoir plus sur la [différence entre le statut inscrit et admis](#diff-statut-admis-inscrit) ;
+      - si l'étudiant est inscrit, en savoir plus sur la [différence entre le statut inscrit et admis](#diff-statut-admis-inscrit)&nbsp;;
       - les dates de début et de fin d'études ; 
       - le régime de formation
       - le lieu et l'établissement d'études. 
       
       {:.fr-highlight}
-      💡 Ces informations sont l'équivalent d'un certificat étudiant.
+      >💡 Ces informations sont l'équivalent d'un certificat étudiant.
   provider_uids:
     - 'mesri'
   keywords: []

--- a/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v1.yml
+++ b/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v1.yml
@@ -4,7 +4,6 @@
   new_endpoint_uids:
     - 'cnav/v2/quotient_familial_v2'
   path: '/api/v2/composition-familiale'
-  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
   position: 201
   perimeter:

--- a/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v1.yml
+++ b/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v1.yml
@@ -1,0 +1,94 @@
+---
+- uid: 'cnav/v2/quotient_familial_v1'
+  opening: protected
+  new_endpoint_uids:
+    - 'cnav/v2/quotient_familial_v2'
+  path: '/api/v2/composition-familiale'
+  ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
+  position: 201
+  perimeter:
+    entity_type_description: |+
+      {:.fr-highlight.fr-highlight--caution}
+      > ⚠️ **Cette API ne sera plus en production à partir de mai 2025**. Les données seront intégrées dans l'[API CNAF MSA](https://particulier.api.gouv.fr/catalogue/cnav/quotient_familial_v2) à partir de janvier 2024.
+
+      Cette API concerne les **allocataires de la majorité des régimes** :
+      - ✅ le régime général ;
+      - ✅ les titulaires de l'éducation nationale ;
+      - ✅ les retraités de la fonction publique d'État et des collectivités locales ;
+      - ✅ les régimes spéciaux suivants : artiste-auteur-compositeur, France Télécom, industries électriques et gazières, marin du commerce et pêche, mines (régime général), poste, RATP, SNCF, navigation intérieure en cas d'accord local et les pensions des autres régimes.
+
+      Ne sont pas concernés par cette API, les bénéficiaires des régimes suivants :
+      - ❌ le régime agricole : les bénéficiaires (1 à 2% des allocataires) sont rattachés à la MSA ;
+      - ❌ le régime des titulaires de l'Assemblée nationale et du Sénat ;
+      - ❌ le régime de la navigation intérieure **sauf** lorsqu'un accord local est passé, et que le régime est alors pris en compte par la CAF.
+
+    geographical_scope_description:  |+
+      - ✅ France métropolitaine
+      - ✅ DROM COM
+      - ✅ allocataires de nationalité étrangère
+    updating_rules_description: |+
+      Les données sont **mises à jour en temps réel**, l'API étant reliée au système d'information de la Caisse nationale des allocations familiales.
+
+      ⚠️ **Les informations obtenues sont représentatives de la situation connue par la CNAF et peuvent évoluer très fréquemment**. Le Quotient familial CAF est recalculé tous les mois, il peut être rétroactif et dépend de la situation du particulier et de l'état du droit. Il peut donc y avoir des écarts, notamment si la situation de la personne évolue entre temps : perte d'un emploi, évolution des ressources, arrivée d'un enfant, majorité d'un enfant, modification de la législation etc. Depuis que les allocations logement sont contemporaines (transmises très régulièrement), le QF est amené à évoluer lui aussi très fréquemment.
+  parameters_details:
+    description: |+
+      Cette API propose une seule modalité d'appel :
+      <p class="fr-badge fr-badge--purple-glycine">Identifiant</p>
+      Le **numéro d'allocataire** du particulier et son **code postal**.
+  data:
+    description: |+
+      Cette API délivre la **composition familiale de l'allocataire et son quotient familial CAF**.
+
+      {:.fr-highlight}
+      > Le quotient familial de la CNAF a une définition différente du quotient familial de l'administration fiscale, [en  savoir plus](#faq_entry_1_api_particulier_endpoint_cnaf_quotient_familial).
+
+      {:.fr-highlight.fr-highlight--caution}
+      > **Le QF CNAF est calculé seulement pour les allocataires dont les ressources sont déclarées**. En effet, pour calculer le quotient familial, la CNAF collecte tous les mois auprès de la DGFIP les ressources de l'individu (revenus salariés et non-salariés, du capital, rentes ...). Elle récupère le bilan en fin d'année. Sans la réception de ces ressources, le QF CNAF ne peut être calculé : une erreur est renvoyée par l'API.
+      >
+      > Si le particulier n'a plus d'allocations, son QF n'est pas renvoyé. Une erreur est transmise par l'API.
+
+      Le montant du quotient familial CAF retourné par l'API Particulier peut être différent de celui transmis par le dossier allocataire (CDAP), [en savoir plus](#faq_entry_0_api_particulier_endpoint_cnaf_quotient_familial).
+
+  provider_uids:
+    - 'cnaf'
+  keywords:
+    - composition
+    - quotient
+    - famille
+    - familial
+  call_id: "Code postal et numéro de l'allocataire"
+  parameters:
+    - Code postal et numéro de l'allocataire
+  faq:
+    - q: Pourquoi le quotient familial (QF) retourné par l'API Particulier est-il parfois différent de celui transmis par le CDAP ?
+      a: |+
+        Actuellement, il peut arriver que le quotient familial transmis par l'API particulier diffère de celui obtenu sur le [CDAP (Consultation du dossier allocataire par les partenaires)](https://www.caf.fr/partenaires/cdap). Voici des éléments de réponses pour comprendre les différences suivantes :
+
+        * **Le montant du QF est différent** :
+          La différence des montants observés est souvent liée à une différence de temporalité. L'API Particulier délivre le QF du mois M-1 ; là où le CDAP indique le QF en cours.
+        * **Le montant du QF est à 0 sur API Particulier, au lieu de non connu sur le CDAP** :
+          Actuellement, l'API de la CNAF qui alimente l'API Particulier, n'indique pas par un code erreur précis le cas des allocataires dont le QF n'est pas calculable faute de connaître les ressources perçues. En effet, actuellement, un QF à 0 est envoyé, plutôt qu'une erreur.
+          La CNAF a conscience que ce retour peut porter à confusion. Il est prévu une évolution dans la future API.
+        * **Le montant du QF n'est pas délivré par l'API Particulier (affiché non droit) alors qu'il est délivré par le CDAP** :
+          Lorsqu'aucune prestation n'est versée au mois M, l'API CNAF, source de l'API Particulier, ne retourne pas de QF, y compris si en M-1 la personne avait bien des prestations. Une question métier est en cours pour faire évoluer l’API afin de fournir le dernier QF calculé ainsi que la date de ce dernier calcul.
+
+
+        La CNAF travaille actuellement sur une nouvelle API qui retournera les mêmes informations que le CDAP. Les développements sont déjà en cours.
+
+    - q: Quelle différence entre le quotient familial de la CAF et le QF de l'administration fiscale ?
+      a: |+
+        Le quotient familial retourné par l'API est le quotient familial de la CAF. Ce QF est différent de celui de l'administration fiscale car il prend en compte les prestations familiales. Contrairement au quotient familial DGFIP calculé au moment de la déclaration de revenu, le QF de la CAF est revu à chaque changement de situation familiale et/ou professionnelle.
+
+        Calcul du QF de la CAF : Revenu imposable de l’année N-2 divisé par 12 + **les prestations familiales du mois de référence**, le tout divisé par le [nombre de parts telles que calculées par la Caf](https://www.caf.fr/allocataires/caf-de-meurthe-et-moselle/offre-de-service/vie-personnelle/comment-est-calcule-le-quotient-familial){:target="_blank"}.
+
+        Source : [Caf.fr](https://caf.fr/allocataires/vies-de-famille/articles/quotient-familial-caf-impots-quelles-differences){:target="_blank"}
+    - q: Qu'est-ce qu'un enfant au sens de la CNAF ?
+      a: |+
+        La liste des enfants transmis par l'API correspond à la notion d'enfant à charge au sens de la législation familiale. Pour qu'un enfant soit considéré comme "à charge", l’allocataire doit assurer financièrement son entretien de manière effective et permanente et assumer à son égard la responsabilité affective et éducative. Il n'y a pas d'obligation de lien de parenté avec l’enfant.
+
+        Deux notions d’enfant à charge cohabitent :
+
+        * enfant à charge au sens des prestations familiales (Pf) : un enfant est reconnu à charge s’il est âgé d’un mois à moins de 20 ans quelle que soit sa situation, dès lors que son salaire net mensuel ne dépasse pas 55 % du Smic brut ;
+        * enfant à charge au sens de la législation familiale: en plus des enfants à charge au sens des Pf, sont également considérés à charge pour les aides au logement, les enfants âgés de moins de 21 ans en Métropole (22 ans dans les Dom), les enfants âgés de 20 à 25 ans pour le calcul du Rmi/Rsa, et dès le mois de leur naissance, les enfants bénéficiaires de l’allocation de base de la Paje.
+
+        Source: [data.caf.fr](http://data.caf.fr/dataset/population-des-foyers-allocataires-par-commune/resource/3baa3b5b-8376-4b24-a79b-10ee364e956f)

--- a/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v1.yml
+++ b/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v1.yml
@@ -4,6 +4,7 @@
   new_endpoint_uids:
     - 'cnav/v2/quotient_familial_v2'
   path: '/api/v2/composition-familiale'
+  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
   position: 201
   perimeter:

--- a/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
+++ b/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
@@ -29,7 +29,10 @@
       - ✅ DROM COM
       - ✅ Allocataires de nationalité étrangère
     updating_rules_description: |+
-      Les données sont **mises à jour en temps réel**, cette API opérée par la CNAV (Caisse nationale d'assurance vieillesse) est reliée au système d'information de la Caisse nationale des allocations familiales (CNAF) et à celui de la mutualité sociale agricole (MSA).
+      Les données sont **mises à jour** :
+      - **une fois par mois, après le premier week-end du mois, pour les allocataires CAF**
+      - **en temps réel lorsqu'il y a un changement de situation pour les allocataires MSA**
+      Le mois remonté est le mois m-1. Par exemple, au mois de janvier, c'est le quotient familial du mois de décembre de l'année précédente qui est remonté. Il faut donc attendre le mois de février pour accéder au quotient familial du mois de janvier. Cette API opérée par la CNAV (Caisse nationale d'assurance vieillesse) est reliée au système d'information de la Caisse nationale des allocations familiales (CNAF) et à celui de la mutualité sociale agricole (MSA).
 
       ⚠️ **Les informations obtenues sont représentatives de la situation connue par la CNAF et la MSA au moment de l'appel**, il est donc possible qu'un quotient familial appelé pour un mois donné à un instant T, soit différent s'il est redemandé à un instant T+. [En savoir plus](faq_entry_1_api_particulier_endpoint_cnav_quotient_familial_v2).
   data:

--- a/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
+++ b/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
@@ -1,7 +1,8 @@
 ---
 - uid: 'cnav/v2/quotient_familial_v2'
   opening: protected
-  new_endpoint_uids: 'cnav/quotient_familial'
+  new_endpoint_uids: 
+    - 'cnav/quotient_familial'
   old_endpoint_uids:
     - 'cnav/v2/quotient_familial_v1'
   path: '/api/v2/composition-familiale-v2'

--- a/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
+++ b/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
@@ -1,9 +1,7 @@
 ---
-- uid: 'cnav/quotient_familial_v2'
+- uid: 'cnav/v2/quotient_familial_v2'
   opening: protected
-  new_version: true
-  old_endpoint_uids:
-    - 'cnav/v2/quotient_familial_v2'
+  new_endpoint_uids: 'cnav/quotient_familial_v2'
   path: '/v3/dss/quotient_familial/identite'
   ping_url: 'https://particulier.api.gouv.fr/api/cnaf_msa_quotient_familial/ping'
   position: 200
@@ -25,12 +23,9 @@
     geographical_scope_description:  |+
       - ✅ France métropolitaine
       - ✅ DROM COM
-      - ✅ Allocataires de nationalité étrangère résidant en France
+      - ✅ Allocataires de nationalité étrangère
     updating_rules_description: |+
-      Les données sont **mises à jour** : 
-      - **une fois par mois, après le premier week-end du mois, pour les allocataires CAF**
-      - **en temps réel lorsqu'il y a un changement de situation pour les allocataires MSA**
-      Le mois remonté est le mois m-1. Par exemple, au mois de janvier, c'est le quotient familial du mois de décembre de l'année précédente qui est remonté. Il faut donc attendre le mois de février pour accéder au quotient familial du mois de janvier. Cette API opérée par la CNAV (Caisse nationale d'assurance vieillesse) est reliée au système d'information de la Caisse nationale des allocations familiales (CNAF) et à celui de la mutualité sociale agricole (MSA).
+      Les données sont **mises à jour en temps réel**, cette API opérée par la CNAV (Caisse nationale d'assurance vieillesse) est reliée au système d'information de la Caisse nationale des allocations familiales (CNAF) et à celui de la mutualité sociale agricole (MSA).
 
       ⚠️ **Les informations obtenues sont représentatives de la situation connue par la CNAF et la MSA au moment de l'appel**, il est donc possible qu'un quotient familial appelé pour un mois donné à un instant T, soit différent s'il est redemandé à un instant T+. [En savoir plus](faq_entry_1_api_particulier_endpoint_cnav_quotient_familial_v2).
   data:
@@ -46,7 +41,7 @@
       {:.fr-highlight.fr-highlight--caution}
       > **Le QF CNAF est calculé seulement pour les allocataires dont les ressources sont déclarées**. En effet, pour calculer le quotient familial, la CNAF collecte tous les mois auprès de la DGFIP les ressources de l'individu (revenus salariés et non-salariés, du capital, rentes ...). Elle récupère le bilan en fin d'année. Sans la réception de ces ressources, le QF CNAF ne peut être calculé : une erreur est renvoyée par l'API.
       >
-      > Si le particulier n'a plus d'allocations, son QF n'est pas renvoyé. Une erreur 404 "Dossier allocataire absent" est transmise par l'API.
+      > Si le particulier n'a plus d'allocations, son QF n'est pas renvoyé. Une erreur est transmise par l'API.
 
 
   parameters_details:
@@ -116,8 +111,6 @@
     - allocataire
     - enfant
     - adresse
-    - CAF
-    - MSA
   faq:
     - q: Quelle différence entre le quotient familial CAF/MSA et le QF de l'administration fiscale ?
       a: |+

--- a/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
+++ b/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
@@ -6,7 +6,6 @@
   old_endpoint_uids:
     - 'cnav/v2/quotient_familial_v1'
   path: '/api/v2/composition-familiale-v2'
-  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/cnaf_msa_quotient_familial/ping'
   position: 200
   perimeter:

--- a/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
+++ b/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
@@ -1,7 +1,9 @@
 ---
 - uid: 'cnav/v2/quotient_familial_v2'
   opening: protected
-  new_endpoint_uids: 'cnav/quotient_familial_v2'
+  new_endpoint_uids: 'cnav/quotient_familial'
+  old_endpoint_uids:
+    - 'cnav/v2/quotient_familial_v1'
   path: '/api/v2/composition-familiale-v2'
   swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/cnaf_msa_quotient_familial/ping'
@@ -176,20 +178,9 @@
         > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
 
   historique: |+
-    **Ce que change cette API CNAF-MSA par rapport à l'API précédente de la CNAF :**
+    **Ce que change cette API CNAF-MSA par rapport à l'[API précédente de la CNAF](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Quotient-familial/paths/~1api~1v2~1composition-familiale/get){:target="_blank"} :**
     - Le périmètre des particuliers concernés s'élargit avec l'**ajout des bénéficiaires de la MSA** qui sont au régime agricole.
     - **Les paramètres d'appel évoluent**. Dans l'API précédente, l'usager devait renseigner son numéro d'allocataire et son code postal. Avec cette API l'usager renseigne [ses données d'identité](#parameters_details).
 
-
-    <div class="fr-callout fr-icon-information-line">
-      <h3 class="fr-h4 fr-callout__title">Migration V.3</h3>
-      <p class="fr-callout__text">
-          Cette fiche métier correspond à la nouvelle version 3 de l'API Particulier. Vos systèmes d'information utilisent encore la V.2 ?
-
-      </p>
-      <a class="fr-btn" href="/blog/migration-api-particulier-v3">
-          Consultez le guide de migration
-      </a>
-    </div>
 
 

--- a/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
+++ b/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
@@ -2,7 +2,8 @@
 - uid: 'cnav/v2/quotient_familial_v2'
   opening: protected
   new_endpoint_uids: 'cnav/quotient_familial_v2'
-  path: '/v3/dss/quotient_familial/identite'
+  path: '/api/v2/composition-familiale-v2'
+  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/cnaf_msa_quotient_familial/ping'
   position: 200
   perimeter:

--- a/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
+++ b/config/endpoints/api_particulier/v2_cnaf_msa_quotient_familial_v2.yml
@@ -178,7 +178,7 @@
         > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
 
   historique: |+
-    **Ce que change cette API CNAF-MSA par rapport à l'[API précédente de la CNAF](https://particulier.api.gouv.fr/developpeurs/openapi-v2#tag/Quotient-familial/paths/~1api~1v2~1composition-familiale/get){:target="_blank"} :**
+    **Ce que change cette API CNAF-MSA par rapport à l'API précédente de la CNAF :**
     - Le périmètre des particuliers concernés s'élargit avec l'**ajout des bénéficiaires de la MSA** qui sont au régime agricole.
     - **Les paramètres d'appel évoluent**. Dans l'API précédente, l'usager devait renseigner son numéro d'allocataire et son code postal. Avec cette API l'usager renseigne [ses données d'identité](#parameters_details).
 

--- a/config/endpoints/api_particulier/v2_cnav_allocation_adulte_handicape.yml
+++ b/config/endpoints/api_particulier/v2_cnav_allocation_adulte_handicape.yml
@@ -1,9 +1,10 @@
 ---
-- uid: 'cnav/allocation_adulte_handicape'
+- uid: 'cnav/v2/allocation_adulte_handicape'
   opening: protected
-  old_endpoint_uids:
-    - 'cnav/v2/allocation_adulte_handicape'
-  path: '/v3/dss/allocation_adulte_handicape/identite'
+  new_endpoint_uids:
+    - 'cnav/allocation_adulte_handicape'
+  path: '/api/v2/allocation-adulte-handicape'
+  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
   position: 800
   perimeter:

--- a/config/endpoints/api_particulier/v2_cnav_allocation_adulte_handicape.yml
+++ b/config/endpoints/api_particulier/v2_cnav_allocation_adulte_handicape.yml
@@ -4,7 +4,6 @@
   new_endpoint_uids:
     - 'cnav/allocation_adulte_handicape'
   path: '/api/v2/allocation-adulte-handicape'
-  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
   position: 800
   perimeter:

--- a/config/endpoints/api_particulier/v2_cnav_allocation_soutien_familial.yml
+++ b/config/endpoints/api_particulier/v2_cnav_allocation_soutien_familial.yml
@@ -1,17 +1,16 @@
----
-- uid: 'cnav/allocation_adulte_handicape'
-  opening: protected
-  old_endpoint_uids:
-    - 'cnav/v2/allocation_adulte_handicape'
-  path: '/v3/dss/allocation_adulte_handicape/identite'
-  ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
-  position: 800
-  perimeter:
-    entity_type_description: |+
-        ✅ Le périmètre de l’API est _a priori_ exhaustif et couvre tous les bénéficiaires de l'allocation adulte handicapé (AAH).
 
-        {:.fr-highlight}
-        > Pour les ménages en couple, il peut y avoir plusieurs attributaires, c'est-à-dire, plusieurs personnes auxquelles l'AAH est versée. Dans ce cas, quelque soit l'attributaire qui sera intérrogé, l'API indiquera qu'il est bénéficiaire.
+---
+- uid: 'cnav/v2/allocation_soutien_familial'
+  opening: protected
+  new_endpoint_uids:
+    - 'cnav/allocation_soutien_familial'
+  path: '/api/v2/allocation-soutien-familial'
+  swagger_version: 2
+  ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
+  position: 900
+  perimeter:
+    entity_type_description:
+        ✅ Le périmètre de l’API est _a priori_ exhaustif et couvre tous les bénéficiaires de l'allocation de soutien familial (ASF).
 
         ⚙️ Vérification en cours avec le fournisseur de données pour confirmer le périmètre exact.
     geographical_scope_description: |+
@@ -40,7 +39,6 @@
               Pour chacune des deux options ci-dessus, le code COG de la France `99100`<sup>\*</sup> doit également être renseigné en paramètre d'appel. Vous n'avez pas besoin de le demander à l'usager, il peut être déduit de la commune de naissance.
             - *Si le lieu de naissance est à l'étranger&nbsp;:* code COG du pays de naissance<sup>\*</sup>.
 
-
       <span class="fr-text--xs">
       <sup>\*</sup> Obligatoire | <sup>\**</sup> Obligatoire pour l'option 2 du lieu de naissance.
       </span>
@@ -48,19 +46,20 @@
       <sup>1</sup> Fournir plusieurs prénoms permet de limiter les risques d'homonymie mais un seul prénom peut fonctionner. Attention, l'usager doit compléter chaque prénom dans un champ distinct.
       </span>
 
-      
+      {:.fr-highlight.fr-highlight--caution}
+      > ⚠️ **Message API Particulier du 04.06.2024** : Nous avons constaté que les appels effectués sans nom de naissance et **avec le nom d'usage ne fonctionnent pas** dans une très grande partie des cas. Après investigation auprès de la CNAV (opérateur de l'API source), API Particulier a donc décidé de passer le paramètre "Nom de naissance" en obligatoire.
   data:
     description: |+
-      Cette API **indique si le particulier est bénéficiaire de l'allocation adulte handicapé**. En précisant :
+      Cette API **indique si le particulier est bénéficiaire de l'allocation de soutien familial**. En précisant :
         - la date d'ouverture du droit ;
         - la date de fermeture du droit.
   provider_uids:
     - 'cnav'
   keywords:
-    - handicap
     - allocation
     - aides
-    - aah
+    - famille
+    - asf
   call_id: 
     - Identité pivot
     - FranceConnect
@@ -84,12 +83,3 @@
 
         {:.fr-highlight}
         > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
-  historique: |+
-    **Ce que change le passage à la V.3 d'API Particulier:**
-
-    - Le passage à la V.3 n'a pas eu d'impact sur la donnée distribuée qui reste identique ; 
-    - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-statut-aah){:target="_blank"}
-
-
-
-

--- a/config/endpoints/api_particulier/v2_cnav_allocation_soutien_familial.yml
+++ b/config/endpoints/api_particulier/v2_cnav_allocation_soutien_familial.yml
@@ -1,11 +1,9 @@
-
 ---
 - uid: 'cnav/v2/allocation_soutien_familial'
   opening: protected
   new_endpoint_uids:
     - 'cnav/allocation_soutien_familial'
   path: '/api/v2/allocation-soutien-familial'
-  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
   position: 900
   perimeter:

--- a/config/endpoints/api_particulier/v2_cnav_complementaire_sante_solidaire.yml
+++ b/config/endpoints/api_particulier/v2_cnav_complementaire_sante_solidaire.yml
@@ -4,7 +4,6 @@
   new_endpoint_uids:
     - 'cnav/complementaire_sante_solidaire'
   path: '/api/v2/complementaire-sante-solidaire'
-  swagger_version: 2
   position: 950
   ping_url: 'https://particulier.api.gouv.fr/api/securite_sociale_complementaire_sante_solidaire/ping'
   perimeter:

--- a/config/endpoints/api_particulier/v2_cnav_complementaire_sante_solidaire.yml
+++ b/config/endpoints/api_particulier/v2_cnav_complementaire_sante_solidaire.yml
@@ -1,9 +1,10 @@
 ---
-- uid: 'cnav/complementaire_sante_solidaire'
+- uid: 'cnav/v2/complementaire_sante_solidaire'
   opening: protected
-  old_endpoint_uids:
-    - 'cnav/v2/complementaire_sante_solidaire'
-  path: '/v3/dss/complementaire_sante_solidaire/identite'
+  new_endpoint_uids:
+    - 'cnav/complementaire_sante_solidaire'
+  path: '/api/v2/complementaire-sante-solidaire'
+  swagger_version: 2
   position: 950
   ping_url: 'https://particulier.api.gouv.fr/api/securite_sociale_complementaire_sante_solidaire/ping'
   perimeter:
@@ -49,7 +50,8 @@
     description: |+
       Cette API **indique si le particulier est bénéficiaire de la complémentaire santé solidaire**. En précisant :
       - si la C2S est avec ou sans participation financière ;
-      - la date d'ouverture du droit.
+      - la date d'ouverture du droit ;
+      - la date de fermeture du droit.
   provider_uids:
     - 'sphere_sociale'
   keywords:
@@ -94,11 +96,4 @@
 
         {:.fr-highlight}
         > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
-
-  historique: |+
-    **Ce que change le passage à la V.3 d'API Particulier:**
-
-    - Suppression de la date de fin car cette donnée était calculée et présentait le risque de ne pas être juste dans toutes les situations ;
-    - Tous les changements sont décrits dans la [table de correspondance du guide migration](blog/migration-api-particulier-v3#correspondance-api-statut-c2s){:target="_blank"}
-
 

--- a/config/endpoints/api_particulier/v2_cnav_prime_activite.yml
+++ b/config/endpoints/api_particulier/v2_cnav_prime_activite.yml
@@ -4,7 +4,6 @@
   new_endpoint_uids:
     - 'cnav/prime_activite'
   path: '/api/v2/prime-activite'
-  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
   position: 700
   perimeter:

--- a/config/endpoints/api_particulier/v2_cnav_prime_activite.yml
+++ b/config/endpoints/api_particulier/v2_cnav_prime_activite.yml
@@ -1,24 +1,30 @@
 ---
-- uid: 'cnav/complementaire_sante_solidaire'
+- uid: 'cnav/v2/prime_activite'
   opening: protected
-  old_endpoint_uids:
-    - 'cnav/v2/complementaire_sante_solidaire'
-  path: '/v3/dss/complementaire_sante_solidaire/identite'
-  position: 950
-  ping_url: 'https://particulier.api.gouv.fr/api/securite_sociale_complementaire_sante_solidaire/ping'
+  new_endpoint_uids:
+    - 'cnav/prime_activite'
+  path: '/api/v2/prime-activite'
+  swagger_version: 2
+  ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
+  position: 700
   perimeter:
     entity_type_description: |+
-      ✅ **Le périmètre de l'API est exhaustif et couvre tous les assurés** de la sphère sociale susceptibles d'être concernés par la complémentaire de santé solidaire ([C2S](#faq_entry_0_api_particulier_endpoint_cnav_complementaire_sante_solidaire)).
-    geographical_scope_description:  |+
-      - ✅ France métropolitaine
-      - ✅ Départements d'Outre-mer
-      - ✅ Assurés de nationalité étrangère
-      - ❌ Les collectivtés d'Outre-mer, ayant un autre système de sécurité sociale, ne sont pas concernées par cette API.
-    updating_rules_description: |+
-      Les données sont **mises à jour en temps réel** et issues du répertoire national commun de la protection sociale (RNCPS) opéré par la CNAV (Caisse nationale d'assurance vieillesse). Les données du répertoire sont remontées directement par les différents organismes comme la CNAM pour les assurés du régime général et la MSA pour les assurés au régime agricole.
+        ✅ Le périmètre de l’API est _a priori_ exhaustif et couvre tous les bénéficiaires de la prime d'activité (PPA).
+
+        {:.fr-highlight}
+        > Les enfants d'un allocataire de la prime d'activité ne sont pas considérés comme des bénéficiaires.
+
+        ⚙️ Vérification en cours avec le fournisseur de données pour confirmer le périmètre exact.
+    geographical_scope_description: |+
+      - ✅ France Métropolitaine
+      - ✅ Départements d’Outre-mer
+      - ❌ Les collectivités d’Outre-mer, ayant un autre système de sécurité sociale, ne sont pas concernées par cette API.
+      - ⚙️ Personne de nationalité étrangère - Vérification en cours avec le fournisseur de la donnée pour confirmer la prise en charge. D'un point de vue métier, des prestations sont bien délivrées à une personne étrangère ayant un numéro d'immatriculation en attente (NIA) mais nous ne savons pas encore si le NIA est supporté par l'API.
+    updating_rules_description:
+      Les données sont **mises à jour en temps réel** et issues du répertoire national commun de la protection sociale (RNCPS) opéré par la CNAV (Caisse nationale d’assurance vieillesse). Les données du répertoire sont remontées directement par les différents organismes comme la CNAF pour les assurés du régime général et la MSA pour les assurés au régime agricole.
   parameters_details:
     description: |+
-      Cette API propose 2 modalités d'appel :
+      Cette API propose deux modalités d'appel :
       <p class="fr-badge fr-badge--blue-ecume">![Cette API est FranceConnectée](<%= image_path('api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg') %>){:width="20px"} FranceConnect</p>
       **Avec la [modalité d'appel FranceConnect](<%= cas_usage_path('modalite_appel_france_connect') %>)**.
 
@@ -47,37 +53,24 @@
       > ⚠️ **Message API Particulier du 04.06.2024** : Nous avons constaté que les appels effectués sans nom de naissance et **avec le nom d'usage ne fonctionnent pas** dans une très grande partie des cas. Après investigation auprès de la CNAV (opérateur de l'API source), API Particulier a donc décidé de passer le paramètre "Nom de naissance" en obligatoire.
   data:
     description: |+
-      Cette API **indique si le particulier est bénéficiaire de la complémentaire santé solidaire**. En précisant :
-      - si la C2S est avec ou sans participation financière ;
-      - la date d'ouverture du droit.
+      Cette API **indique si le particulier est bénéficiaire de la prime d'activité**. En précisant :
+        - la date d'ouverture du droit ;
+        - la date de fermeture du droit.
   provider_uids:
-    - 'sphere_sociale'
+    - 'cnav'
   keywords:
-    - complementaire
-    - sante
-    - solidaire
-    - C2S
-    - assuré
-    - assurance maladie
-    - mutuelle
+    - prime
+    - emploi
+    - activité
+    - ppa
+    - pa
   call_id:
     - Identité pivot
     - FranceConnect
-  parameters:
+  parameters: 
     - Identité pivot
     - FranceConnect
   faq:
-    - q: "Qu'est-ce qu'une complémentaire santé solidaire ?"
-      a: |+
-        La complémentaire santé solidaire est une **aide versée par l'assurance maladie sous conditions de ressources et de résidence**. Elle prend en charge la part des dépenses de santé qui ne sont pas remboursées par la sécurité sociale et permet d'accéder à d'autres avantages.
-
-        La complémentaire santé solidaire peut être :
-        - gratuite, indiquée par _"sans participation"_ dans cette API ;
-        - payante à partir d'un certain montant de ressources, indiquée par _"avec participation"_ dans cette API.
-
-
-        **En savoir plus sur le dispositif** : [service-public.fr](https://www.service-public.fr/particuliers/vosdroits/F10027){:target="_blank"}.
-        **En savoir plus sur les conditions d'accès** : [complementaire-sante-solidaire.gouv.fr](https://www.complementaire-sante-solidaire.gouv.fr/complementairesantesolidaire.php){:target="_blank"}.
     - q: <a name="renseigner-lieu-de-naissance"></a> Appel avec l'identité pivot, comment renseigner le lieu de naissance ?
       a: |+
        Lorsque l'API est appelée avec l'identité pivot, pour identifier correctement le particulier, le système d'information a besoin de récupérer le lieu de naissance du particulier.
@@ -94,11 +87,4 @@
 
         {:.fr-highlight}
         > **Le code COG du pays de naissance est obligatoire pour tous les appels.** Pour simplifier le parcours des usagers, évitez de demander aux particuliers nés en France de saisir leur pays de naissance, puisque vous pouvez le paramétrer directement -code COG pays France `99100`-, dès qu'un particuloer renseigne les informations de sa commune de naissance (forcément en France).
-
-  historique: |+
-    **Ce que change le passage à la V.3 d'API Particulier:**
-
-    - Suppression de la date de fin car cette donnée était calculée et présentait le risque de ne pas être juste dans toutes les situations ;
-    - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-statut-c2s){:target="_blank"}
-
 

--- a/config/endpoints/api_particulier/v2_cnav_revenu_solidarite_active.yml
+++ b/config/endpoints/api_particulier/v2_cnav_revenu_solidarite_active.yml
@@ -4,7 +4,6 @@
   new_endpoint_uids:
     - 'cnav/revenu_solidarite_active'
   path: '/api/v2/revenu-solidarite-active'
-  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
   position: 600
   perimeter:

--- a/config/endpoints/api_particulier/v2_cnav_revenu_solidarite_active.yml
+++ b/config/endpoints/api_particulier/v2_cnav_revenu_solidarite_active.yml
@@ -1,9 +1,10 @@
 ---
-- uid: 'cnav/revenu_solidarite_active'
+- uid: 'cnav/v2/revenu_solidarite_active'
   opening: protected
-  old_endpoint_uids:
-    - 'cnav/v2/revenu_solidarite_active'
-  path: '/v3/dss/revenu_solidarite_active/identite'
+  new_endpoint_uids:
+    - 'cnav/revenu_solidarite_active'
+  path: '/api/v2/revenu-solidarite-active'
+  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/caf/ping'
   position: 600
   perimeter:
@@ -47,7 +48,9 @@
       > ⚠️ **Message API Particulier du 04.06.2024** : Nous avons constaté que les appels effectués sans nom de naissance et **avec le nom d'usage ne fonctionnent pas** dans une très grande partie des cas. Après investigation auprès de la CNAV (opérateur de l'API source), API Particulier a donc décidé de passer le paramètre "Nom de naissance" en obligatoire.
   data:
     description: |+
-      Cette API **indique si le particulier est bénéficiaire du revenu de solidarité active**, en précisant la date d'ouverture du droit.
+      Cette API **indique si le particulier est bénéficiaire du revenu de solidarité active**. En précisant :
+        - la date d'ouverture du droit ;
+        - la date de fermeture du droit.
   provider_uids:
     - 'cnav'
   keywords:
@@ -83,9 +86,3 @@
         Cette option à pour objectif de faciliter vos développements, mais elle n'est pas exhaustive puisque les usagers nés à l'étranger ne pourront pas être identifiés. 
 
         Avec cette option, vous pouvez appeler l'API avec le nom de la commune de naissance et le code du département de naissance. La date de naissance est obligatoire car c'est elle qui permettra à l'API de faire la correspondance avec le bon code COG.
-  historique: |+
-    **Ce que change le passage à la V.3 d'API Particulier:**
-
-    - Le passage à la V.3 n'a pas eu d'impact sur la donnée distribuée qui reste identique ; 
-    - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-statut-rsa){:target="_blank"}
-

--- a/config/endpoints/api_particulier/v2_cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/v2_cnous_student_scholarship.yml
@@ -4,7 +4,6 @@
   new_endpoint_uids:
     - 'cnous/statut_etudiant_boursier'
   path: '/api/v2/etudiants-boursiers'
-  swagger_version: 2
   position: 400
   ping_url: 'https://particulier.api.gouv.fr/api/cnous_etudiant_boursier_ine/ping'
   perimeter:

--- a/config/endpoints/api_particulier/v2_cnous_student_scholarship.yml
+++ b/config/endpoints/api_particulier/v2_cnous_student_scholarship.yml
@@ -1,9 +1,10 @@
 ---
-- uid: 'cnous/statut_etudiant_boursier'
+- uid: 'cnous/v2/statut_etudiant_boursier'
   opening: protected
-  old_endpoint_uids:
-    - 'cnous/v2/statut_etudiant_boursier'
-  path: '/v3/cnous/etudiant_boursier/identite'
+  new_endpoint_uids:
+    - 'cnous/statut_etudiant_boursier'
+  path: '/api/v2/etudiants-boursiers'
+  swagger_version: 2
   position: 400
   ping_url: 'https://particulier.api.gouv.fr/api/cnous_etudiant_boursier_ine/ping'
   perimeter:
@@ -63,10 +64,3 @@
         Pour chaque échelon, il y a deux montants possibles, le premier correspond au montant versé pour 10 mois ; le second, plus élevé, équivaut à 12 mois. Il est versé aux étudiants bénéficiant du maintien de la bourse pendant les grandes vacances universitaires. Les taux sont fixés par arrêté, la page dédiée sur [Service-public.fr](https://www.service-public.fr/particuliers/vosdroits/F12214) détaille les montants et vous permettra de retrouver l'arrêté de l'année en cours.
 
         Cette API vous permet de connaître le montant exact perçu par l'étudiant car elle délivre l'échelon de la bourse et la durée de versement en mois."
-  historique: |+
-    **Ce que change le passage à la V.3 d'API Particulier:**
-
-    - Le passage à la V.3 n'a pas eu d'impact sur la donnée distribuée qui reste identique ;
-    - Les données d'identité ne sont plus renvoyées lorsque la modalité d'appel est FranceConnect ;
-    - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-statut-etudiant-boursier){:target="_blank"}
-

--- a/config/endpoints/api_particulier/v2_education_nationale_statut_eleve.yml
+++ b/config/endpoints/api_particulier/v2_education_nationale_statut_eleve.yml
@@ -1,11 +1,16 @@
 ---
-- uid: 'education_nationale/statut_eleve_scolarise'
+- uid: 'education_nationale/v2/statut_eleve_scolarise'
   opening: protected
-  old_endpoint_uids:
-    - 'education_nationale/v2/statut_eleve_scolarise'
-  path: '/v3/men/scolarites/identite'
+  new_endpoint_uids:
+    - 'education_nationale/statut_eleve_scolarise'
+  path: '/api/v2/scolarites'
+  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/men_scolarite/ping'
   position: 500
+  alert:
+    title: "Données de bourse indisponibles"
+    description: |+
+      Cette API ne délivre plus de données en lien avec la bourse depuis décembre 2024 : statut boursier et échelon de la bourse. La notion de bourse sera réintroduite dans l'API courant 2025.
   perimeter:
     entity_type_description: |+
       Cette API concerne les **✅ élèves de la maternelle, du primaire, du collège et du lycée**.
@@ -16,6 +21,8 @@
       - ✅ lycées militaires dépendant du ministère des armées ;
       - ✅ lycées maritimes dépendant du ministère de la mer ;
       - ✅ une partie des formations à distance du CNED.
+
+      **Concernant le statut boursier des élèves** : seules les bourses sur critères sociaux à l'échelle nationale sont couvertes par l'API. Par ailleurs, les bourses ne concernent que les collégiens et lycéens.
 
 
       **Les établissements et formations suivants ne sont pas couverts par l'API** :
@@ -32,6 +39,9 @@
       Les données du **premier degré** (primaire) sont mises à jour en **temps réel**. Les données du **second degré** (collèges et lycées) sont mises à jour **quotidiennement toutes les nuits**.
 
       Les informations, même si elles évoluent principalement lors de la rentrée scolaire en septembre, peuvent changer en cours d'année (déménagements, etc.).
+
+      {:.fr-highlight.fr-highlight--caution}
+      Attention, si un élève est indiqué "non-boursier" avant mi-octobre, il ne faut pas prendre en compte cette information. Le **statut non-boursier est véritablement fiable à partir de mi-octobre**. [En savoir plus](#faq_entry_answer_1_api_particulier_endpoint_education_nationale_statut_eleve_scolarise).
   parameters_details:
     description: |+
       Cette API propose une modalité d'appel :
@@ -42,7 +52,7 @@
       </span>
   data:
     description: |+
-      Cette API **indique si l'élève est scolarisé et sous quel statut** pour l'[année scolaire en cours et bientôt N+1](#faq_entry_0_api_particulier_endpoint_education_nationale_statut_eleve_scolarise).
+      Cette API **indique si l'élève est scolarisé et sous quel statut** pour l'[année scolaire en cours et bientôt N+1](#faq_entry_0_api_particulier_endpoint_education_nationale_statut_eleve_scolarise). Le statut boursier ainsi que l'échelon de bourse est également précisé le cas échéant.
   provider_uids:
     - 'education_nationale'
   keywords: []
@@ -60,7 +70,8 @@
         - ✅ Pour les **élèves du premier degrés**, les données de l'année scolaire en cours sont accessibles ; et spécifiquement pour le premier degré, uniquement à partir du lendemain de la rentrée ;
         - ✅ Pour les **élèves du second degré**, les données de l'année scolaire n+1 sont accessibles fin juin pour les collégiens et fin août pour les lycéens. 
         - ⚠️ Pour les **élèves des établissements privés**, le constat de rentrée obligatoire pour ces établissements se fait fréquemment en octobre. Par conséquent, il peut arriver qu'au mois de septembre, l'API n'ait pas connaissance du statut d'un élève si celui-ci vise à être scolarisé dans l'établissement privé.
-
+        - ⚠️ Le **statut boursier est un peu plus complexe** : du fait d'une purge de la base de donnée fin août, il peut arriver que les données soient indisponibles jusqu'en septembre inclus.
+        <br>
 
         #### Bientôt l'année scolaire N+1 :
         Dans le cadre de démarches administratives, il peut être utile de connaître le statut scolarisé en avance de phase par rapport à la rentrée. _Par exemple, connaître dès juin, le statut de l'élève pour septembre_. À ce jour l'API n'est pas en mesure de délivrer ces informations pour toutes les situations :
@@ -70,12 +81,19 @@
 
         {:.fr-highlight}
         ⚠️ Les données transmises pour l'année scolaire N+1 sont et seront toujours des informations susceptibles d'évoluer car l'élève peut changer d'avis jusqu'à la rentrée.
-   
-  historique: |+
-    **Ce que change le passage à la V.3 d'API Particulier:**
+    - q: Pourquoi le statut non-boursier est-il fiable seulement à partir de mi-octobre ?
+      a: |+
+        Pour cette première mouture de l'API scolarité de l'élève, le statut boursier n'est pas encore complètement fiable.
+        Au mois d'août de chaque année, la **base des élèves boursiers est entièrement purgée**. La constitution de la base des élèves boursiers est donc refaite chaque année au compte-goutte, à partir des transmissions des établissements.
 
-    - Suppression des données de bourse : le fournisseur de données ne renvoie plus le statut boursier ;
-    - Ajout de nouvelles données : Le module élémentaire de formation, ainsi que le ministère de tutelle de l’établissement sont désormais indiqués ;
-    - Les données d'identité ne sont plus renvoyées lorsque la modalité d'appel est FranceConnect ;
-    - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-statut-eleve-scolarise){:target="_blank"}
+        **Par conséquent, jusqu'à mi-octobre** :
+        - le **statut non-boursier** (`"est_boursier" : "false"`) peut représenter deux situations :
+            - l'élève n'est pas boursier ;
+            - le statut boursier est inconnu par l'API.
+        - le **statut boursier positif** (`"est_boursier" : "true"`) **est fiable.**
 
+        <br>
+        Le Ministère de l'éducation nationale est en recherche d'une meilleure alternative dont le calendrier pourrait être 2024.
+    - q: À quoi correspondent les échelons de bourse ?
+      a:
+        "Il existe trois échelons de bourses pour les collégiens, de 1 à 3 et six échelons pour les lycéens, de 1 à 6. Chaque échelon de bourse indique **le montant reçu par l'élève pour l'année scolaire**. Le montant de la bourse dépend d'un barème en fonction du revenu fiscal et du nombre enfants à charge du foyer."

--- a/config/endpoints/api_particulier/v2_education_nationale_statut_eleve.yml
+++ b/config/endpoints/api_particulier/v2_education_nationale_statut_eleve.yml
@@ -4,7 +4,6 @@
   new_endpoint_uids:
     - 'education_nationale/statut_eleve_scolarise'
   path: '/api/v2/scolarites'
-  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/men_scolarite/ping'
   position: 500
   alert:

--- a/config/endpoints/api_particulier/v2_mesri_student_status.yml
+++ b/config/endpoints/api_particulier/v2_mesri_student_status.yml
@@ -1,14 +1,14 @@
 ---
-- uid: 'mesri/statut_etudiant'
+- uid: 'mesri/v2/statut_etudiant'
   opening: protected
-  old_endpoint_uids:
-    - 'mesri/v2/statut_etudiant'
-  path: '/v3/mesri/statut_etudiant/identite'
+  new_endpoint_uids: 'mesri/statut_etudiant'
+  path: '/api/v2/etudiants'
+  swagger_version: 2
   position: 300
   ping_url: 'https://particulier.api.gouv.fr/api/mesri_statut_etudiant_ine/ping'
   perimeter:
     entity_type_description: |+
-      Cette API permet d'accéder aux **admissions et inscriptions de 2 millions d'étudiants** (_Valeur d'avril 2025 - statistique à jour [ici](https://statutetudiant.esr.gouv.fr/){:target="_blank"}_) sur les un peu moins de 3 millions d'étudiants scolarisés dans l'enseignement supérieur (_[Statistique Insee 2023](https://www.insee.fr/fr/statistiques/8242335?sommaire=8242421){:target="_blank"}_). 
+      Cette API permet d'accéder aux **admissions et inscriptions de 1,3 million d'étudiants** (_Nombre de septembre 2024 - statistique à jour [ici](https://statutetudiant.esr.gouv.fr/){:target="_blank"}_) sur les un peu moins de 3 millions d'étudiants scolarisés dans l'enseignement supérieur (_[Statistique Insee 2022](https://www.insee.fr/fr/statistiques/2387291#tableau-figure1){:target="_blank"}_). 
 
       **Cette API concerne :**
       - ✅ **les étudiants admis ou inscrits dans les établissements sous tutelle du ministère de l'enseignement supérieur** (_avec pour objectif, à terme, de couvrir les tutelles de tous les ministères  et les établissements privés_), ayant au minimum une admission ou inscription dans l'année en cours et quelque soit leur régime : formation initiale, apprentissage, stagiaire de la formation continue, contrat de professionnalisation...
@@ -23,6 +23,11 @@
       **Ne sont pas couverts**, les étudiants des établissements :
       - ❌ les étudiants en service civique ;
       - ❌ les étudiants en formation sociale.
+
+      {:.fr-highlight}
+      > ⚠️ **Tous les établissements ne délivrent pas les informations des étudiants admis**. Par conséquent si l'API ne vous renvoie pas d'informations concernant un particulier, il n'est pas possible de considérer de façon définitive que cet étudiant n'est pas admis.
+      >
+      > En savoir plus sur la [différence entre le statut inscrit et admis](#faq_entry_0_api_particulier_endpoint_mesri_statut_etudiant).
 
     geographical_scope_description:  |+
       Cette API délivre les informations des **✅étudiants français et étrangers**.
@@ -43,7 +48,7 @@
       - Pour les **grandes universités**, le délai peut être en **temps réel** ;
       - Pour les petits établissements, le délai est probablement plus long.
 
-      Des admissions peuvent avoir lieu toute l'année, et la transmission de ces informations par les établissements se fait elle aussi tout au long de l'année.
+      Des inscriptions peuvent avoir lieu toute l'année, et la transmission de ces informations par les établissements se fait elle aussi tout au long de l'année.
   parameters_details:
     description: |+
       Cette API propose trois modalités d'appel :
@@ -63,19 +68,7 @@
       [✒️ **Aider les usagers à renseigner leur lieu de naissance par code COG** - Lire la publication du 08/11/2023](https://particulier.api.gouv.fr/blog/parametre-lieu-naissance-code-cog){:target="_blank"}
   data:
     description: |+
-      Cette API délivre la **liste des admissions d'un étudiant**, en précisant pour chacune d'elles : 
-      - si l'étudiant est isncrit ;
-      - les dates de début et de fin d'études ; 
-      - le régime de formation
-      - le lieu et l'établissement d'études. 
-      
-      {:.fr-highlight}
-      💡 L'obtention de ces informations permet d'éviter de demander un certificat étudiant.
-
-      {:.fr-highlight fr-highlight--caution"}
-      > ⚠️ **Tous les établissements ne délivrent pas les informations des étudiants admis**. Par conséquent si l'API ne vous renvoie pas d'informations concernant un particulier, il n'est pas possible de considérer de façon définitive que cet étudiant n'est pas admis.
-      >
-      > En savoir plus sur la [différence entre le statut inscrit et admis](#diff-statut-admis-inscrit).
+      Cette API délivre la **liste des inscriptions et admissions d'un étudiant**, en précisant les dates de début et de fin d'études, le régime de formation et le l'établisssement. L'obtention de ces informations permet d'éviter de demander un certificat étudiant.
   provider_uids:
     - 'mesri'
   keywords: []
@@ -88,7 +81,7 @@
     - INE
     - FranceConnect
   faq:
-    - q: <a name="diff-statut-admis-inscrit"></a> Quelle différence entre le statut "admis" et le statut "inscrit" ?
+    - q: Quelle différence entre le statut "admis" et le statut "inscrit" ?
       a:
         "Lorsque la candidature ou la demande de l'étudiant à rejoindre un établissement d'enseignement supérieur est accordée, le statut d'inscription est \"admis\".
 
@@ -98,13 +91,6 @@
 
         Un étudiant peut être inscrit dans différents établissements."
 
-    - q: <a name="diff-formation-initiale-continue"></a> Quelle différence entre formation initiale et formation continue ?
+    - q: Quelle différence entre formation initiale et formation continue ?
       a:
         La distinction principale entre formation initiale et formation continue est le **critère de conventionnement spécifique à la formation continue** et qui se traduit par la signature d’une convention ou d’un contrat de formation professionnelle entre la personne et l’établissement formateur tel qu’il est décrit dans les [articles L.6353-1 à L. 6353-7 du Code du travail](https://www.legifrance.gouv.fr/codes/section_lc/LEGITEXT000006072050/LEGISCTA000006178215/#LEGISCTA000006178215) et l’[article D. 714-62 du Code de l’éducation](https://www.legifrance.gouv.fr/codes/article_lc/LEGIARTI000027866356/).
-  historique: |+
-    **Ce que change le passage à la V.3 d'API Particulier:**
-
-    - Afin de faciliter la compréhension de l’API, la liste "Inscriptions" a été renommée en "Admissions". En effet, c’est bien la liste des admissions qui est délivrée pour chaque étudiant. Parmi elles, l’étudiant peut être allé jusqu’à l’inscription, qui est alors indiquée par le champ "Statut étudiant inscrit".
-    - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-statut-etudiant){:target="_blank"}
-
-

--- a/config/endpoints/api_particulier/v2_mesri_student_status.yml
+++ b/config/endpoints/api_particulier/v2_mesri_student_status.yml
@@ -4,7 +4,6 @@
   new_endpoint_uids: 
     - 'mesri/statut_etudiant'
   path: '/api/v2/etudiants'
-  swagger_version: 2
   position: 300
   ping_url: 'https://particulier.api.gouv.fr/api/mesri_statut_etudiant_ine/ping'
   perimeter:

--- a/config/endpoints/api_particulier/v2_mesri_student_status.yml
+++ b/config/endpoints/api_particulier/v2_mesri_student_status.yml
@@ -1,7 +1,8 @@
 ---
 - uid: 'mesri/v2/statut_etudiant'
   opening: protected
-  new_endpoint_uids: 'mesri/statut_etudiant'
+  new_endpoint_uids: 
+    - 'mesri/statut_etudiant'
   path: '/api/v2/etudiants'
   swagger_version: 2
   position: 300

--- a/config/endpoints/api_particulier/v2_pole_emploi.yml
+++ b/config/endpoints/api_particulier/v2_pole_emploi.yml
@@ -1,7 +1,8 @@
 ---
 - uid: 'pole_emploi/v2/situation'
   opening: protected
-  new_endpoint_uids: 'pole_emploi/situation'
+  new_endpoint_uids: 
+    - 'pole_emploi/situation'
   path: '/api/v2/situations-pole-emploi'
   swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/pole_emploi_status/ping'
@@ -82,7 +83,8 @@
 
 - uid: 'pole_emploi/v2/indemnites'
   opening: protected
-  new_endpoint_uids: 'pole_emploi/indemnites'
+  new_endpoint_uids: 
+    - 'pole_emploi/indemnites'
   path: '/api/v2/paiements-pole-emploi'
   swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/pole_emploi_indemnites/ping'

--- a/config/endpoints/api_particulier/v2_pole_emploi.yml
+++ b/config/endpoints/api_particulier/v2_pole_emploi.yml
@@ -4,7 +4,6 @@
   new_endpoint_uids: 
     - 'pole_emploi/situation'
   path: '/api/v2/situations-pole-emploi'
-  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/pole_emploi_status/ping'
   position: 501
   perimeter:
@@ -86,7 +85,7 @@
   new_endpoint_uids: 
     - 'pole_emploi/indemnites'
   path: '/api/v2/paiements-pole-emploi'
-  swagger_version: 2
+  
   ping_url: 'https://particulier.api.gouv.fr/api/pole_emploi_indemnites/ping'
   position: 502
   perimeter:

--- a/config/endpoints/api_particulier/v2_pole_emploi.yml
+++ b/config/endpoints/api_particulier/v2_pole_emploi.yml
@@ -1,9 +1,9 @@
 ---
-- uid: 'pole_emploi/situation'
+- uid: 'pole_emploi/v2/situation'
   opening: protected
-  old_endpoint_uids:
-    - 'pole_emploi/v2/situation'
-  path: '/v3/france_travail/statut/identifiant'
+  new_endpoint_uids: 'pole_emploi/situation'
+  path: '/api/v2/situations-pole-emploi'
+  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/pole_emploi_status/ping'
   position: 501
   perimeter:
@@ -80,18 +80,11 @@
         | 7          | Personnes non immédiatement disponibles à la recherche d'un autre emploi, à durée indéterminée à temps partiel, tenues d'accomplir des actes positifs de recherche d'emploi.  |  ❌  |
         | 8          | Personnes non immédiatement à la recherche d'un autre emploi, à durée déterminée, temporaire ou saisonnier, y compris de très courte durée, tenues d'accomplir des actes positifs de recherche d'emploi.  |  ❌  |
 
-
-  historique: |+
-    **Ce que change le passage à la V.3 d'API Particulier:**
-
-    Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-statut-demandeur-emploi){:target="_blank"}
-
-
-- uid: 'pole_emploi/indemnites'
+- uid: 'pole_emploi/v2/indemnites'
   opening: protected
-  old_endpoint_uids:
-    - 'pole_emploi/v2/indemnites'
-  path: '/v3/france_travail/indemnites/identifiant'
+  new_endpoint_uids: 'pole_emploi/indemnites'
+  path: '/api/v2/paiements-pole-emploi'
+  swagger_version: 2
   ping_url: 'https://particulier.api.gouv.fr/api/pole_emploi_indemnites/ping'
   position: 502
   perimeter:
@@ -171,8 +164,4 @@
         >
         > À notre connaissance, l'identifiant du compte utilisateur est configuré par l'usager au moment de la création de son espace et n'est donc présent sur aucun document ou courriel qui permettrait à un agent de vérifier l'identité. L'appel à l'API statut demandeur d'emploi est donc indispensable pour vérifier l'identité.
 
-  historique: |+
-    **Ce que change le passage à la V.3 d'API Particulier:**
 
-    - Suppression du champ "identifiant" car il s’agissait du paramètre d’appel saisi.
-    - Tous les changements sont décrits dans la [table de correspondance du guide migration](/blog/migration-api-particulier-v3#correspondance-api-paiements-france-travail){:target="_blank"}

--- a/config/locales/api_entreprise/documentation.fr.yml
+++ b/config/locales/api_entreprise/documentation.fr.yml
@@ -237,7 +237,7 @@ fr:
                 anchor: 'changer-de-version'
                 content: |+
                   Depuis la version 3 de l'API&nbsp;Entreprise, toutes les API peuvent évoluer indépendamment les unes des autres. Les anciennes versions (à partir de la V.3) restent donc toujours disponibles si le fournisseur de la donnée continue de transmettre les informations.
-                  Depuis la version 3, le numéro de version est un paramètre de l’appel et non plus une valeur fixe pour toutes les API comme en version 1 et 2 (Les versions 1 et 2 sont définitivement dépréciées, la version 1 étant déjà fermée et **la version 2 fermant le 30 juin 2023**).
+                  Depuis la version 3, le numéro de version est un paramètre de l’appel et non plus une valeur fixe pour toutes les API comme en version 1 et 2 (Les versions 1 et 2 sont définitivement dépréciées).
 
                   >_Exemple d'utilisation du paramètre d'appel de version :_
                   > Imaginons un exemple fictif : l'API documents, cette API est disponible en v.3 et une nouvelle version est sortie, la V.4.

--- a/config/locales/api_entreprise/fr.yml
+++ b/config/locales/api_entreprise/fr.yml
@@ -276,10 +276,10 @@ fr:
           cta: "CGU API Entreprise"
       use_cases:
         main:
-          title: "Cas d'usage"
-          description: "Liste des cas d'usage où cette API est utile :"
+          title: "Cas d'usages"
+          description: "API utile pour :"
         optional:
-          description: "Liste des cas d'usage où cette API est peut être utile :"
+          description: "API parfois utile pour :"
       details:
         title: "Détails de l'API"
         format:

--- a/config/locales/api_particulier/cas_usages_entries.fr.yml
+++ b/config/locales/api_particulier/cas_usages_entries.fr.yml
@@ -7,7 +7,6 @@ fr:
           - intercommunalités
         name: 'Tarification sociale des services municipaux à l’enfance'
         endpoints:
-          - cnav/quotient_familial_v2
           - cnav/quotient_familial
         endpoints_optional:
           - cnav/revenu_solidarite_active
@@ -22,8 +21,7 @@ fr:
           - cnav/allocation_adulte_handicape
           - cnav/allocation_soutien_familial
         comments_endpoints:
-            "cnav/quotient_familial_v2" : "Permet de récupérer le quotient familial CAF ou MSA.<br/><br/>Les données d'identité des membres de la famille et l'adresse postale sont aussi disponibles sous réserve d'un cadre légal précis."
-            "cnaf/quotient_familial" : ""
+            "cnav/quotient_familial" : "Permet de récupérer le quotient familial CAF ou MSA.<br/><br/>Les données d'identité des membres de la famille et l'adresse postale sont aussi disponibles sous réserve d'un cadre légal précis."
             "cnous/statut_etudiant_boursier" : ""
             "education_nationale/statut_eleve_scolarise" : ""
             "mesri/statut_etudiant" : ""
@@ -197,7 +195,6 @@ fr:
           - départements
         name: 'Tarification cantine'
         endpoints:
-          - cnav/quotient_familial_v2
           - cnav/quotient_familial
         endpoints_optional:
           - education_nationale/statut_eleve_scolarise
@@ -212,8 +209,7 @@ fr:
           - cnav/allocation_adulte_handicape
           - cnav/allocation_soutien_familial
         comments_endpoints:
-            "cnav/quotient_familial_v2" : "Permet de récupérer le quotient familial CAF ou MSA.<br/><br/>Les données d'identité des membres de la famille et l'adresse postale sont aussi disponibles sous réserve d'un cadre légal précis."
-            "cnaf/quotient_familial" : ""
+            "cnav/quotient_familial" : "Permet de récupérer le quotient familial CAF ou MSA.<br/><br/>Les données d'identité des membres de la famille et l'adresse postale sont aussi disponibles sous réserve d'un cadre légal précis."
             "cnous/statut_etudiant_boursier" : ""
             "education_nationale/statut_eleve_scolarise" : "Permet de savoir si l'enfant est scolarisé au primaire, collège ou lycée et s'il est boursier."
             "mesri/statut_etudiant" : ""
@@ -308,8 +304,7 @@ fr:
         name: 'Aides facultatives départementales et régionales'
         endpoints:
         endpoints_optional:
-          - cnav/quotient_familial_v2
-          - cnaf/quotient_familial
+          - cnav/quotient_familial
           - cnous/statut_etudiant_boursier
           - education_nationale/statut_eleve_scolarise
           - mesri/statut_etudiant
@@ -322,8 +317,7 @@ fr:
           - cnav/allocation_soutien_familial
         endpoints_forbidden:
         comments_endpoints:
-            "cnav/quotient_familial_v2" : "Permet de récupérer le quotient familial CAF ou MSA.<br/><br/>Les données d'identité des membres de la famille et l'adresse postale sont aussi disponibles sous réserve d'un cadre légal précis."
-            "cnaf/quotient_familial" : ""
+            "cnav/quotient_familial" : "Permet de récupérer le quotient familial CAF ou MSA.<br/><br/>Les données d'identité des membres de la famille et l'adresse postale sont aussi disponibles sous réserve d'un cadre légal précis."
             "cnous/statut_etudiant_boursier" : "Aides études supérieures</span> Indique si le particulier est étudiant boursier et donne l'échelon de sa bourse."
             "education_nationale/statut_eleve_scolarise" : "Indique si l'élève est scolarisé au primaire, collège ou lycée. Précise si l'élève est boursier et donne l'échelon de sa bourse."
             "mesri/statut_etudiant" : "Indique si le particulier est étudiant et peut préciser l'établissement où il est inscrit."
@@ -444,8 +438,7 @@ fr:
           - ccas
         name: "Aides sociales des CCAS"
         endpoints:
-          - cnav/quotient_familial_v2
-          - cnaf/quotient_familial
+          - cnav/quotient_familial
         endpoints_optional:
           - cnous/statut_etudiant_boursier
           - education_nationale/statut_eleve_scolarise
@@ -458,8 +451,7 @@ fr:
           - cnav/allocation_adulte_handicape
           - cnav/allocation_soutien_familial
         comments_endpoints:
-            "cnav/quotient_familial_v2" : "Permet de récupérer le quotient familial CAF ou MSA.<br/><br/>Les données d'identité des membres de la famille et l'adresse postale sont aussi disponibles sous réserve d'un cadre légal précis."
-            "cnaf/quotient_familial" : ""
+            "cnav/quotient_familial" : "Permet de récupérer le quotient familial CAF ou MSA.<br/><br/>Les données d'identité des membres de la famille et l'adresse postale sont aussi disponibles sous réserve d'un cadre légal précis."
             "cnous/statut_etudiant_boursier" : "Aides études supérieures</span> Indique si le particulier est étudiant boursier et donne l'échelon de sa bourse."
             "education_nationale/statut_eleve_scolarise" : "Indique si l'élève est scolarisé au primaire, collège ou lycée. Précise si l'élève est boursier et donne l'échelon de sa bourse."
             "mesri/statut_etudiant" : "Indique si le particulier est étudiant et peut préciser l'établissement où il est inscrit."
@@ -571,8 +563,7 @@ fr:
         name: 'Tarification des transports'
         endpoints:
         endpoints_optional:
-          - cnav/quotient_familial_v2
-          - cnaf/quotient_familial
+          - cnav/quotient_familial
           - cnous/statut_etudiant_boursier
           - education_nationale/statut_eleve_scolarise
           - mesri/statut_etudiant
@@ -585,7 +576,7 @@ fr:
           - cnav/prime_activite
           - cnav/allocation_soutien_familial
         comments_endpoints:
-            "cnav/quotient_familial_v2" : "<span class='fr-badge fr-badge--sm fr-badge--green-archipel fr-badge--new'>Tarification solidaire</span> Permet de récupérer le quotient familial CAF ou MSA.<br/><br/>Les données d'identité des membres de la famille et l'adresse postale sont aussi disponibles sous réserve d'un cadre légal précis."
+            "cnav/quotient_familial" : "<span class='fr-badge fr-badge--sm fr-badge--green-archipel fr-badge--new'>Tarification solidaire</span> Permet de récupérer le quotient familial CAF ou MSA.<br/><br/>Les données d'identité des membres de la famille et l'adresse postale sont aussi disponibles sous réserve d'un cadre légal précis."
             "cnaf/quotient_familial" : "Indique le quotient familial CAF, ainsi que les données d'identité de membres de la famille et l'adresse déclarée à la caisse."
             "cnous/statut_etudiant_boursier" : "<span class='fr-badge fr-badge--sm fr-badge--new fr-badge--purple-glycine'>Tarification sociale</span> Indique si l'étudiant est boursier et l'échelon de sa bourse."
             "education_nationale/statut_eleve_scolarise" : "<span class='fr-badge fr-badge--sm fr-badge--new fr-badge--purple-glycine'>Tarification sociale</span> Indique si l'élève est scolarisé au primaire, collège ou lycée. Précise si l'élève est boursier et l'échelon de sa bourse."
@@ -707,8 +698,7 @@ fr:
         endpoints_optional:
           - mesri/statut_etudiant
         endpoints_forbidden:
-          - cnav/quotient_familial_v2
-          - cnaf/quotient_familial
+          - cnav/quotient_familial
           - cnous/statut_etudiant_boursier
           - education_nationale/statut_eleve_scolarise
           - pole_emploi/situation
@@ -719,8 +709,7 @@ fr:
           - cnav/prime_activite
           - cnav/allocation_soutien_familial
         comments_endpoints:
-            "cnav/quotient_familial_v2" : ""
-            "cnaf/quotient_familial" : ""
+            "cnav/quotient_familial" : ""
             "cnous/statut_etudiant_boursier" : ""
             "education_nationale/statut_eleve_scolarise" : ""
             "mesri/statut_etudiant" : "Indique si un étudiant est inscrit dans un établissement."
@@ -893,7 +882,7 @@ fr:
             {:.fr-table}
             |  API du bouquet API Particulier |   Modalité d'appel <br/>Identité pivot ou Indentifiant   | Modalité d'appel <br/>FranceConnect |
             | :--------------- | :--------------------------------: | :-----------: |
-            |  **Quotient familial MSA & CAF** - Cnaf & msa<br/> [Fiche métier](<%= endpoint_path(uid: 'cnav/quotient_familial_v2') %>) |  Identité pivot |   ![Cette API est FranceConnectée](<%= image_path('api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg') %>){:width="40px"} |
+            |  **Quotient familial MSA & CAF** - Cnaf & msa<br/> [Fiche métier](<%= endpoint_path(uid: 'cnav/quotient_familial') %>) |  Identité pivot |   ![Cette API est FranceConnectée](<%= image_path('api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg') %>){:width="40px"} |
             |  **Statut étudiant** - Mesri<br/> [Fiche métier](<%= endpoint_path(uid: 'mesri/statut_etudiant') %>) |  Identité pivot & Identifiant INE | ![Cette API est FranceConnectée](<%= image_path('api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg') %>){:width="40px"} |
             |  **Statut étudiant boursier** - Cnous<br/> [Fiche métier](<%= endpoint_path(uid: 'cnous/statut_etudiant_boursier') %>) | Identité pivot & Identifiant INE | ![Cette API est FranceConnectée](<%= image_path('api_particulier/cas_usages/pictos/modalite_appel_france_connect.svg') %>){:width="40px"} |
             |  **Statut élève scolarisé et boursier** - Ministère de l'éducation nationale<br/> [Fiche métier](<%= endpoint_path(uid: 'cnous/education_nationale/statut_eleve_scolarise') %>) | Identité pivot | ❌ N'est pas FranceConnectée |
@@ -1130,9 +1119,9 @@ fr:
             - Un espace de stockage temporaire de la donnée, sur [Hubee](https://www.hubee.numerique.gouv.fr/){:target="_blank"}, permettant aux collectivités de récupérer les informations collectées.
 
             {:.fr-text--lg}
-            Cette solution interroge l'[API quotient familial MSA & CAF](<%= endpoint_path(uid: 'cnav/quotient_familial_v2') %>) et FranceConnect pour récupérer les informations de l'usager, à savoir son identité pivot, celles des membres de sa famille et son quotient familial. La collectivité pourra ensuite utiliser l'identité pivot pour mettre à jour les quotients familiaux.
+            Cette solution interroge l'[API quotient familial MSA & CAF](<%= endpoint_path(uid: 'cnav/quotient_familial') %>) et FranceConnect pour récupérer les informations de l'usager, à savoir son identité pivot, celles des membres de sa famille et son quotient familial. La collectivité pourra ensuite utiliser l'identité pivot pour mettre à jour les quotients familiaux.
 
-            Cette solution permet ainsi à la collectvité d'interroger l'[API quotient familial MSA & CAF](<%= endpoint_path(uid: 'cnav/quotient_familial_v2') %>) avec une identité pivot vérifiée, sans avoir à intégrer tout de suite la [modalité d'appel FranceConnect](<%= cas_usage_path('modalite-appel-franceconnect') %>).
+            Cette solution permet ainsi à la collectvité d'interroger l'[API quotient familial MSA & CAF](<%= endpoint_path(uid: 'cnav/quotient_familial') %>) avec une identité pivot vérifiée, sans avoir à intégrer tout de suite la [modalité d'appel FranceConnect](<%= cas_usage_path('modalite-appel-franceconnect') %>).
 
 
 

--- a/config/locales/api_particulier/cas_usages_entries.fr.yml
+++ b/config/locales/api_particulier/cas_usages_entries.fr.yml
@@ -5,7 +5,7 @@ fr:
         user_types:
           - communes
           - intercommunalités
-        name: 'Tarificiation sociale des services municipaux à l’enfance'
+        name: 'Tarification sociale des services municipaux à l’enfance'
         endpoints:
           - cnav/quotient_familial_v2
           - cnav/quotient_familial

--- a/config/locales/api_particulier/cas_usages_entries.fr.yml
+++ b/config/locales/api_particulier/cas_usages_entries.fr.yml
@@ -8,7 +8,7 @@ fr:
         name: 'Tarificiation sociale des services municipaux à l’enfance'
         endpoints:
           - cnav/quotient_familial_v2
-          - cnaf/quotient_familial
+          - cnav/quotient_familial
         endpoints_optional:
           - cnav/revenu_solidarite_active
         endpoints_forbidden:
@@ -198,7 +198,7 @@ fr:
         name: 'Tarification cantine'
         endpoints:
           - cnav/quotient_familial_v2
-          - cnaf/quotient_familial
+          - cnav/quotient_familial
         endpoints_optional:
           - education_nationale/statut_eleve_scolarise
         endpoints_forbidden:

--- a/config/locales/api_particulier/documentation.fr.yml
+++ b/config/locales/api_particulier/documentation.fr.yml
@@ -428,6 +428,54 @@ fr:
                   | Paramètre                                                  |      Information à renseigner           |
                   |:----------------------------------------------------------:|-----------------------------------------|
                   |`&recipient=BénéficaireDeL'Appel`|**Le bénéficiaire de l'appel** <br><br>Ce paramètre permet la traçabilité de l'appel et doit correspondre au _SIRET de l'organisation publique habilitée à utiliser la donnée_. <br><br>Si vous êtes une collectivité ou une administration, ce paramètre doit donc être votre numéro de SIRET. Si vous êtes un éditeur, il s'agit du SIRET de l'organisation publique cliente demandant la donnée.<br><br>Une vérification est effectuée par API Particulier pour refuser tout format qui ne serait pas un numéro de SIRET.
+
+              - title: Gérer les évolutions de version
+                anchor: 'gerer-les-evolutions-de-version'
+                content: |+
+                  Il est fréquent que les API évoluent et que, par conséquent, de nouvelles versions soient publiées.
+                  La version majeure V.3 de l'API&nbsp;Particulier permet de créer facilement de nouvelles versions, tout en gardant les précédentes, rendant ainsi accessibles rapidement les évolutions qu'API Particulier obtient de ses fournisseurs.
+
+                  {:.fr-h5}
+                  #### Toute évolution implique une montée de version
+
+                  Les montés de version d'une API interviennent pour toute évolution, c'est-à-dire :
+                  - l'ajout d'un nouveau champ par le fournisseur de la donnée ;
+
+                    {:.fr-highlight.fr-highlight--example}
+                    > Exemple fictif : Ajout d'un champ "catégorie de formation" par le Cnous.
+
+                  - la transformation de la structure de l'API par le fournisseur de la donnée ;
+
+                    {:.fr-highlight.fr-highlight--example}
+                    > Par exemple : Sortie d'une évolution majeure chez le fournisseur donnée.
+
+                  - l'ajout d'une fonctionnalité par API&nbsp;Particulier
+
+                    {:.fr-highlight.fr-highlight--example}
+                    > Par exemple : Délivrance d'un nouveau champ "Certification valide" pour une API qui ne renvoyait avant que l'URL de téléchargement de l'attestation.
+
+                  Pour comprendre comment monter en version, [consultez la rubrique suivante](#changer-de-version).
+
+                  {:.fr-h5}
+                  #### Les anciennes versions maintenues tant que le fournisseur de la donnée le permet
+
+                  Depuis la V.3 de l'API&nbsp;Particulier, les anciennes versions sont maintenues par le service API Particulier tant que cela est possible.
+                  En pratique, cela signifie que :
+                  - tant que le fournisseur continue d'envoyer la strcuture de données de l'ancienne version, cette ancienne version est maintenue par l'API&nbsp;Particulier ;
+                  - si le fournisseur ne renvoie plus la même structure de donnée, API&nbsp;Particulier supprimera l'ancienne version car la maintenir reviendrait à renvoyer des champs vides.
+
+              - title: Changer de version
+                anchor: 'changer-de-version'
+                content: |+
+                  Depuis la version 3 de l'API&nbsp;Particulier, toutes les API peuvent évoluer indépendamment les unes des autres. Les anciennes versions (à partir de la V.3) restent donc toujours disponibles si le fournisseur de la donnée continue de transmettre les informations.
+                  Depuis la version 3, le numéro de version est un paramètre de l’appel et non plus une valeur fixe pour toutes les API comme en version 2.
+
+                  >_Exemple d'utilisation du paramètre d'appel de version :_
+                  > Imaginons un exemple fictif : l'API documents, cette API est disponible en v.3 et une nouvelle version est sortie, la V.4.
+                  > Pour appeler la version souhaitée, il vous faudra directement inscrire le numéro de la version dans l'URL : `https://particulier.api.gouv.fr/v3/...` pour la V.3 ou `https://particulier.api.gouv.fr/v4/...` pour la V.4.
+
+                  {:.fr-highlight}
+                  📩 Une lettre d'information annonce systématiquement les nouvelles évolutions. Vous pouvez vous abonner [ici](<%= newsletter_path %>).
               - title: Surveiller l'état des fournisseurs
                 anchor: 'surveillance-etat-fournisseurs'
                 content: |+

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -165,6 +165,8 @@ fr:
           title: "Historique"
           old_endpoints:
             description: "Documentations des anciennes API :"
+            link_documentation: |-
+              Plus d'informations sur la gestion de version API&nbsp;Particulier dans cette <a href='/developpeurs#gerer-les-evolutions-de-version' target='_blank'>documentation</a>.
         cgu:
           title: "Conditions d'utilisation des données"
           main_title_opening: "Ouverture de la donnée :"

--- a/config/locales/api_particulier/fr.yml
+++ b/config/locales/api_particulier/fr.yml
@@ -175,8 +175,10 @@ fr:
           cta: "CGU API Particulier"
       use_cases:
         main:
-          title: "Cas d'usage"
-          description: "Liste des cas d'usage où cette API est utile :"
+          title: "Cas d'usages"
+          description: "API utile pour :"
+        optional:
+          description: "API parfois utile pour :"
       details:
         title: "Spécifications de l'API"
         format:

--- a/spec/features/api_particulier/endpoints/show_spec.rb
+++ b/spec/features/api_particulier/endpoints/show_spec.rb
@@ -53,6 +53,16 @@ RSpec.describe 'Endpoints show', app: :api_particulier do
     end
   end
 
+  describe 'each endpoint V2' do
+    APIParticulier::EndpointV2.all.each do |endpoint|
+      it "works for #{endpoint.uid} endpoint" do
+        visit endpoint_path(uid: endpoint.uid)
+
+        expect(page).to have_css("#api_particulier_endpoint_v2_#{endpoint.id}")
+      end
+    end
+  end
+
   describe 'actions' do
     describe 'click on example', :js do
       it 'opens modal with example' do

--- a/spec/features/api_particulier/endpoints/show_spec.rb
+++ b/spec/features/api_particulier/endpoints/show_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Endpoints show', app: :api_particulier do
   let(:endpoint) { APIParticulier::Endpoint.find(uid) }
-  let(:uid) { api_particulier_example_uid }
+  let(:uid) { 'cnav/quotient_familial' }
   let(:api_status) { 200 }
 
   before do

--- a/spec/helpers/specs_helper.rb
+++ b/spec/helpers/specs_helper.rb
@@ -1,6 +1,6 @@
 module SpecsHelper
   def api_particulier_example_uid
-    'cnav/quotient_familial_v2'
+    'cnav/quotient_familial'
   end
 
   def api_entreprise_example_uid

--- a/spec/helpers/specs_helper.rb
+++ b/spec/helpers/specs_helper.rb
@@ -1,8 +1,4 @@
 module SpecsHelper
-  def api_particulier_example_uid
-    'cnav/quotient_familial'
-  end
-
   def api_entreprise_example_uid
     'insee/unites_legales'
   end

--- a/spec/models/api_particulier/endpoint_spec.rb
+++ b/spec/models/api_particulier/endpoint_spec.rb
@@ -3,6 +3,13 @@ require 'rails_helper'
 RSpec.describe APIParticulier::Endpoint do
   let(:uid) { 'cnav/quotient_familial' }
 
+  describe '.all' do
+    it 'contains only v3 endpoints' do
+      expect(described_class.all.map(&:uid)).to include('cnav/quotient_familial')
+      expect(described_class.all.map(&:uid)).not_to include('cnav/v2/quotient_familial_v2')
+    end
+  end
+
   describe '.find' do
     subject { described_class.find(uid) }
 

--- a/spec/models/api_particulier/endpoint_spec.rb
+++ b/spec/models/api_particulier/endpoint_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe APIParticulier::Endpoint do
-  let(:uid) { 'cnav/quotient_familial_v2' }
+  let(:uid) { 'cnav/quotient_familial' }
 
   describe '.find' do
     subject { described_class.find(uid) }

--- a/spec/models/api_particulier/endpoint_v2_spec.rb
+++ b/spec/models/api_particulier/endpoint_v2_spec.rb
@@ -3,6 +3,13 @@ require 'rails_helper'
 RSpec.describe APIParticulier::EndpointV2 do
   let(:uid) { 'cnav/v2/quotient_familial_v2' }
 
+  describe '.all' do
+    it 'contains only v2 endpoints' do
+      expect(described_class.all.map(&:uid)).to include('cnav/v2/quotient_familial_v2')
+      expect(described_class.all.map(&:uid)).not_to include('cnav/quotient_familial')
+    end
+  end
+
   describe '.find' do
     subject { described_class.find(uid) }
 

--- a/spec/models/api_particulier/endpoint_v2_spec.rb
+++ b/spec/models/api_particulier/endpoint_v2_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe APIParticulier::EndpointV2 do
+  let(:uid) { 'cnav/v2/quotient_familial_v2' }
+
+  describe '.find' do
+    subject { described_class.find(uid) }
+
+    it { is_expected.to be_an_instance_of(described_class) }
+
+    its(:uid) { is_expected.to eq(uid) }
+    its(:path) { is_expected.to eq('/api/v2/composition-familiale-v2') }
+
+    its(:providers) { is_expected.to be_an_instance_of(Array) }
+
+    its(:attributes) { is_expected.to be_an_instance_of(Hash) }
+    its(:attributes) { is_expected.to have_key('allocataires') }
+    its(:attributes) { is_expected.to have_key('adresse') }
+
+    its(:title) { is_expected.to eq('Quotient familial MSA & CAF') }
+  end
+
+  describe '#test_cases_external_url' do
+    subject { described_class.find(uid).test_cases_external_url }
+
+    it { is_expected.to eq('https://github.com/etalab/siade_staging_data/tree/develop/payloads/api_particulier_v2_cnav_quotient_familial_v2') }
+  end
+
+  describe '#redoc_anchor' do
+    subject { described_class.find(uid).redoc_anchor }
+
+    it { is_expected.to eq('tag/Quotient-familial/paths/~1api~1v2~1composition-familiale-v2/get') }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -138,6 +138,11 @@ RSpec.configure do |config|
       body: Rails.root.join('config/api-particulier-openapi.yml').read
     )
 
+    stub_request(:get, 'https://particulier.api.gouv.fr/api/open-api-v2.yml').and_return(
+      status: 200,
+      body: Rails.root.join('config/api-particulier-openapi-v2.yml').read
+    )
+
     stub_request(:get, 'https://particulier.api.gouv.fr/api/open-api-v3.yml').and_return(
       status: 200,
       body: Rails.root.join('config/api-particulier-openapi-v3.yml').read


### PR DESCRIPTION
Cette PR, vise à créer de nouvelles fiches métiers pour la V3, fiches qui font références aux fiches métiers de la V2.

**Vu ici du composant qui fait référence à l'ancienne fiche métier :** 

<img width="788" alt="image" src="https://github.com/user-attachments/assets/6e4832f8-fe54-4c7c-94a4-4266e66e390c" />


Cette PR a pour objectif de normaliser ce principe de fiches historisées, déjà appliquées pour les API deprecated d'un même swagger, mais ici l'objectif est que cela fonctionne sur 2 swaggers en période de migration.