### PR TITLE
Bump production dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'good_job', '~> 3.99'
 
 gem 'draper'
 gem 'ip_anonymizer'
-gem 'jwt'
+gem 'jwt', '< 3.0'
 gem 'mailjet'
 gem 'mjml-rails'
 gem 'omniauth-oauth2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,9 +158,9 @@ GEM
     faraday-gzip (3.0.4)
       faraday (>= 2.0, < 3)
       zlib (~> 3.0)
-    faraday-net_http (3.4.0)
+    faraday-net_http (3.4.1)
       net-http (>= 0.5.0)
-    faraday-retry (2.3.1)
+    faraday-retry (2.3.2)
       faraday (~> 2.0)
     ferrum (0.17.1)
       addressable (~> 2.5)
@@ -529,10 +529,10 @@ GEM
       sprockets-rails
       tilt
     securerandom (0.4.1)
-    sentry-rails (5.24.0)
+    sentry-rails (5.25.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.24.0)
-    sentry-ruby (5.24.0)
+      sentry-ruby (~> 5.25.0)
+    sentry-ruby (5.25.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shellany (0.0.1)
@@ -648,7 +648,7 @@ DEPENDENCIES
   i18n-tasks
   interactor
   ip_anonymizer
-  jwt
+  jwt (< 3.0)
   kaminari
   kramdown-parser-gfm
   listen


### PR DESCRIPTION
jwt major bump breaks everything, fix it to 2.x

Ref https://github.com/etalab/admin_api_entreprise/pull/1917