### PR TITLE
Add namespace on redis cache in order to mitigate congestion in produ…

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -46,7 +46,8 @@ module AdminApientreprise
     config.assets.version = 'v3'
 
     config.cache_store = :redis_cache_store, config_for(:cache_redis).merge(
-      namespace: "admin_api_entreprise_cache_#{Rails.env}_#{Time.now.to_i}"
+      namespace: "admin_api_entreprise_cache_#{Rails.env}_#{Time.now.to_i}",
+      expires_in: (7 * 24 * 60 * 60)
     )
 
     config.active_support.to_time_preserves_timezone = :zone

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,9 @@ module AdminApientreprise
     config.assets.prefix = '/assets'
     config.assets.version = 'v3'
 
-    config.cache_store = :redis_cache_store, config_for(:cache_redis)
+    config.cache_store = :redis_cache_store, config_for(:cache_redis).merge(
+      namespace: "admin_api_entreprise_cache_#{Rails.env}_#{Time.now.to_i}"
+    )
 
     config.active_support.to_time_preserves_timezone = :zone
 


### PR DESCRIPTION
…ction

Our deployment script used to call Rails.cache.clear in order to avoid potential conflicts between cache version across deployment. Under the hood the `clear` command, with `redis`, use `flushdb`, which is a synchrone command. Because of this, our entire webapp is blocked in read on deployment because of the duration of this flush. Recent deployments have a clear cache with a huge duration (~3min).

This behaviour is not acceptable. We can invalidate old cache entries with a global namespace within application.rb, thanks to a timestamp.

This implementation is valid with puma thanks to preloading behaviour: application.rb is only load on puma boot, forks/workers do not reload this file, so our cache is constant for the entire app until the next reboot.

Source of flushdb: https://github.com/rails/rails/blob/b0c813bc7b61c71dd21ee3a6c6210f6d14030f71/activesupport/lib/active_support/cache/redis_cache_store.rb#L295