### PR TITLE
Admin tokens: display only one token

### DIFF
--- a/app/controllers/admin/tokens_controller.rb
+++ b/app/controllers/admin/tokens_controller.rb
@@ -1,7 +1,7 @@
 class Admin::TokensController < AdminController
   def index
     @user = User.find(params[:user_id])
-    @tokens = @user.tokens.joins(:authorization_request).where(authorization_requests: { api: namespace }).order(created_at: :desc)
+    @tokens = @user.tokens.where(authorization_requests: { api: 'entreprise' }).uniq
   end
 
   def ban


### PR DESCRIPTION
Can't use distinct because of the join which built a sql query with a group by (incompatible with a top level distinct)

`uniq` is good enough