### PR TITLE
Retire tag novelty de l'API QF

### DIFF
--- a/config/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
+++ b/config/endpoints/api_particulier/cnaf_msa_quotient_familial.yml
@@ -1,7 +1,6 @@
 ---
 - uid: 'cnav/quotient_familial'
   opening: protected
-  new_version: true
   old_endpoint_uids:
     - 'cnav/v2/quotient_familial_v2'
   path: '/v3/dss/quotient_familial/identite'


### PR DESCRIPTION
@Miryad3108 maintenant qu'on est passé en V3, il me semble que ça n'a plus de sens de garder la mention "nouvelle version"

## Avant

<img width="294" alt="image" src="https://github.com/user-attachments/assets/d60bbfe6-c307-4277-ae80-1bfa1b7beadc" />

## Après

<img width="307" alt="image" src="https://github.com/user-attachments/assets/09f765f6-543c-4b01-844a-39721f6a2eb4" />
